### PR TITLE
fix: respect subfolder structure in page sorting & exporting

### DIFF
--- a/koharu-app/src/storage.rs
+++ b/koharu-app/src/storage.rs
@@ -1,5 +1,5 @@
 use std::num::NonZeroUsize;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::sync::Mutex;
 
 use anyhow::{Context, Result};
@@ -285,10 +285,7 @@ impl Storage {
                 let (width, height) = reader.into_dimensions().ok()?;
                 let id = blake3::hash(&file.data).to_hex().to_string();
                 let source = self.images.store_bytes(&file.data).ok()?;
-                let name = Path::new(&file.name)
-                    .file_stem()?
-                    .to_string_lossy()
-                    .to_string();
+                let name = sanitized_path_string(Path::new(&file.name).with_extension(""))?;
                 Some(Document {
                     id,
                     name,
@@ -396,6 +393,26 @@ fn assign_missing_orders(pages: &mut [Document], start: u32) {
     }
 }
 
+/// Normalize path without traversing the filesystem, remove prefix `../` and replace path separator with `_`, return [`None`] if the result is empty.
+fn sanitized_path_string(path: impl AsRef<Path>) -> Option<String> {
+    let mut parts: Vec<String> = Vec::new();
+    for c in path.as_ref().components() {
+        match c {
+            Component::Normal(s) => parts.push(s.to_string_lossy().into_owned()),
+            Component::ParentDir => {
+                parts.pop();
+            }
+            _ => {}
+        }
+    }
+    let result = parts.join("_");
+    if result.is_empty() {
+        None
+    } else {
+        Some(result)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -459,6 +476,35 @@ mod tests {
         let mut pages = Vec::<Document>::new();
         assign_missing_orders(&mut pages, 0);
         assert!(pages.is_empty());
+    }
+
+    // ── sanitized_path_string ──────────────────────────────────────
+
+    #[test]
+    fn sanitized_path_string_joins_components_with_underscore() {
+        assert_eq!(
+            sanitized_path_string(Path::new("chapter1/page10")),
+            Some("chapter1_page10".to_string())
+        );
+    }
+
+    #[test]
+    fn sanitized_path_string_resolves_parent_dir_components() {
+        assert_eq!(
+            sanitized_path_string(Path::new("chapter1/draft/../page10")),
+            Some("chapter1_page10".to_string())
+        );
+        assert_eq!(
+            sanitized_path_string(Path::new("../chapter2/page1")),
+            Some("chapter2_page1".to_string())
+        );
+    }
+
+    #[test]
+    fn sanitized_path_string_returns_none_when_empty_after_normalization() {
+        assert_eq!(sanitized_path_string(Path::new("")), None);
+        assert_eq!(sanitized_path_string(Path::new(".")), None);
+        assert_eq!(sanitized_path_string(Path::new("chapter/..")), None);
     }
 
     // ── list_documents ──────────────────────────────────────────────
@@ -530,6 +576,16 @@ mod tests {
         (storage, dir)
     }
 
+    fn solid_png_bytes(seed: u8) -> Vec<u8> {
+        let pixel = image::Rgba([seed, seed, seed, 255]);
+        let image = image::RgbaImage::from_pixel(1, 1, pixel);
+        let mut cursor = std::io::Cursor::new(Vec::new());
+        image::DynamicImage::ImageRgba8(image)
+            .write_to(&mut cursor, image::ImageFormat::Png)
+            .unwrap();
+        cursor.into_inner()
+    }
+
     #[tokio::test]
     async fn reorder_pages_assigns_sequential_orders() {
         let (storage, _dir) = open_test_storage(vec![
@@ -548,6 +604,117 @@ mod tests {
         assert_eq!(pages[1].order, 2);
         assert_eq!(pages[2].id, "b");
         assert_eq!(pages[2].order, 3);
+    }
+
+    #[tokio::test]
+    async fn import_files_sorts_by_relative_path_when_names_repeat_across_subfolders() {
+        let (storage, _dir) = open_test_storage(Vec::new());
+        let files = vec![
+            koharu_core::FileEntry {
+                name: "chp1/2.png".to_string(),
+                data: solid_png_bytes(1),
+            },
+            koharu_core::FileEntry {
+                name: "chp1/10.png".to_string(),
+                data: solid_png_bytes(2),
+            },
+            koharu_core::FileEntry {
+                name: "chp2/2.png".to_string(),
+                data: solid_png_bytes(3),
+            },
+            koharu_core::FileEntry {
+                name: "chp2/10.png".to_string(),
+                data: solid_png_bytes(4),
+            },
+            koharu_core::FileEntry {
+                name: "chp10/2.png".to_string(),
+                data: solid_png_bytes(5),
+            },
+            koharu_core::FileEntry {
+                name: "chp2/1.png".to_string(),
+                data: solid_png_bytes(6),
+            },
+            koharu_core::FileEntry {
+                name: "chp1/1.png".to_string(),
+                data: solid_png_bytes(7),
+            },
+            koharu_core::FileEntry {
+                name: "chp10/10.png".to_string(),
+                data: solid_png_bytes(8),
+            },
+            koharu_core::FileEntry {
+                name: "chp10/1.png".to_string(),
+                data: solid_png_bytes(9),
+            },
+        ];
+
+        storage.import_files(files, true).await.unwrap();
+
+        let pages = storage.list_pages().await;
+        let names: Vec<&str> = pages.iter().map(|p| p.name.as_str()).collect();
+        let orders: Vec<u32> = pages.iter().map(|p| p.order).collect();
+
+        assert_eq!(
+            names,
+            [
+                "chp1_1", "chp1_2", "chp1_10", "chp2_1", "chp2_2", "chp2_10", "chp10_1", "chp10_2",
+                "chp10_10"
+            ]
+        );
+        assert_eq!(orders, [1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    }
+
+    #[tokio::test]
+    async fn import_files_append_keeps_existing_pages_and_appends_new_orders() {
+        let (storage, _dir) =
+            open_test_storage(vec![make_page("a", "alpha", 3), make_page("b", "beta", 4)]);
+        let files = vec![
+            koharu_core::FileEntry {
+                name: "chp2/2.png".to_string(),
+                data: solid_png_bytes(1),
+            },
+            koharu_core::FileEntry {
+                name: "chp2/1.png".to_string(),
+                data: solid_png_bytes(2),
+            },
+        ];
+
+        storage.import_files(files, false).await.unwrap();
+
+        let pages = storage.list_pages().await;
+        let names: Vec<&str> = pages.iter().map(|p| p.name.as_str()).collect();
+        let orders: Vec<u32> = pages.iter().map(|p| p.order).collect();
+
+        assert_eq!(names, ["alpha", "beta", "chp2_1", "chp2_2"]);
+        assert_eq!(orders, [3, 4, 5, 6]);
+    }
+
+    #[tokio::test]
+    async fn import_files_skips_invalid_images_and_empty_normalized_names() {
+        let (storage, _dir) = open_test_storage(Vec::new());
+        let files = vec![
+            koharu_core::FileEntry {
+                name: "valid/1.png".to_string(),
+                data: solid_png_bytes(1),
+            },
+            koharu_core::FileEntry {
+                name: "".to_string(),
+                data: solid_png_bytes(2),
+            },
+            koharu_core::FileEntry {
+                name: "not-image.png".to_string(),
+                data: vec![1, 2, 3, 4],
+            },
+        ];
+
+        let imported = storage.import_files(files, true).await.unwrap();
+        assert_eq!(imported.len(), 1);
+        assert_eq!(imported[0].name, "valid_1");
+
+        let pages = storage.list_pages().await;
+        assert_eq!(pages.len(), 1);
+        assert_eq!(pages[0].name, "valid_1");
+        assert_eq!(pages[0].order, 1);
     }
 
     #[tokio::test]

--- a/koharu-app/src/storage.rs
+++ b/koharu-app/src/storage.rs
@@ -393,7 +393,7 @@ fn assign_missing_orders(pages: &mut [Document], start: u32) {
     }
 }
 
-/// Normalize path without traversing the filesystem, remove prefix `../`, flatten path separators as `_`, and escape `_`/`%` inside components to keep boundaries collision-safe. Return [`None`] if the result is empty.
+/// Normalize a path lexically (without filesystem access): collapse `..`, ignore any extra `..` for security reasons, join components with `_`, and percent-escape `_`/`%` inside each component to keep boundaries collision-safe. Return [`None`] if the result is empty.
 fn sanitized_path_string(path: impl AsRef<Path>) -> Option<String> {
     let mut parts: Vec<String> = Vec::new();
     for c in path.as_ref().components() {

--- a/koharu-app/src/storage.rs
+++ b/koharu-app/src/storage.rs
@@ -393,12 +393,19 @@ fn assign_missing_orders(pages: &mut [Document], start: u32) {
     }
 }
 
-/// Normalize path without traversing the filesystem, remove prefix `../` and replace path separator with `_`, return [`None`] if the result is empty.
+/// Normalize path without traversing the filesystem, remove prefix `../`, flatten path separators as `_`, and escape `_`/`%` inside components to keep boundaries collision-safe. Return [`None`] if the result is empty.
 fn sanitized_path_string(path: impl AsRef<Path>) -> Option<String> {
     let mut parts: Vec<String> = Vec::new();
     for c in path.as_ref().components() {
         match c {
-            Component::Normal(s) => parts.push(s.to_string_lossy().into_owned()),
+            Component::Normal(s) => {
+                parts.push(
+                    s.to_string_lossy()
+                        .into_owned()
+                        .replace('%', "%25")
+                        .replace('_', "%5F"),
+                );
+            }
             Component::ParentDir => {
                 parts.pop();
             }
@@ -497,6 +504,22 @@ mod tests {
         assert_eq!(
             sanitized_path_string(Path::new("../chapter2/page1")),
             Some("chapter2_page1".to_string())
+        );
+    }
+
+    #[test]
+    fn sanitized_path_string_is_collision_safe_for_component_boundaries() {
+        assert_eq!(
+            sanitized_path_string(Path::new("a/b_c")),
+            Some("a_b%5Fc".to_string())
+        );
+        assert_eq!(
+            sanitized_path_string(Path::new("a_b/c")),
+            Some("a%5Fb_c".to_string())
+        );
+        assert_ne!(
+            sanitized_path_string(Path::new("a/b_c")),
+            sanitized_path_string(Path::new("a_b/c"))
         );
     }
 

--- a/koharu-app/src/storage.rs
+++ b/koharu-app/src/storage.rs
@@ -393,18 +393,13 @@ fn assign_missing_orders(pages: &mut [Document], start: u32) {
     }
 }
 
-/// Normalize a path lexically (without filesystem access): collapse `..`, ignore any extra `..` for security reasons, join components with `_`, and percent-escape `_`/`%` inside each component to keep boundaries collision-safe. Return [`None`] if the result is empty.
+/// Normalize a path lexically (without filesystem access): collapse `..`, ignore any extra `..` for security reasons, join components with `%2F`, and percent-escape `%` inside each component to keep boundaries collision-safe. Return [`None`] if the result is empty.
 fn sanitized_path_string(path: impl AsRef<Path>) -> Option<String> {
     let mut parts: Vec<String> = Vec::new();
     for c in path.as_ref().components() {
         match c {
             Component::Normal(s) => {
-                parts.push(
-                    s.to_string_lossy()
-                        .into_owned()
-                        .replace('%', "%25")
-                        .replace('_', "%5F"),
-                );
+                parts.push(s.to_string_lossy().into_owned().replace('%', "%25"));
             }
             Component::ParentDir => {
                 parts.pop();
@@ -412,7 +407,7 @@ fn sanitized_path_string(path: impl AsRef<Path>) -> Option<String> {
             _ => {}
         }
     }
-    let result = parts.join("_");
+    let result = parts.join("%2F");
     if result.is_empty() {
         None
     } else {
@@ -491,7 +486,7 @@ mod tests {
     fn sanitized_path_string_joins_components_with_underscore() {
         assert_eq!(
             sanitized_path_string(Path::new("chapter1/page10")),
-            Some("chapter1_page10".to_string())
+            Some("chapter1%2Fpage10".to_string())
         );
     }
 
@@ -499,11 +494,11 @@ mod tests {
     fn sanitized_path_string_resolves_parent_dir_components() {
         assert_eq!(
             sanitized_path_string(Path::new("chapter1/draft/../page10")),
-            Some("chapter1_page10".to_string())
+            Some("chapter1%2Fpage10".to_string())
         );
         assert_eq!(
             sanitized_path_string(Path::new("../chapter2/page1")),
-            Some("chapter2_page1".to_string())
+            Some("chapter2%2Fpage1".to_string())
         );
     }
 
@@ -511,15 +506,19 @@ mod tests {
     fn sanitized_path_string_is_collision_safe_for_component_boundaries() {
         assert_eq!(
             sanitized_path_string(Path::new("a/b_c")),
-            Some("a_b%5Fc".to_string())
+            Some("a%2Fb_c".to_string())
         );
         assert_eq!(
             sanitized_path_string(Path::new("a_b/c")),
-            Some("a%5Fb_c".to_string())
+            Some("a_b%2Fc".to_string())
         );
-        assert_ne!(
-            sanitized_path_string(Path::new("a/b_c")),
-            sanitized_path_string(Path::new("a_b/c"))
+        assert_eq!(
+            sanitized_path_string(Path::new("a/b%c")),
+            Some("a%2Fb%25c".to_string())
+        );
+        assert_eq!(
+            sanitized_path_string(Path::new("a%b/c")),
+            Some("a%25b%2Fc".to_string())
         );
     }
 
@@ -680,8 +679,15 @@ mod tests {
         assert_eq!(
             names,
             [
-                "chp1_1", "chp1_2", "chp1_10", "chp2_1", "chp2_2", "chp2_10", "chp10_1", "chp10_2",
-                "chp10_10"
+                "chp1%2F1",
+                "chp1%2F2",
+                "chp1%2F10",
+                "chp2%2F1",
+                "chp2%2F2",
+                "chp2%2F10",
+                "chp10%2F1",
+                "chp10%2F2",
+                "chp10%2F10"
             ]
         );
         assert_eq!(orders, [1, 2, 3, 4, 5, 6, 7, 8, 9]);
@@ -708,7 +714,7 @@ mod tests {
         let names: Vec<&str> = pages.iter().map(|p| p.name.as_str()).collect();
         let orders: Vec<u32> = pages.iter().map(|p| p.order).collect();
 
-        assert_eq!(names, ["alpha", "beta", "chp2_1", "chp2_2"]);
+        assert_eq!(names, ["alpha", "beta", "chp2%2F1", "chp2%2F2"]);
         assert_eq!(orders, [3, 4, 5, 6]);
     }
 
@@ -732,11 +738,11 @@ mod tests {
 
         let imported = storage.import_files(files, true).await.unwrap();
         assert_eq!(imported.len(), 1);
-        assert_eq!(imported[0].name, "valid_1");
+        assert_eq!(imported[0].name, "valid%2F1");
 
         let pages = storage.list_pages().await;
         assert_eq!(pages.len(), 1);
-        assert_eq!(pages[0].name, "valid_1");
+        assert_eq!(pages[0].name, "valid%2F1");
         assert_eq!(pages[0].order, 1);
     }
 

--- a/ui/lib/api/documents/documents.ts
+++ b/ui/lib/api/documents/documents.ts
@@ -155,19 +155,13 @@ export const getImportDocumentsUrl = (params?: ImportDocumentsParams) => {
     : `/api/v1/documents`
 }
 
-const uploadFilename = (value: Blob): string => {
-  const isFile = (value: Blob): value is File => 'name' in value
-  if (!isFile(value)) return 'blob'
-  return value.webkitRelativePath || value.name
-}
-
 export const importDocuments = async (
   importDocumentsBody: ImportDocumentsBody,
   params?: ImportDocumentsParams,
   options?: RequestInit,
 ): Promise<ImportResult> => {
   const formData = new FormData()
-  importDocumentsBody.files.forEach((value) => formData.append(`files`, value, uploadFilename(value)))
+  importDocumentsBody.files.forEach((value) => formData.append(`files`, value))
 
   return fetchApi<ImportResult>(getImportDocumentsUrl(params), {
     ...options,

--- a/ui/lib/api/documents/documents.ts
+++ b/ui/lib/api/documents/documents.ts
@@ -155,13 +155,19 @@ export const getImportDocumentsUrl = (params?: ImportDocumentsParams) => {
     : `/api/v1/documents`
 }
 
+const uploadFilename = (value: Blob): string => {
+  const isFile = (value: Blob): value is File => 'name' in value
+  if (!isFile(value)) return 'blob'
+  return value.webkitRelativePath || value.name
+}
+
 export const importDocuments = async (
   importDocumentsBody: ImportDocumentsBody,
   params?: ImportDocumentsParams,
   options?: RequestInit,
 ): Promise<ImportResult> => {
   const formData = new FormData()
-  importDocumentsBody.files.forEach((value) => formData.append(`files`, value))
+  importDocumentsBody.files.forEach((value) => formData.append(`files`, value, uploadFilename(value)))
 
   return fetchApi<ImportResult>(getImportDocumentsUrl(params), {
     ...options,

--- a/ui/lib/api/fetch.ts
+++ b/ui/lib/api/fetch.ts
@@ -1,5 +1,24 @@
+const getFormDataFilename = (value: File): string => value.webkitRelativePath || value.name
+
+const normalizeFormDataBody = (body: BodyInit | null | undefined): BodyInit | null | undefined => {
+  if (!(body instanceof FormData)) return body
+
+  const normalized = new FormData()
+  for (const [key, value] of body.entries()) {
+    if (typeof value === 'string') {
+      normalized.append(key, value)
+      continue
+    }
+
+    normalized.append(key, value, getFormDataFilename(value))
+  }
+
+  return normalized
+}
+
 export const fetchApi = async <T>(url: string, options?: RequestInit): Promise<T> => {
-  const res = await fetch(url, options)
+  const normalizedBody = normalizeFormDataBody(options?.body)
+  const res = await fetch(url, { ...options, body: normalizedBody })
   if (!res.ok) {
     throw await res.json().catch(() => ({ status: res.status, message: res.statusText }))
   }


### PR DESCRIPTION
fix part 2 of #459

This PR passing relative path instead of filename from frontend to backend, then normalize the path in backend and storage in `Document.name`, so page sorting & exporting can keep relative path information.

Example input dir:

<img width="192" height="186" alt="test" src="https://github.com/user-attachments/assets/5b82936c-534c-4446-bd60-12a8aa473f35" />

In `test/ch1`:

<img width="537" height="288" alt="test_ch1" src="https://github.com/user-attachments/assets/8fc177a5-850e-48c9-9a76-e1ade1f3bf54" />

In `test/ch2`:

<img width="538" height="317" alt="test_ch2" src="https://github.com/user-attachments/assets/82113642-8f9b-4f66-90f9-0e7dcbc9cb6e" />

|before|after|
|-|-|
|<img width="1272" height="952" alt="before1" src="https://github.com/user-attachments/assets/28c913a9-70d4-4922-9a7d-95d5172d7973" /> The page order is `ch1/1.png, ch2/1.png, ch2/2.png, ch1/2.png`|<img width="1272" height="952" alt="after1" src="https://github.com/user-attachments/assets/1c4f956f-12c8-4b37-9fe8-78ed6b165a4e" /> The page order is `ch1/1.png, ch1/2.png, ch2/1.png, ch2/2.png`|
|<img width="857" height="370" alt="before2" src="https://github.com/user-attachments/assets/a7ec9422-10a2-4b6f-8db7-e20bf0a63c31" /> Only exported `ch2/1.png` and `ch1/2.png`|<img width="1134" height="401" alt="after2" src="https://github.com/user-attachments/assets/2bd9b074-969e-45d9-865e-296a0d281aea" /> All four images are exported|
