### PR TITLE
fix(i18n): show language names in their native locale

### DIFF
--- a/ui/components/SettingsDialog.tsx
+++ b/ui/components/SettingsDialog.tsx
@@ -65,7 +65,7 @@ import type {
   ProviderConfig,
 } from '@/lib/api/schemas'
 import { isTauri, openExternalUrl } from '@/lib/backend'
-import { languageDisplayNames, supportedLanguages } from '@/lib/i18n'
+import { supportedLanguages } from '@/lib/i18n'
 import {
   areShortcutsEqual,
   formatShortcut,
@@ -468,7 +468,7 @@ function AppearancePane() {
           <SelectContent>
             {locales.map((code) => (
               <SelectItem key={code} value={code}>
-                {languageDisplayNames[code]}
+                {t(`menu.languages.${code}`, { defaultValue: code })}
               </SelectItem>
             ))}
           </SelectContent>

--- a/ui/components/SettingsDialog.tsx
+++ b/ui/components/SettingsDialog.tsx
@@ -65,7 +65,7 @@ import type {
   ProviderConfig,
 } from '@/lib/api/schemas'
 import { isTauri, openExternalUrl } from '@/lib/backend'
-import { supportedLanguages } from '@/lib/i18n'
+import { languageDisplayNames, supportedLanguages } from '@/lib/i18n'
 import {
   areShortcutsEqual,
   formatShortcut,
@@ -468,7 +468,7 @@ function AppearancePane() {
           <SelectContent>
             {locales.map((code) => (
               <SelectItem key={code} value={code}>
-                {t(`menu.languages.${code}`)}
+                {languageDisplayNames[code]}
               </SelectItem>
             ))}
           </SelectContent>

--- a/ui/components/canvas/CanvasToolbar.tsx
+++ b/ui/components/canvas/CanvasToolbar.tsx
@@ -33,7 +33,6 @@ import {
   useGetCurrentLlm,
 } from '@/lib/api/default/default'
 import type { LlmCatalog, LlmCatalogModel, LlmProviderCatalog, LlmTarget } from '@/lib/api/schemas'
-import { getLanguageDisplayName } from '@/lib/i18n'
 import { useEditorUiStore } from '@/lib/stores/editorUiStore'
 import { useJobsStore } from '@/lib/stores/jobsStore'
 import { usePreferencesStore } from '@/lib/stores/preferencesStore'
@@ -401,7 +400,7 @@ function LlmStatusPopover() {
                       value={language}
                       data-testid={`llm-language-option-${index}`}
                     >
-                      {getLanguageDisplayName(language) ?? t(`llm.languages.${language}`)}
+                      {t(`llm.languages.${language}`, { defaultValue: language })}
                     </SelectItem>
                   ))}
                 </SelectContent>

--- a/ui/components/canvas/CanvasToolbar.tsx
+++ b/ui/components/canvas/CanvasToolbar.tsx
@@ -33,6 +33,7 @@ import {
   useGetCurrentLlm,
 } from '@/lib/api/default/default'
 import type { LlmCatalog, LlmCatalogModel, LlmProviderCatalog, LlmTarget } from '@/lib/api/schemas'
+import { getLanguageDisplayName } from '@/lib/i18n'
 import { useEditorUiStore } from '@/lib/stores/editorUiStore'
 import { useJobsStore } from '@/lib/stores/jobsStore'
 import { usePreferencesStore } from '@/lib/stores/preferencesStore'
@@ -400,7 +401,7 @@ function LlmStatusPopover() {
                       value={language}
                       data-testid={`llm-language-option-${index}`}
                     >
-                      {t(`llm.languages.${language}`)}
+                      {getLanguageDisplayName(language) ?? t(`llm.languages.${language}`)}
                     </SelectItem>
                   ))}
                 </SelectContent>

--- a/ui/lib/i18n.ts
+++ b/ui/lib/i18n.ts
@@ -27,7 +27,25 @@ export const resources = {
   'pt-BR': { translation: ptBR },
 } satisfies Resource
 
