### PR TITLE
fix(editor): Delete key removes all selected text blocks (closes #559)

### DIFF
--- a/ui/components/canvas/TextBlockLayer.tsx
+++ b/ui/components/canvas/TextBlockLayer.tsx
@@ -31,9 +31,9 @@ export function TextBlockLayer({ showSprites, scale, style }: TextBlockLayerProp
   const mode = useEditorUiStore((s) => s.mode)
   const interactive = mode === 'select' || mode === 'block'
 
-  const firstSelectedId = useMemo(() => {
-    for (const id of selectedIds) if (id) return id
-    return null
+  const hasSelection = useMemo(() => {
+    for (const id of selectedIds) if (id) return true
+    return false
   }, [selectedIds])
 
   const removeNode = async (id: string) => {
@@ -45,6 +45,16 @@ export function TextBlockLayer({ showSprites, scale, style }: TextBlockLayerProp
     if ('text' in node.kind) queueAutoRender(page.id)
   }
 
+  const removeSelected = async () => {
+    if (!page) return
+    // Snapshot selection now: each op invalidates the page state by removing a
+    // node, so we can't iterate against a stale closure mid-loop.
+    const ids = Array.from(selectedIds).filter((id): id is string => !!id)
+    for (const id of ids) {
+      await removeNode(id)
+    }
+  }
+
   const updateTransform = async (id: string, t: Transform) => {
     if (!page) return
     await applyOp(ops.updateNode(page.id, id, { transform: t }))
@@ -54,10 +64,10 @@ export function TextBlockLayer({ showSprites, scale, style }: TextBlockLayerProp
   useHotkeys(
     'delete',
     () => {
-      if (firstSelectedId && interactive) void removeNode(firstSelectedId)
+      if (hasSelection && interactive) void removeSelected()
     },
-    { enabled: !!firstSelectedId && interactive },
-    [firstSelectedId, interactive],
+    { enabled: hasSelection && interactive },
+    [selectedIds, interactive],
   )
 
   return (


### PR DESCRIPTION
Closes #559.

The \`delete\` hotkey on the canvas only removed \`firstSelectedId\`, so a Ctrl+A selection followed by Delete cleared a single block and left the rest behind.

This iterates over the full \`selectedIds\` set and awaits \`removeNode\` for each in turn. Snapshotting the selection up front matters because each removal invalidates the closure's view of the page (each op shifts node indices), so we can't iterate the underlying \`selectedIds\` reference mid-loop.

The single-selection case is unchanged: with one id selected, the new path still calls \`removeNode\` once.

\`\`\`
- const firstSelectedId = useMemo(() => { for (const id of selectedIds) if (id) return id; return null }, [selectedIds])
+ const hasSelection = useMemo(() => { for (const id of selectedIds) if (id) return true; return false }, [selectedIds])
\`\`\`

## Verification

- \`bun run lint:ui\` -- 0 errors (16 pre-existing warnings unchanged)
- \`bun x oxfmt --check ui/components/canvas/TextBlockLayer.tsx\` -- formatted
- \`bun run --filter ui test\` -- 138 / 138 pass
- (Note: \`bun run format:check\` reports a pre-existing formatting issue in \`ui/app/(app)/page.tsx\` unrelated to this change.)

## AI disclosure

Per Koharu's AI usage policy: this PR was authored with Claude Code assistance. I read the surrounding selection / hotkey / op code paths before changing them and ran the lint and test suites locally; happy to walk through the snapshot-vs-stale-closure reasoning in review if that's useful.