### PR TITLE
Fix ZLUDA cuBLAS 12 runtime extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ ZLUDA is a CUDA compatibility layer that lets some CUDA workloads run on AMD GPU
 
 To use it, install the [AMD HIP SDK](https://www.amd.com/en/developer/resources/rocm-hub/hip-sdk.html).
 
+On Windows with a Radeon RX 9070 XT, use `therock-dist-windows-gfx120X-all-7.12.0a20260311.tar.gz` or an older HIP runtime for ZLUDA compatibility.
+
 ### Metal (Apple Silicon on macOS)
 
 Koharu supports Metal on Apple Silicon Macs. No extra runtime setup is required beyond a normal app install.

--- a/docs/en-US/explanation/acceleration-and-runtime.md
+++ b/docs/en-US/explanation/acceleration-and-runtime.md
@@ -29,6 +29,12 @@ On Windows and Linux, Vulkan is available as an alternative GPU path for OCR and
 
 AMD and Intel GPUs can benefit from Vulkan, but detection and inpainting still depend on CUDA or Metal.
 
+## ZLUDA on AMD GPUs
+
+On Windows, Koharu can use experimental ZLUDA acceleration on AMD GPUs when a compatible HIP runtime is installed.
+
+For Radeon RX 9070 XT systems on Windows, use `therock-dist-windows-gfx120X-all-7.12.0a20260311.tar.gz` or an older HIP runtime. Newer HIP builds may change runtime library behavior in ways that prevent the bundled ZLUDA runtime from loading correctly.
+
 ## CPU fallback
 
 Koharu can always run on CPU when GPU acceleration is unavailable or when you force CPU mode explicitly.

--- a/koharu-runtime/src/zluda.rs
+++ b/koharu-runtime/src/zluda.rs
@@ -6,12 +6,14 @@ const RELEASE_TAG: &str = "v6-preview.65";
 const ZLUDA_ASSET_NAME: &str = "zluda-windows-5c75a54.zip";
 #[cfg(any(target_os = "windows", test))]
 // Bump this when extraction behavior changes but the upstream asset name stays the same.
-const ZLUDA_EXTRACT_REVISION: u32 = 4;
+const ZLUDA_EXTRACT_REVISION: u32 = 5;
 #[cfg(any(target_os = "windows", test))]
 const ZLUDA_DLLS: &[&str] = &[
     "nvcudart_hybrid64.dll",
     "nvcuda.dll",
+    "cublasLt64_12.dll",
     "cublasLt64_13.dll",
+    "cublas64_12.dll",
     "cublas64_13.dll",
     "cufft64_12.dll",
     "cudnn64_9.dll",
@@ -200,7 +202,9 @@ mod tests {
     #[test]
     fn required_runtime_dlls_cover_zluda_cuda_entrypoints() {
         assert!(ZLUDA_DLLS.contains(&"nvcuda.dll"));
+        assert!(ZLUDA_DLLS.contains(&"cublas64_12.dll"));
         assert!(ZLUDA_DLLS.contains(&"cublas64_13.dll"));
+        assert!(ZLUDA_DLLS.contains(&"cublasLt64_12.dll"));
         assert!(ZLUDA_DLLS.contains(&"cublasLt64_13.dll"));
         assert!(ZLUDA_DLLS.contains(&"cufft64_12.dll"));
         assert!(ZLUDA_DLLS.contains(&"cudnn64_9.dll"));
@@ -231,7 +235,7 @@ mod tests {
 
     #[test]
     fn runtime_extract_list_matches_preload_list() {
-        assert_eq!(ZLUDA_DLLS.len(), 6);
+        assert_eq!(ZLUDA_DLLS.len(), 8);
         assert!(ZLUDA_DLLS.iter().all(|dll| dll.ends_with(".dll")));
     }
 }


### PR DESCRIPTION
## Summary

Fixes https://github.com/mayocream/koharu/issues/580.

This updates the bundled ZLUDA runtime extraction list to include the CUDA 12 cuBLAS DLL names that `cudarc` probes at runtime: `cublas64_12.dll` and `cublasLt64_12.dll`.

It also documents the HIP runtime version known to work for Radeon RX 9070 XT systems on Windows.

## Root Cause

The ZLUDA package already includes both CUDA 12 and CUDA 13 cuBLAS shim DLLs, but Koharu only extracted the CUDA 13 names into `runtime/zluda`. When `cudarc` attempted to dynamically load cuBLAS, it searched for `cublas64_12.dll` before the CUDA 13 name and failed because that DLL was not present in the runtime directory.

## Changes

- Add `cublas64_12.dll` and `cublasLt64_12.dll` to `ZLUDA_DLLS`.
- Bump `ZLUDA_EXTRACT_REVISION` so existing runtime installs are refreshed.
- Update ZLUDA runtime tests for the expanded DLL list.
- Document that Windows + Radeon RX 9070 XT systems should use `therock-dist-windows-gfx120X-all-7.12.0a20260311.tar.gz` or an older HIP runtime for ZLUDA compatibility.

## Validation

- `cargo test -p koharu-runtime zluda`