-export const supportedLanguages = Object.keys(resources)
+export type SupportedLanguage = keyof typeof resources
+
+export const supportedLanguages = Object.keys(resources) as SupportedLanguage[]
+
+export const languageDisplayNames = {
+  'en-US': 'English',
+  'zh-CN': '中文（简体）',
+  'zh-TW': '中文（繁體）',
+  'ja-JP': '日本語',
+  'ru-RU': 'Русский',
+  'es-ES': 'Español',
+  'tr-TR': 'Türkçe',
+  'ko-KR': '한국어',
+  'pt-BR': 'Português (Brasil)',
+} satisfies Record<SupportedLanguage, string>
+
+export function getLanguageDisplayName(language: string): string | undefined {
+  return (languageDisplayNames as Partial<Record<string, string>>)[language]
+}
 
 i18n
   .use(LocalStorageBackend)

--- a/ui/lib/i18n.ts
+++ b/ui/lib/i18n.ts
@@ -31,22 +31,6 @@ export type SupportedLanguage = keyof typeof resources
 
 export const supportedLanguages = Object.keys(resources) as SupportedLanguage[]
 
-export const languageDisplayNames = {
-  'en-US': 'English',
-  'zh-CN': '中文（简体）',
-  'zh-TW': '中文（繁體）',
-  'ja-JP': '日本語',
-  'ru-RU': 'Русский',
-  'es-ES': 'Español',
-  'tr-TR': 'Türkçe',
-  'ko-KR': '한국어',
-  'pt-BR': 'Português (Brasil)',
-} satisfies Record<SupportedLanguage, string>
-
-export function getLanguageDisplayName(language: string): string | undefined {
-  return (languageDisplayNames as Partial<Record<string, string>>)[language]
-}
-
 i18n
   .use(LocalStorageBackend)
   .use(LanguageDetector)

