### PR TITLE
Add manual text direction toggle to render controls

### DIFF
--- a/ui/components/panels/RenderControlsPanel.tsx
+++ b/ui/components/panels/RenderControlsPanel.tsx
@@ -4,6 +4,8 @@ import {
   AlignCenterIcon,
   AlignLeftIcon,
   AlignRightIcon,
+  ArrowDownIcon,
+  ArrowRightIcon,
   BoldIcon,
   ItalicIcon,
   MinusIcon,
@@ -31,6 +33,7 @@ import type {
   FontPrediction,
   Op,
   TextAlign,
+  TextDirection,
   TextShaderEffect,
   TextStrokeStyle,
   TextStyle,
@@ -191,6 +194,15 @@ export function RenderControlsPanel() {
     firstNode?.data.style?.textAlign ??
     (selectedNode?.data.translation ? 'center' : 'left')
 
+  const effectiveTextDirection: TextDirection =
+    selectedNode?.data.sourceDirection ??
+    selectedNode?.data.renderedDirection ??
+    firstNode?.data.sourceDirection ??
+    firstNode?.data.renderedDirection ?? 'horizontal'
+
+  const DirectionIcon =
+    effectiveTextDirection === 'vertical' ? ArrowDownIcon : ArrowRightIcon
+
   // ---------------------------------------------------------------------------
   // Mutations
   // ---------------------------------------------------------------------------
@@ -237,6 +249,47 @@ export function RenderControlsPanel() {
 
   const applyStyleToAll = (updates: Partial<TextStyle>) => {
     applyStyleToNodes(textNodes, updates, 'Bulk style update')
+  }
+
+  const buildTextDirectionOp = (n: TextNodeEntry, direction: TextDirection): Op => {
+    return ops.updateNode(page!.id, n.id, {
+      data: { text: { sourceDirection: direction } } as never,
+    })
+  }
+
+  const applyTextDirectionToNodes = (
+    nodes: TextNodeEntry[],
+    direction: TextDirection,
+    label: string,
+  ) => {
+    if (!page || nodes.length === 0) return
+    void (async () => {
+      const op =
+        nodes.length === 1
+          ? buildTextDirectionOp(nodes[0], direction)
+          : ops.batch(
+              label,
+              nodes.map((n) => buildTextDirectionOp(n, direction)),
+            )
+      await applyOp(op)
+      queueAutoRender(page.id)
+    })()
+  }
+
+  const applyTextDirectionToSelected = (direction: TextDirection): boolean => {
+    if (selectedNodes.length === 0) return false
+    applyTextDirectionToNodes(selectedNodes, direction, 'Multi-block text direction update')
+    return true
+  }
+
+  const applyTextDirectionToAll = (direction: TextDirection) => {
+    applyTextDirectionToNodes(textNodes, direction, 'Bulk text direction update')
+  }
+
+  const toggleTextDirection = () => {
+    const next: TextDirection = effectiveTextDirection === 'vertical' ? 'horizontal' : 'vertical'
+    if (applyTextDirectionToSelected(next)) return
+    applyTextDirectionToAll(next)
   }
 
   const applyStrokeSetting = (nextStroke: TextStrokeStyle) => {
@@ -347,12 +400,15 @@ export function RenderControlsPanel() {
       </div>
 
       {/* Size / Effect / Align */}
-      <div className='grid w-full grid-cols-[minmax(0,1fr)_auto_auto] items-end gap-x-1.5'>
+      <div className='grid w-full grid-cols-[minmax(0,1fr)_auto_auto_auto] items-end gap-x-1.5'>
         <span className='text-[10px] font-medium text-muted-foreground uppercase'>
           {t('render.fontSizeLabel')}
         </span>
         <span className='text-[10px] font-medium text-muted-foreground uppercase'>
           {t('render.effectLabel')}
+        </span>
+        <span className='text-[10px] font-medium text-muted-foreground uppercase'>
+          {t('render.textDirectionLabel')}
         </span>
         <span className='text-[10px] font-medium text-muted-foreground uppercase'>
           {t('render.alignLabel')}
@@ -442,6 +498,29 @@ export function RenderControlsPanel() {
               </Tooltip>
             )
           })}
+        </div>
+
+        <div className='flex items-center gap-0.5'>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                type='button'
+                variant='outline'
+                size='icon-sm'
+                aria-label={t('render.textDirectionToggle')}
+                data-testid='render-text-direction-toggle'
+                aria-pressed={effectiveTextDirection === 'vertical'}
+                disabled={!hasNodes}
+                className='size-6 shrink-0'
+                onClick={toggleTextDirection}
+              >
+                <DirectionIcon className='size-3' />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side='bottom' sideOffset={4}>
+              {t('render.textDirectionToggle')}
+            </TooltipContent>
+          </Tooltip>
         </div>
 
         <div className='flex items-center gap-0.5'>

--- a/ui/public/locales/en-US/translation.json
+++ b/ui/public/locales/en-US/translation.json
@@ -216,6 +216,8 @@
   "render": {
     "effectLabel": "Text effect",
     "alignLabel": "Align",
+    "textDirectionLabel": "Direction",
+    "textDirectionToggle": "Toggle text direction",
     "alignLeft": "Align left",
     "alignCenter": "Align center",
     "alignRight": "Align right",

--- a/ui/public/locales/es-ES/translation.json
+++ b/ui/public/locales/es-ES/translation.json
@@ -183,6 +183,8 @@
   "render": {
     "effectLabel": "Efecto de texto",
     "alignLabel": "Alineación",
+    "textDirectionLabel": "Dirección",
+    "textDirectionToggle": "Cambiar dirección del texto",
     "alignLeft": "Alinear a la izquierda",
     "alignCenter": "Centrar",
     "alignRight": "Alinear a la derecha",

--- a/ui/public/locales/ja-JP/translation.json
+++ b/ui/public/locales/ja-JP/translation.json
@@ -183,6 +183,8 @@
   "render": {
     "effectLabel": "文字効果",
     "alignLabel": "配置",
+    "textDirectionLabel": "方向",
+    "textDirectionToggle": "文字方向を切り替え",
     "alignLeft": "左揃え",
     "alignCenter": "中央揃え",
     "alignRight": "右揃え",

--- a/ui/public/locales/ko-KR/translation.json
+++ b/ui/public/locales/ko-KR/translation.json
@@ -216,6 +216,8 @@
   "render": {
     "effectLabel": "텍스트 효과",
     "alignLabel": "정렬",
+    "textDirectionLabel": "방향",
+    "textDirectionToggle": "텍스트 방향 전환",
     "alignLeft": "왼쪽 정렬",
     "alignCenter": "가운데 정렬",
     "alignRight": "오른쪽 정렬",

--- a/ui/public/locales/pt-BR/translation.json
+++ b/ui/public/locales/pt-BR/translation.json
@@ -184,6 +184,8 @@
   "render": {
     "effectLabel": "Efeito de texto",
     "alignLabel": "Alinhamento",
+    "textDirectionLabel": "Direção",
+    "textDirectionToggle": "Alternar direção do texto",
     "alignLeft": "Alinhar à esquerda",
     "alignCenter": "Centralizar",
     "alignRight": "Alinhar à direita",

--- a/ui/public/locales/ru-RU/translation.json
+++ b/ui/public/locales/ru-RU/translation.json
@@ -183,6 +183,8 @@
   "render": {
     "effectLabel": "Эффект текста",
     "alignLabel": "Выравнивание",
+    "textDirectionLabel": "Направление",
+    "textDirectionToggle": "Переключить направление текста",
     "alignLeft": "По левому краю",
     "alignCenter": "По центру",
     "alignRight": "По правому краю",

--- a/ui/public/locales/tr-TR/translation.json
+++ b/ui/public/locales/tr-TR/translation.json
@@ -183,6 +183,8 @@
   "render": {
     "effectLabel": "Metin efekti",
     "alignLabel": "Hizalama",
+    "textDirectionLabel": "Yön",
+    "textDirectionToggle": "Metin yönünü değiştir",
     "alignLeft": "Sola hizala",
     "alignCenter": "Ortala",
     "alignRight": "Sağa hizala",

--- a/ui/public/locales/zh-CN/translation.json
+++ b/ui/public/locales/zh-CN/translation.json
@@ -182,6 +182,8 @@
   },
   "render": {
     "effectLabel": "文字效果",
+    "textDirectionLabel": "方向",
+    "textDirectionToggle": "切换文字方向",
     "alignLabel": "对齐",
     "alignLeft": "左对齐",
     "alignCenter": "居中对齐",

--- a/ui/public/locales/zh-TW/translation.json
+++ b/ui/public/locales/zh-TW/translation.json
@@ -182,6 +182,8 @@
   },
   "render": {
     "effectLabel": "文字效果",
+    "textDirectionLabel": "方向",
+    "textDirectionToggle": "切換文字方向",
     "alignLabel": "對齊",
     "alignLeft": "靠左對齊",
     "alignCenter": "置中對齊",

--- a/ui/tests/components/RenderControlsPanel.test.tsx
+++ b/ui/tests/components/RenderControlsPanel.test.tsx
@@ -169,4 +169,32 @@ describe('RenderControlsPanel Font Assignment', () => {
     await waitFor(() => expect(input.value).toBe(''))
     expect(input).toHaveAttribute('placeholder', 'auto')
   })
+
+  it('toggles text direction for a selected text block', async () => {
+    renderWithQuery(<RenderControlsPanel />)
+    useSelectionStore.getState().select('t1', false)
+    const toggle = await screen.findByTestId('render-text-direction-toggle')
+    await userEvent.click(toggle)
+    await waitFor(() => expect(sceneActions.applyOp).toHaveBeenCalled())
+    const op = (sceneActions.applyOp as any).mock.calls[0][0]
+    expect(op).toHaveProperty('updateNode')
+    expect(op.updateNode.id).toBe('t1')
+    expect(op.updateNode.patch.data.text.sourceDirection).toBe('vertical')
+    expect(sceneActions.queueAutoRender).toHaveBeenCalled()
+  })
+
+  it('applies text direction globally when no text block is selected', async () => {
+    renderWithQuery(<RenderControlsPanel />)
+    useSelectionStore.getState().clear()
+    const toggle = await screen.findByTestId('render-text-direction-toggle')
+    await userEvent.click(toggle)
+    await waitFor(() => expect(sceneActions.applyOp).toHaveBeenCalled())
+    const op = (sceneActions.applyOp as any).mock.calls[0][0]
+    expect(op).toHaveProperty('batch')
+    expect(op.batch.ops).toHaveLength(2)
+    for (const inner of op.batch.ops) {
+      expect(inner.updateNode.patch.data.text.sourceDirection).toBe('vertical')
+    }
+    expect(sceneActions.queueAutoRender).toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
## Summary

This PR adds a manual text direction toggle to the render controls panel.

It allows users to switch selected text blocks between horizontal and vertical direction when automatic writing-mode detection misclassifies a block. This is mainly intended for CJK manga/OCR cases, such as vertical Japanese text being detected or rendered as horizontal.

Closes #597

## Changes

- Add a text direction toggle to `RenderControlsPanel`
- Toggle selected text blocks between `horizontal` and `vertical`
- Write the selected direction to `text.sourceDirection` through the existing op pipeline
- Add i18n labels for the new render control
- Add tests for selected-block and global text direction updates

## Current behavior / open question

This PR does not change renderer behavior.

Non-CJK text is still rendered horizontally even when `sourceDirection` is set to `vertical`, because the renderer currently returns horizontal for non-CJK text before checking `source_direction`.

If maintainers think this feature is useful, I’m happy to adjust the UI based on the intended behavior: either make vertical direction a general override for all scripts, or keep it CJK-only and hide/disable/explain the control for unsupported text blocks.

## Screenshots

<img width="2212" height="1488" alt="image" src="https://github.com/user-attachments/assets/c4143181-3bfc-4a80-a0d2-5ff0e5f2dd7b" />

## Testing

- Added tests for toggling text direction on a selected text block
- Added tests for applying text direction globally when no text block is selected
- Manually confirmed that the selected text block updates and the page re-renders