### PR TITLE
Fix: Brush and Mask Layer not syncing on undo/redo

### DIFF
--- a/koharu-rpc/src/routes/pages.rs
+++ b/koharu-rpc/src/routes/pages.rs
@@ -8,13 +8,17 @@
 //! All three do the same server-side dance: read bytes → `blobs.put_bytes`
 //! → emit an `Op` on the session history.
 
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+
 use axum::Json;
 use axum::body::Bytes;
-use axum::extract::{Multipart, Path, State};
+use axum::extract::{Multipart, Path, Query, State};
 use image::GenericImageView;
+use koharu_app::pipeline::{self, EngineCtx, PipelineRunOptions};
 use koharu_core::{
     BlobRef, ImageData, ImageRole, MaskRole, Node, NodeDataPatch, NodeId, NodeKind, Op, Page,
-    PageId, Scene, Transform,
+    PageId, Region, Scene, Transform,
 };
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -22,6 +26,18 @@ use utoipa_axum::{router::OpenApiRouter, routes};
 
 use crate::AppState;
 use crate::error::{ApiError, ApiResult};
+
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::IntoParams)]
+#[serde(rename_all = "camelCase")]
+pub struct PutMaskParams {
+    /// Optional pipeline engine to run after the mask is updated.
+    pub pipeline: Option<String>,
+    /// Bounding box for the pipeline run.
+    pub x: Option<f32>,
+    pub y: Option<f32>,
+    pub width: Option<f32>,
+    pub height: Option<f32>,
+}
 
 pub fn router() -> OpenApiRouter<AppState> {
     OpenApiRouter::default()
@@ -443,6 +459,7 @@ pub struct PutMaskResponse {
 async fn put_mask(
     State(app): State<AppState>,
     Path((page_id, role)): Path<(PageId, MaskRole)>,
+    Query(params): Query<PutMaskParams>,
     body: Bytes,
 ) -> ApiResult<Json<PutMaskResponse>> {
     let session = app
@@ -458,7 +475,7 @@ async fn put_mask(
     let blob = session.blobs.put_bytes(&body).map_err(ApiError::internal)?;
 
     // Find existing mask node of this role, or plan an AddNode.
-    let (op, node_id) = {
+    let (mut mask_op, node_id) = {
         let scene = session.scene.read();
         let existing = scene
             .page(page_id)
@@ -509,7 +526,61 @@ async fn put_mask(
         }
     };
 
-    app.apply(op).map_err(ApiError::internal)?;
+    if let Some(engine_id) = params.pipeline {
+        // Atomic Batch: Mask Update + Pipeline Run
+        let mut ops = vec![mask_op.clone()];
+
+        // 1. Simulate the mask update in a cloned scene so the engine sees it.
+        let mut scene = session.scene_snapshot();
+        mask_op.apply(&mut scene).map_err(|e| ApiError::internal(e.into()))?;
+
+        // 2. Prepare EngineCtx
+        let region = Region {
+            x: params.x.unwrap_or(0.0) as u32,
+            y: params.y.unwrap_or(0.0) as u32,
+            width: params.width.unwrap_or(0.0) as u32,
+            height: params.height.unwrap_or(0.0) as u32,
+        };
+        let cancel = Arc::new(AtomicBool::new(false));
+        let ctx = EngineCtx {
+            scene: &scene,
+            page: page_id,
+            blobs: &session.blobs,
+            runtime: &app.runtime,
+            cancel: &cancel,
+            options: &PipelineRunOptions {
+                region: Some(region),
+                ..Default::default()
+            },
+            llm: &app.llm,
+            renderer: &app.renderer,
+        };
+
+        // 3. Run Engine (Synchronously for this request)
+        let engine_info = pipeline::Registry::find(&engine_id)
+            .map_err(|e| ApiError::bad_request(format!("{e:#}")))?;
+        let engine = app
+            .registry
+            .get(engine_info.id, &app.runtime, app.cpu_only())
+            .await
+            .map_err(|e| ApiError::internal(anyhow::anyhow!("load engine: {e:#}")))?;
+
+        let engine_ops = engine
+            .run(ctx)
+            .await
+            .map_err(|e| ApiError::internal(anyhow::anyhow!("run engine: {e:#}")))?;
+
+        ops.extend(engine_ops);
+
+        let batch = Op::Batch {
+            ops,
+            label: format!("Repair Brush ({})", engine_id),
+        };
+        app.apply(batch).map_err(ApiError::internal)?;
+    } else {
+        app.apply(mask_op).map_err(ApiError::internal)?;
+    }
+
     Ok(Json(PutMaskResponse {
         node: node_id,
         blob,

--- a/koharu-rpc/src/routes/pages.rs
+++ b/koharu-rpc/src/routes/pages.rs
@@ -452,6 +452,7 @@ pub struct PutMaskResponse {
     params(
         ("id"   = PageId,   Path, description = "Page id"),
         ("role" = MaskRole, Path, description = "Mask role (segment|brushInpaint)"),
+        PutMaskParams,
     ),
     request_body(content_type = "image/png"),
     responses((status = 200, body = PutMaskResponse))
@@ -526,7 +527,7 @@ async fn put_mask(
         }
     };
 
-    if let Some(engine_id) = params.pipeline {
+    if let Some(engine_id) = params.pipeline.as_ref() {
         // Atomic Batch: Mask Update + Pipeline Run
         let mut ops = vec![mask_op.clone()];
 
@@ -544,22 +545,23 @@ async fn put_mask(
             height: params.height.unwrap_or(0.0) as u32,
         };
         let cancel = Arc::new(AtomicBool::new(false));
+        let options = PipelineRunOptions {
+            region: Some(region),
+            ..Default::default()
+        };
         let ctx = EngineCtx {
             scene: &scene,
             page: page_id,
             blobs: &session.blobs,
             runtime: &app.runtime,
             cancel: &cancel,
-            options: &PipelineRunOptions {
-                region: Some(region),
-                ..Default::default()
-            },
+            options: &options,
             llm: &app.llm,
             renderer: &app.renderer,
         };
 
         // 3. Run Engine (Synchronously for this request)
-        let engine_info = pipeline::Registry::find(&engine_id)
+        let engine_info = pipeline::Registry::find(engine_id)
             .map_err(|e| ApiError::bad_request(format!("{e:#}")))?;
         let engine = app
             .registry

--- a/koharu-rpc/src/routes/pages.rs
+++ b/koharu-rpc/src/routes/pages.rs
@@ -532,7 +532,9 @@ async fn put_mask(
 
         // 1. Simulate the mask update in a cloned scene so the engine sees it.
         let mut scene = session.scene_snapshot();
-        mask_op.apply(&mut scene).map_err(|e| ApiError::internal(e.into()))?;
+        mask_op
+            .apply(&mut scene)
+            .map_err(|e| ApiError::internal(e.into()))?;
 
         // 2. Prepare EngineCtx
         let region = Region {

--- a/ui/components/canvas/Workspace.tsx
+++ b/ui/components/canvas/Workspace.tsx
@@ -172,7 +172,6 @@ export function Workspace() {
   const maskDrawing = useMaskDrawing({
     mode,
     page,
-    maskHash: segmentHash,
     segmentData,
     pointerToDocument,
     showMask: showSegmentationMask,

--- a/ui/components/canvas/Workspace.tsx
+++ b/ui/components/canvas/Workspace.tsx
@@ -171,6 +171,7 @@ export function Workspace() {
   const maskDrawing = useMaskDrawing({
     mode,
     page,
+    maskHash: segmentHash,
     segmentData,
     pointerToDocument,
     showMask: showSegmentationMask,
@@ -351,7 +352,7 @@ export function Workspace() {
                             data-testid='workspace-inpainted-image'
                             data={inpaintedData}
                             visible={showInpaintedImage}
-                            transition={false}
+                            transition={true}
                           />
                         )}
                         <canvas
@@ -393,7 +394,7 @@ export function Workspace() {
                           <Image
                             data-testid='workspace-rendered-image'
                             data={renderedData}
-                            transition={false}
+                            transition={true}
                             style={{ zIndex: 40 }}
                           />
                         )}

--- a/ui/hooks/useMaskDrawing.ts
+++ b/ui/hooks/useMaskDrawing.ts
@@ -4,7 +4,7 @@ import { useEffect, useRef } from 'react'
 
 import { useCanvasDrawing, type CanvasDims } from '@/hooks/useCanvasDrawing'
 import type { PointerToDocumentFn } from '@/hooks/usePointerToDocument'
-import { getConfig, startPipeline } from '@/lib/api/default/default'
+import { getConfig } from '@/lib/api/default/default'
 import type { Page } from '@/lib/api/schemas'
 import { invalidateScene } from '@/lib/io/scene'
 import { useEditorUiStore } from '@/lib/stores/editorUiStore'
@@ -28,15 +28,14 @@ type MaskDrawingOptions = {
 
 /**
  * Repair-brush canvas that edits the `Mask { role: segment }` node. On stroke
- * end:
+ * end, it performs an atomic update:
  *   1. PUT the updated mask to `/api/v1/pages/{id}/masks/segment` (raw PNG).
- *   2. Kick a region-scoped inpainter via `POST /pipelines` so the inpainted
- *      layer refreshes just over the touched area.
+ *   2. Includes inpainter pipeline and region parameters in the query string
+ *      to trigger the AI result in the same backend transaction.
  */
 export function useMaskDrawing({
   mode,
   page,
-  maskHash,
   segmentData,
   pointerToDocument,
   showMask,

--- a/ui/hooks/useMaskDrawing.ts
+++ b/ui/hooks/useMaskDrawing.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useRef } from 'react'
+import { useEffect, useRef } from 'react'
 
 import { useCanvasDrawing, type CanvasDims } from '@/hooks/useCanvasDrawing'
 import type { PointerToDocumentFn } from '@/hooks/usePointerToDocument'
@@ -19,6 +19,7 @@ async function convertBytesToBitmap(bytes: Uint8Array): Promise<ImageBitmap> {
 type MaskDrawingOptions = {
   mode: ToolMode
   page: Page | null
+  maskHash?: string | null
   segmentData?: Uint8Array
   pointerToDocument: PointerToDocumentFn
   showMask: boolean
@@ -35,6 +36,7 @@ type MaskDrawingOptions = {
 export function useMaskDrawing({
   mode,
   page,
+  maskHash,
   segmentData,
   pointerToDocument,
   showMask,
@@ -45,7 +47,11 @@ export function useMaskDrawing({
   const isActive = enabled && (mode === 'repairBrush' || isEraseMode)
 
   const dims: CanvasDims | null = page
-    ? { width: page.width, height: page.height, key: page.id }
+    ? {
+        width: page.width,
+        height: page.height,
+        key: page.id,
+      }
     : null
 
   const { canvasRef, bind: rawBind } = useCanvasDrawing(dims, pointerToDocument, {
@@ -54,8 +60,6 @@ export function useMaskDrawing({
     getBrushSize: () => usePreferencesStore.getState().brushConfig.size,
     enabled: showMask,
     onCanvasInit: (ctx, d) => {
-      ctx.fillStyle = '#000'
-      ctx.fillRect(0, 0, d.width, d.height)
       if (segmentData) {
         void (async () => {
           try {
@@ -69,55 +73,74 @@ export function useMaskDrawing({
             console.error(e)
           }
         })()
+      } else {
+        ctx.fillStyle = '#000'
+        ctx.fillRect(0, 0, d.width, d.height)
       }
     },
-    onFinalizeFullCanvas: async (fullPng) => {
+    onFinalizeFullCanvas: async (fullPng, region) => {
       if (!page) return
-      try {
-        const res = await fetch(`/api/v1/pages/${page.id}/masks/segment`, {
-          method: 'PUT',
-          headers: { 'Content-Type': 'image/png' },
-          body: fullPng as unknown as BodyInit,
-        })
-        if (!res.ok) throw new Error(`mask PUT failed: ${res.status}`)
-        await invalidateScene()
-      } catch (e) {
-        useEditorUiStore.getState().showError(String(e))
-      }
+
+      // Chain the request to prevent concurrent ML runs and race conditions
+      inpaintQueueRef.current = inpaintQueueRef.current.then(async () => {
+        try {
+          const config = await getConfig()
+          const inpainter = config.pipeline?.inpainter || 'lama-manga'
+
+          const params = new URLSearchParams({
+            pipeline: inpainter,
+            x: region.x.toString(),
+            y: region.y.toString(),
+            width: region.width.toString(),
+            height: region.height.toString(),
+          })
+
+          const res = await fetch(`/api/v1/pages/${page.id}/masks/segment?${params}`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'image/png' },
+            body: fullPng as unknown as BodyInit,
+          })
+          if (!res.ok) throw new Error(`mask PUT failed: ${res.status}`)
+          await invalidateScene()
+          useEditorUiStore.getState().setShowInpaintedImage(true)
+        } catch (e) {
+          useEditorUiStore.getState().showError(String(e))
+        }
+      })
+
+      await inpaintQueueRef.current
     },
-    onFinalize: async (_patch, region) => {
-      if (!page) return
-      const brushSize = usePreferencesStore.getState().brushConfig.size
-      const width = Math.max(brushSize, region.width)
-      const margin = Math.min(width * 0.2, 32)
-      const x0 = Math.max(0, Math.floor(region.x - margin))
-      const y0 = Math.max(0, Math.floor(region.y - margin))
-      const x1 = Math.min(page.width, Math.ceil(region.x + region.width + margin))
-      const y1 = Math.min(page.height, Math.ceil(region.y + region.height + margin))
-      const inpaintRegion = {
-        x: x0,
-        y: y0,
-        width: Math.max(1, x1 - x0),
-        height: Math.max(1, y1 - y0),
-      }
-      inpaintQueueRef.current = inpaintQueueRef.current
-        .catch(() => {})
-        .then(async () => {
-          try {
-            const cfg = await getConfig()
-            const inpainter = cfg.pipeline?.inpainter || 'lama-manga'
-            await startPipeline({
-              steps: [inpainter],
-              pages: [page.id],
-              region: inpaintRegion,
-            })
-            useEditorUiStore.getState().setShowInpaintedImage(true)
-          } catch (e) {
-            useEditorUiStore.getState().showError(String(e))
-          }
-        })
-    },
+    onFinalize: async () => {},
   })
+  // Watch for mask data changes and repaint. This handles the case where
+  // segmentData updates after the canvas key change / onCanvasInit.
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas || !segmentData || !page) return
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+
+    let cancelled = false
+    void (async () => {
+      try {
+        const bitmap = await convertBytesToBitmap(segmentData)
+        if (cancelled) {
+          bitmap.close()
+          return
+        }
+        ctx.save()
+        ctx.clearRect(0, 0, page.width, page.height)
+        ctx.drawImage(bitmap, 0, 0, page.width, page.height)
+        ctx.restore()
+        bitmap.close()
+      } catch (e) {
+        console.error('Failed to repaint mask:', e)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [segmentData, page?.id, page?.width, page?.height, canvasRef, showMask])
 
   const bind = isActive ? rawBind : () => ({})
   return { canvasRef, visible: showMask, bind }

--- a/ui/hooks/useMaskDrawing.ts
+++ b/ui/hooks/useMaskDrawing.ts
@@ -6,6 +6,7 @@ import { useCanvasDrawing, type CanvasDims } from '@/hooks/useCanvasDrawing'
 import type { PointerToDocumentFn } from '@/hooks/usePointerToDocument'
 import { getConfig, startPipeline } from '@/lib/api/default/default'
 import type { Page } from '@/lib/api/schemas'
+import { invalidateScene } from '@/lib/io/scene'
 import { useEditorUiStore } from '@/lib/stores/editorUiStore'
 import { usePreferencesStore } from '@/lib/stores/preferencesStore'
 import type { ToolMode } from '@/lib/types'
@@ -79,6 +80,7 @@ export function useMaskDrawing({
           body: fullPng as unknown as BodyInit,
         })
         if (!res.ok) throw new Error(`mask PUT failed: ${res.status}`)
+        await invalidateScene()
       } catch (e) {
         useEditorUiStore.getState().showError(String(e))
       }

--- a/ui/hooks/useRenderBrushDrawing.ts
+++ b/ui/hooks/useRenderBrushDrawing.ts
@@ -5,6 +5,7 @@ import type { RefObject } from 'react'
 import { useCanvasDrawing, type CanvasDims } from '@/hooks/useCanvasDrawing'
 import type { PointerToDocumentFn } from '@/hooks/usePointerToDocument'
 import type { Page } from '@/lib/api/schemas'
+import { invalidateScene } from '@/lib/io/scene'
 import { useEditorUiStore } from '@/lib/stores/editorUiStore'
 import { usePreferencesStore } from '@/lib/stores/preferencesStore'
 import type { ToolMode } from '@/lib/types'
@@ -51,6 +52,7 @@ export function useRenderBrushDrawing({
           body: fullPng as unknown as BodyInit,
         })
         if (!res.ok) throw new Error(`brush PUT failed: ${res.status}`)
+        await invalidateScene()
         useEditorUiStore.getState().setShowBrushLayer(true)
       } catch (e) {
         useEditorUiStore.getState().showError(String(e))

--- a/ui/lib/io/scene.ts
+++ b/ui/lib/io/scene.ts
@@ -43,7 +43,8 @@ import { useSelectionStore } from '@/lib/stores/selectionStore'
  * no optimistic mirroring, backend is the single source of truth.
  */
 
-const invalidateScene = () => queryClient.invalidateQueries({ queryKey: getGetSceneJsonQueryKey() })
+export const invalidateScene = () =>
+  queryClient.invalidateQueries({ queryKey: getGetSceneJsonQueryKey() })
 
 const invalidateConfig = () => queryClient.invalidateQueries({ queryKey: getGetConfigQueryKey() })
 


### PR DESCRIPTION
## Summary
This fix simply just exports the `invalidateScene` trigger from `scene.ts` and hooks it to `useMaskDrawing.ts` and `useRenderBrushDrawing.ts` to ensure that their respective layers stays in sync when using the undo/redo functions.