### PR TITLE
fix(ui): open updater release-note links externally

### DIFF
--- a/ui/components/Updater.tsx
+++ b/ui/components/Updater.tsx
@@ -20,7 +20,7 @@ import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/compone
 import { Progress } from '@/components/ui/progress'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { Separator } from '@/components/ui/separator'
-import { isTauri } from '@/lib/backend'
+import { isTauri, openExternalUrl } from '@/lib/backend'
 
 export type UpdaterStatus = 'idle' | 'loading' | 'latest' | 'outdated' | 'error'
 
@@ -45,6 +45,14 @@ const UpdaterContext = createContext<UpdaterContextValue>({
   checkForUpdates: async () => {},
   installUpdate: async () => {},
 })
+
+function isExternalUrl(href: string): boolean {
+  return /^https?:\/\//i.test(href)
+}
+
+async function openUpdateLink(href: string): Promise<void> {
+  await openExternalUrl(href)
+}
 
 export function useUpdater(): UpdaterContextValue {
   return useContext(UpdaterContext)
@@ -221,7 +229,28 @@ function PromptView({
       {update.body ? (
         <ScrollArea className='h-64'>
           <div className='prose prose-sm dark:prose-invert max-w-none px-6 py-4 [&_a]:text-primary [&_h2]:mt-4 [&_h2]:mb-2 [&_h2]:text-sm [&_h2]:font-semibold [&_h3]:mt-3 [&_h3]:mb-1 [&_h3]:text-xs [&_h3]:font-semibold [&_h3]:tracking-wide [&_h3]:text-muted-foreground [&_h3]:uppercase [&_li]:my-0.5 [&_p]:my-1.5 [&_ul]:my-1.5 [&_ul]:list-disc [&_ul]:pl-5'>
-            <ReactMarkdown remarkPlugins={[remarkGfm]}>{update.body}</ReactMarkdown>
+            <ReactMarkdown
+              remarkPlugins={[remarkGfm]}
+              components={{
+                a({ node: _node, href, children, ...props }) {
+                  return (
+                    <a
+                      {...props}
+                      href={href}
+                      onClick={(event) => {
+                        if (!href || !isExternalUrl(href)) return
+                        event.preventDefault()
+                        void openUpdateLink(href)
+                      }}
+                    >
+                      {children}
+                    </a>
+                  )
+                },
+              }}
+            >
+              {update.body}
+            </ReactMarkdown>
           </div>
         </ScrollArea>
       ) : (

--- a/ui/components/Updater.tsx
+++ b/ui/components/Updater.tsx
@@ -50,10 +50,6 @@ function isExternalUrl(href: string): boolean {
   return /^https?:\/\//i.test(href)
 }
 
-async function openUpdateLink(href: string): Promise<void> {
-  await openExternalUrl(href)
-}
-
 export function useUpdater(): UpdaterContextValue {
   return useContext(UpdaterContext)
 }
@@ -240,7 +236,7 @@ function PromptView({
                       onClick={(event) => {
                         if (!href || !isExternalUrl(href)) return
                         event.preventDefault()
-                        void openUpdateLink(href)
+                        void openExternalUrl(href)
                       }}
                     >
                       {children}


### PR DESCRIPTION
## Summary

Fixes #564.

Updater release notes are rendered from markdown. External links were rendered as normal anchors, which caused the embedded Tauri webview to navigate to GitHub or other external pages.

This adds a custom `ReactMarkdown` anchor renderer for updater release notes. External `http(s)` links now call `preventDefault()` and open through the existing `openExternalUrl()` helper, so they open in the system browser instead of replacing the app view.

## Testing

- Ran `bun --cwd ui lint`
- Verified in Tauri dev that clicking an updater release-note link opens the system browser
- Verified the Koharu webview stays on the app instead of navigating to the external URL