--- a/ui/public/locales/en-US/translation.json
+++ b/ui/public/locales/en-US/translation.json
@@ -42,8 +42,8 @@
     "language": "Language",
     "languages": {
       "en-US": "English",
-      "zh-CN": "简体中文",
-      "zh-TW": "繁體中文",
+      "zh-CN": "中文（简体）",
+      "zh-TW": "中文（繁體）",
       "ja-JP": "日本語",
       "ru-RU": "Русский",
       "es-ES": "Español",

--- a/ui/public/locales/es-ES/translation.json
+++ b/ui/public/locales/es-ES/translation.json
@@ -36,18 +36,7 @@
     "github": "GitHub",
     "version": "Versión: {{version}}",
     "versionUnknown": "Versión: Desconocida",
-    "language": "Idioma",
-    "languages": {
-      "en-US": "Inglés",
-      "zh-CN": "Chino simplificado",
-      "zh-TW": "Chino tradicional",
-      "ja-JP": "Japonés",
-      "ru-RU": "Ruso",
-      "es-ES": "Español",
-      "tr-TR": "Turco",
-      "ko-KR": "Coreano",
-      "pt-BR": "Português (Brasil)"
-    }
+    "language": "Idioma"
   },
   "welcome": {
     "title": "Koharu",

--- a/ui/public/locales/ja-JP/translation.json
+++ b/ui/public/locales/ja-JP/translation.json
@@ -36,18 +36,7 @@
     "github": "GitHub",
     "version": "バージョン: {{version}}",
     "versionUnknown": "バージョン: 不明",
-    "language": "言語",
-    "languages": {
-      "en-US": "English",
-      "zh-CN": "简体中文",
-      "zh-TW": "繁體中文",
-      "ja-JP": "日本語",
-      "ru-RU": "Русский",
-      "es-ES": "Español",
-      "tr-TR": "トルコ語",
-      "ko-KR": "한국어",
-      "pt-BR": "Português (Brasil)"
-    }
+    "language": "言語"
   },
   "welcome": {
     "title": "Koharu",

--- a/ui/public/locales/ko-KR/translation.json
+++ b/ui/public/locales/ko-KR/translation.json
@@ -36,18 +36,7 @@
     "github": "GitHub",
     "version": "버전: {{version}}",
     "versionUnknown": "버전: 알 수 없음",
-    "language": "언어",
-    "languages": {
-      "en-US": "English",
-      "zh-CN": "简体中文",
-      "zh-TW": "繁體中文",
-      "ja-JP": "日本語",
-      "ru-RU": "Русский",
-      "es-ES": "Español",
-      "tr-TR": "Türkçe",
-      "ko-KR": "한국어",
-      "pt-BR": "Português (Brasil)"
-    }
+    "language": "언어"
   },
   "welcome": {
     "title": "Koharu",

--- a/ui/public/locales/pt-BR/translation.json
+++ b/ui/public/locales/pt-BR/translation.json
@@ -37,18 +37,7 @@
     "github": "GitHub",
     "version": "Versão: {{version}}",
     "versionUnknown": "Versão: Desconhecida",
-    "language": "Idioma",
-    "languages": {
-      "en-US": "Inglês",
-      "zh-CN": "Chinês simplificado",
-      "zh-TW": "Chinês tradicional",
-      "ja-JP": "Japonês",
-      "ru-RU": "Russo",
-      "es-ES": "Espanhol",
-      "tr-TR": "Turco",
-      "ko-KR": "Coreano",
-      "pt-BR": "Português (Brasil)"
-    }
+    "language": "Idioma"
   },
   "welcome": {
     "title": "Koharu",

--- a/ui/public/locales/ru-RU/translation.json
+++ b/ui/public/locales/ru-RU/translation.json
@@ -36,18 +36,7 @@
     "github": "GitHub",
     "version": "Версия: {{version}}",
     "versionUnknown": "Версия: Неизвестно",
-    "language": "Язык",
-    "languages": {
-      "en-US": "Английский",
-      "zh-CN": "Китайский (упр.)",
-      "zh-TW": "Китайский (трад.)",
-      "ja-JP": "Японский",
-      "ru-RU": "Русский",
-      "es-ES": "Испанский",
-      "tr-TR": "Турецкий",
-      "ko-KR": "Корейский",
-      "pt-BR": "Português (Brasil)"
-    }
+    "language": "Язык"
   },
   "welcome": {
     "title": "Koharu",

--- a/ui/public/locales/tr-TR/translation.json
+++ b/ui/public/locales/tr-TR/translation.json
@@ -36,18 +36,7 @@
     "github": "GitHub",
     "version": "Sürüm: {{version}}",
     "versionUnknown": "Sürüm: Bilinmiyor",
-    "language": "Dil",
-    "languages": {
-      "en-US": "İngilizce",
-      "zh-CN": "Basitleştirilmiş Çince",
-      "zh-TW": "Geleneksel Çince",
-      "ja-JP": "Japonca",
-      "ru-RU": "Rusça",
-      "es-ES": "İspanyolca",
-      "tr-TR": "Türkçe",
-      "ko-KR": "Korece",
-      "pt-BR": "Português (Brasil)"
-    }
+    "language": "Dil"
   },
   "welcome": {
     "title": "Koharu",

--- a/ui/public/locales/zh-CN/translation.json
+++ b/ui/public/locales/zh-CN/translation.json
@@ -36,18 +36,7 @@
     "github": "GitHub",
     "version": "版本：{{version}}",
     "versionUnknown": "版本：未知",
-    "language": "语言",
-    "languages": {
-      "en-US": "English",
-      "zh-CN": "简体中文",
-      "zh-TW": "繁體中文",
-      "ja-JP": "日本語",
-      "ru-RU": "Русский",
-      "es-ES": "Español",
-      "tr-TR": "土耳其语",
-      "ko-KR": "한국어",
-      "pt-BR": "Português (Brasil)"
-    }
+    "language": "语言"
   },
   "welcome": {
     "title": "Koharu",

--- a/ui/public/locales/zh-TW/translation.json
+++ b/ui/public/locales/zh-TW/translation.json
@@ -36,18 +36,7 @@
     "github": "GitHub",
     "version": "版本：{{version}}",
     "versionUnknown": "版本：未知",
-    "language": "語言",
-    "languages": {
-      "en-US": "English",
-      "zh-CN": "简体中文",
-      "zh-TW": "繁體中文",
-      "ja-JP": "日本語",
-      "ru-RU": "Русский",
-      "es-ES": "Español",
-      "tr-TR": "土耳其語",
-      "ko-KR": "한국어",
-      "pt-BR": "Português (Brasil)"
-    }
+    "language": "語言"
   },
   "welcome": {
     "title": "Koharu",


### PR DESCRIPTION
Show app language choices using each language's native name instead of the active UI locale