### PR TITLE
feat(pipeline): support page exclusion from batch processing

### DIFF
--- a/koharu-app/src/session.rs
+++ b/koharu-app/src/session.rs
@@ -36,12 +36,27 @@ const BLOBS_DIR: &str = "blobs";
 const CACHE_DIR: &str = "cache";
 const PROJECT_TOML: &str = "project.toml";
 
-/// Snapshot written to `scene.bin`.
+const SNAPSHOT_MAGIC: &[u8; 4] = b"KHR!";
+const SNAPSHOT_VERSION: u32 = 1;
+
+/// Legacy snapshot without versioning (V0).
 #[derive(Serialize, Deserialize)]
-struct Snapshot {
+struct SnapshotV0 {
     epoch: u64,
     scene: Scene,
 }
+
+/// Versioned snapshot (V1+).
+#[derive(Serialize, Deserialize)]
+struct SnapshotV1 {
+    magic: [u8; 4],
+    version: u32,
+    epoch: u64,
+    scene: Scene,
+}
+
+/// Current active snapshot type.
+type Snapshot = SnapshotV1;
 
 /// A loaded project.
 pub struct ProjectSession {
@@ -161,6 +176,8 @@ impl ProjectSession {
             let scene = self.scene.read();
             let epoch = self.history.lock().epoch();
             Snapshot {
+                magic: *SNAPSHOT_MAGIC,
+                version: SNAPSHOT_VERSION,
                 epoch,
                 scene: scene.clone(),
             }
@@ -188,8 +205,15 @@ fn load_snapshot(dir: &Utf8Path, creating: bool) -> Result<(Scene, u64)> {
         let bytes = std::fs::read(scene_path.as_std_path())
             .with_context(|| format!("read {}", scene_path))?;
 
-        // Try decoding with current format
-        match postcard::from_bytes::<Snapshot>(&bytes) {
+        // 1. Try decoding with current versioned format (V1)
+        if let Ok(snap) = postcard::from_bytes::<SnapshotV1>(&bytes) {
+            if &snap.magic == SNAPSHOT_MAGIC && snap.version == 1 {
+                return Ok((snap.scene, snap.epoch));
+            }
+        }
+
+        // 2. Fallback: Try decoding with legacy unversioned format (V0)
+        match postcard::from_bytes::<SnapshotV0>(&bytes) {
             Ok(snap) => return Ok((snap.scene, snap.epoch)),
             Err(e) => {
                 // If decoding fails, try legacy format (without 'excluded' field in Page)

--- a/koharu-app/src/session.rs
+++ b/koharu-app/src/session.rs
@@ -22,7 +22,8 @@ use atomicwrites::{AtomicFile, OverwriteBehavior};
 use camino::{Utf8Path, Utf8PathBuf};
 use chrono::Utc;
 use fs4::fs_std::FileExt;
-use koharu_core::{Scene, op::Op};
+use indexmap::IndexMap;
+use koharu_core::{Node, NodeId, Page, PageId, ProjectMeta, Scene, op::Op};
 use parking_lot::{Mutex, RwLock};
 use serde::{Deserialize, Serialize};
 
@@ -46,6 +47,55 @@ struct SnapshotV1 {
     version: u32,
     epoch: u64,
     scene: Scene,
+}
+
+/// Legacy snapshot without versioning (V0).
+/// Represents the format before 'excluded' field was added and before versioning.
+#[derive(Deserialize)]
+struct SnapshotV0 {
+    epoch: u64,
+    scene: SceneV0,
+}
+
+#[derive(Deserialize)]
+struct SceneV0 {
+    project: ProjectMeta,
+    pages: IndexMap<PageId, PageV0>,
+}
+
+#[derive(Deserialize)]
+struct PageV0 {
+    id: PageId,
+    name: String,
+    width: u32,
+    height: u32,
+    nodes: IndexMap<NodeId, Node>,
+}
+
+impl SnapshotV0 {
+    fn migrate(self) -> (Scene, u64) {
+        let mut pages = IndexMap::new();
+        for (id, lp) in self.scene.pages {
+            pages.insert(
+                id,
+                Page {
+                    id: lp.id,
+                    name: lp.name,
+                    width: lp.width,
+                    height: lp.height,
+                    nodes: lp.nodes,
+                    excluded: false,
+                },
+            );
+        }
+        (
+            Scene {
+                project: self.scene.project,
+                pages,
+            },
+            self.epoch,
+        )
+    }
 }
 
 /// Current active snapshot type.
@@ -206,56 +256,11 @@ fn load_snapshot(dir: &Utf8Path, creating: bool) -> Result<(Scene, u64)> {
         }
 
         // 2. Fallback: Try decoding with legacy unversioned format (V0)
-        // V0 represents the format before 'excluded' field was added and before versioning.
-        use koharu_core::{Node, NodeId, Page, PageId, ProjectMeta};
-        use indexmap::IndexMap;
-
-        #[derive(Deserialize)]
-        struct PageV0 {
-            id: PageId,
-            name: String,
-            width: u32,
-            height: u32,
-            nodes: IndexMap<NodeId, Node>,
-        }
-
-        #[derive(Deserialize)]
-        struct SceneV0 {
-            project: ProjectMeta,
-            pages: IndexMap<PageId, PageV0>,
-        }
-
-        #[derive(Deserialize)]
-        struct SnapshotV0 {
-            epoch: u64,
-            scene: SceneV0,
-        }
-
         if let Ok(v0) = postcard::from_bytes::<SnapshotV0>(&bytes) {
-            let mut pages = IndexMap::new();
-            for (id, lp) in v0.scene.pages {
-                pages.insert(
-                    id,
-                    Page {
-                        id: lp.id,
-                        name: lp.name,
-                        width: lp.width,
-                        height: lp.height,
-                        nodes: lp.nodes,
-                        excluded: false,
-                    },
-                );
-            }
-            return Ok((
-                Scene {
-                    project: v0.scene.project,
-                    pages,
-                },
-                v0.epoch,
-            ));
+            return Ok(v0.migrate());
         }
-        return Err(anyhow::anyhow!("decode failed for both V1 and V0 formats"))
-            .with_context(|| format!("decode {}", scene_path));
+
+        anyhow::bail!("decode failed for both V1 and V0 formats (file: {})", scene_path);
     }
 
     // No snapshot — build one from `project.toml` (or defaults for creation).

--- a/koharu-app/src/session.rs
+++ b/koharu-app/src/session.rs
@@ -39,13 +39,6 @@ const PROJECT_TOML: &str = "project.toml";
 const SNAPSHOT_MAGIC: &[u8; 4] = b"KHR!";
 const SNAPSHOT_VERSION: u32 = 1;
 
-/// Legacy snapshot without versioning (V0).
-#[derive(Serialize, Deserialize)]
-struct SnapshotV0 {
-    epoch: u64,
-    scene: Scene,
-}
-
 /// Versioned snapshot (V1+).
 #[derive(Serialize, Deserialize)]
 struct SnapshotV1 {
@@ -213,62 +206,56 @@ fn load_snapshot(dir: &Utf8Path, creating: bool) -> Result<(Scene, u64)> {
         }
 
         // 2. Fallback: Try decoding with legacy unversioned format (V0)
-        match postcard::from_bytes::<SnapshotV0>(&bytes) {
-            Ok(snap) => return Ok((snap.scene, snap.epoch)),
-            Err(e) => {
-                // If decoding fails, try legacy format (without 'excluded' field in Page)
-                // This is needed because postcard is a positional format and adding a field
-                // breaks backward compatibility.
-                use koharu_core::{Node, NodeId, Page, PageId, ProjectMeta};
-                use indexmap::IndexMap;
+        // V0 represents the format before 'excluded' field was added and before versioning.
+        use koharu_core::{Node, NodeId, Page, PageId, ProjectMeta};
+        use indexmap::IndexMap;
 
-                #[derive(Deserialize)]
-                struct LegacyPage {
-                    id: PageId,
-                    name: String,
-                    width: u32,
-                    height: u32,
-                    nodes: IndexMap<NodeId, Node>,
-                }
-
-                #[derive(Deserialize)]
-                struct LegacyScene {
-                    project: ProjectMeta,
-                    pages: IndexMap<PageId, LegacyPage>,
-                }
-
-                #[derive(Deserialize)]
-                struct LegacySnapshot {
-                    epoch: u64,
-                    scene: LegacyScene,
-                }
-
-                if let Ok(legacy) = postcard::from_bytes::<LegacySnapshot>(&bytes) {
-                    let mut pages = IndexMap::new();
-                    for (id, lp) in legacy.scene.pages {
-                        pages.insert(
-                            id,
-                            Page {
-                                id: lp.id,
-                                name: lp.name,
-                                width: lp.width,
-                                height: lp.height,
-                                nodes: lp.nodes,
-                                excluded: false,
-                            },
-                        );
-                    }
-                    return Ok((
-                        Scene {
-                            project: legacy.scene.project,
-                            pages,
-                        },
-                        legacy.epoch,
-                    ));
-                }
-                return Err(e).with_context(|| format!("decode {}", scene_path));
-            }
+        #[derive(Deserialize)]
+        struct PageV0 {
+            id: PageId,
+            name: String,
+            width: u32,
+            height: u32,
+            nodes: IndexMap<NodeId, Node>,
         }
+
+        #[derive(Deserialize)]
+        struct SceneV0 {
+            project: ProjectMeta,
+            pages: IndexMap<PageId, PageV0>,
+        }
+
+        #[derive(Deserialize)]
+        struct SnapshotV0 {
+            epoch: u64,
+            scene: SceneV0,
+        }
+
+        if let Ok(v0) = postcard::from_bytes::<SnapshotV0>(&bytes) {
+            let mut pages = IndexMap::new();
+            for (id, lp) in v0.scene.pages {
+                pages.insert(
+                    id,
+                    Page {
+                        id: lp.id,
+                        name: lp.name,
+                        width: lp.width,
+                        height: lp.height,
+                        nodes: lp.nodes,
+                        excluded: false,
+                    },
+                );
+            }
+            return Ok((
+                Scene {
+                    project: v0.scene.project,
+                    pages,
+                },
+                v0.epoch,
+            ));
+        }
+        return Err(anyhow::anyhow!("decode failed for both V1 and V0 formats"))
+            .with_context(|| format!("decode {}", scene_path));
     }
 
     // No snapshot — build one from `project.toml` (or defaults for creation).

--- a/koharu-app/src/session.rs
+++ b/koharu-app/src/session.rs
@@ -187,9 +187,64 @@ fn load_snapshot(dir: &Utf8Path, creating: bool) -> Result<(Scene, u64)> {
     if scene_path.exists() {
         let bytes = std::fs::read(scene_path.as_std_path())
             .with_context(|| format!("read {}", scene_path))?;
-        let snap: Snapshot =
-            postcard::from_bytes(&bytes).with_context(|| format!("decode {}", scene_path))?;
-        return Ok((snap.scene, snap.epoch));
+
+        // Try decoding with current format
+        match postcard::from_bytes::<Snapshot>(&bytes) {
+            Ok(snap) => return Ok((snap.scene, snap.epoch)),
+            Err(e) => {
+                // If decoding fails, try legacy format (without 'excluded' field in Page)
+                // This is needed because postcard is a positional format and adding a field
+                // breaks backward compatibility.
+                use koharu_core::{Node, NodeId, Page, PageId, ProjectMeta};
+                use indexmap::IndexMap;
+
+                #[derive(Deserialize)]
+                struct LegacyPage {
+                    id: PageId,
+                    name: String,
+                    width: u32,
+                    height: u32,
+                    nodes: IndexMap<NodeId, Node>,
+                }
+
+                #[derive(Deserialize)]
+                struct LegacyScene {
+                    project: ProjectMeta,
+                    pages: IndexMap<PageId, LegacyPage>,
+                }
+
+                #[derive(Deserialize)]
+                struct LegacySnapshot {
+                    epoch: u64,
+                    scene: LegacyScene,
+                }
+
+                if let Ok(legacy) = postcard::from_bytes::<LegacySnapshot>(&bytes) {
+                    let mut pages = IndexMap::new();
+                    for (id, lp) in legacy.scene.pages {
+                        pages.insert(
+                            id,
+                            Page {
+                                id: lp.id,
+                                name: lp.name,
+                                width: lp.width,
+                                height: lp.height,
+                                nodes: lp.nodes,
+                                excluded: false,
+                            },
+                        );
+                    }
+                    return Ok((
+                        Scene {
+                            project: legacy.scene.project,
+                            pages,
+                        },
+                        legacy.epoch,
+                    ));
+                }
+                return Err(e).with_context(|| format!("decode {}", scene_path));
+            }
+        }
     }
 
     // No snapshot — build one from `project.toml` (or defaults for creation).

--- a/koharu-core/src/op.rs
+++ b/koharu-core/src/op.rs
@@ -153,6 +153,8 @@ pub struct PagePatch {
     pub width: Option<u32>,
     #[serde(default)]
     pub height: Option<u32>,
+    #[serde(default)]
+    pub excluded: Option<bool>,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema, ToSchema)]
@@ -311,6 +313,7 @@ impl Op {
                     name: patch.name.as_ref().map(|_| page.name.clone()),
                     width: patch.width.as_ref().map(|_| page.width),
                     height: patch.height.as_ref().map(|_| page.height),
+                    excluded: patch.excluded.map(|_| page.excluded),
                 };
                 if let Some(name) = &patch.name {
                     page.name = name.clone();
@@ -320,6 +323,9 @@ impl Op {
                 }
                 if let Some(h) = patch.height {
                     page.height = h;
+                }
+                if let Some(e) = patch.excluded {
+                    page.excluded = e;
                 }
             }
 

--- a/koharu-core/src/scene.rs
+++ b/koharu-core/src/scene.rs
@@ -153,11 +153,11 @@ pub struct Page {
     pub name: String,
     pub width: u32,
     pub height: u32,
-    #[serde(default)]
-    pub excluded: bool,
     /// Stacking = insertion order. Bottom-first: `source` is typically first,
     /// `rendered` typically last.
     pub nodes: IndexMap<NodeId, Node>,
+    #[serde(default)]
+    pub excluded: bool,
 }
 
 impl Page {

--- a/koharu-core/src/scene.rs
+++ b/koharu-core/src/scene.rs
@@ -153,6 +153,8 @@ pub struct Page {
     pub name: String,
     pub width: u32,
     pub height: u32,
+    #[serde(default)]
+    pub excluded: bool,
     /// Stacking = insertion order. Bottom-first: `source` is typically first,
     /// `rendered` typically last.
     pub nodes: IndexMap<NodeId, Node>,
@@ -165,6 +167,7 @@ impl Page {
             name: name.into(),
             width,
             height,
+            excluded: false,
             nodes: IndexMap::new(),
         }
     }

--- a/ui/components/MenuBar.tsx
+++ b/ui/components/MenuBar.tsx
@@ -91,7 +91,7 @@ export function MenuBar() {
     const prefs = usePreferencesStore.getState()
     await startPipeline({
       steps,
-      pages: opts.pageId ? [opts.pageId] : undefined,
+      pages: opts.pageId ? [opts.pageId] : (scene ? Object.values(scene.pages).filter(p => !p.excluded).map(p => p.id) : undefined),
       targetLanguage: editor.selectedLanguage,
       systemPrompt: prefs.customSystemPrompt,
       defaultFont: prefs.defaultFont,

--- a/ui/components/MenuBar.tsx
+++ b/ui/components/MenuBar.tsx
@@ -17,11 +17,13 @@ import {
   MenubarTrigger,
 } from '@/components/ui/menubar'
 import { useScene } from '@/hooks/useScene'
-import { getConfig, startPipeline } from '@/lib/api/default/default'
+import { getConfig, getGetSceneJsonQueryKey, startPipeline } from '@/lib/api/default/default'
+import type { SceneSnapshot } from '@/lib/api/schemas'
 import { isTauri, openExternalUrl } from '@/lib/backend'
 import { exportCurrentProjectAs, importPages } from '@/lib/io/pagesIo'
 import { closeProject, redoOp, selectAllTextNodesOnCurrentPage, undoOp } from '@/lib/io/scene'
 import { formatShortcutForDisplay, getPlatform } from '@/lib/shortcutUtils'
+import { queryClient } from '@/lib/queryClient'
 import { useEditorUiStore } from '@/lib/stores/editorUiStore'
 import { usePreferencesStore } from '@/lib/stores/preferencesStore'
 import { useSelectionStore } from '@/lib/stores/selectionStore'
@@ -91,7 +93,14 @@ export function MenuBar() {
     const prefs = usePreferencesStore.getState()
     await startPipeline({
       steps,
-      pages: opts.pageId ? [opts.pageId] : (scene ? Object.values(scene.pages).filter(p => !p.excluded).map(p => p.id) : undefined),
+      pages: opts.pageId
+        ? [opts.pageId]
+        : (() => {
+            const snap = queryClient.getQueryData<SceneSnapshot>(getGetSceneJsonQueryKey())
+            const pages = snap?.scene?.pages
+            if (!pages) return undefined
+            return Object.values(pages).filter(p => !p.excluded).map(p => p.id)
+          })(),
       targetLanguage: editor.selectedLanguage,
       systemPrompt: prefs.customSystemPrompt,
       defaultFont: prefs.defaultFont,

--- a/ui/components/Navigator.tsx
+++ b/ui/components/Navigator.tsx
@@ -10,7 +10,14 @@ import { Button } from '@/components/ui/button'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { useScene } from '@/hooks/useScene'
 import { getGetPageThumbnailUrl } from '@/lib/api/default/default'
+import { applyOp } from '@/lib/io/scene'
 import { useSelectionStore } from '@/lib/stores/selectionStore'
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+} from '@/components/ui/context-menu'
 
 const THUMBNAIL_DPR =
   typeof window !== 'undefined' ? Math.min(Math.ceil(window.devicePixelRatio || 1), 3) : 2
@@ -49,7 +56,13 @@ export function Navigator() {
             {t('navigator.title')}
           </p>
           <p className='text-xs font-semibold text-foreground'>
-            {totalPages ? t('navigator.pages', { count: totalPages }) : t('navigator.empty')}
+            {totalPages
+              ? (() => {
+                  const excluded = pages.filter((p) => p.excluded).length
+                  const countText = t('navigator.pages', { count: totalPages - excluded })
+                  return excluded > 0 ? `${countText} (${excluded} excluded)` : countText
+                })()
+              : t('navigator.empty')}
           </p>
         </div>
         {totalPages > 1 && (
@@ -94,7 +107,17 @@ export function Navigator() {
                   index={virtualRow.index}
                   pageId={page?.id}
                   selected={page?.id === pageId}
+                  excluded={page?.excluded ?? false}
                   onSelect={() => page && setPage(page.id)}
+                  onToggleExcluded={() =>
+                    page && applyOp({
+                      updatePage: {
+                        id: page.id,
+                        patch: { excluded: !(page.excluded ?? false) },
+                        prev: {}, // Handled by backend
+                      },
+                    })
+                  }
                 />
               </div>
             )
@@ -111,36 +134,50 @@ type PagePreviewProps = {
   index: number
   pageId?: string
   selected: boolean
+  excluded: boolean
   onSelect: () => void
+  onToggleExcluded: () => void
 }
 
-function PagePreview({ index, pageId, selected, onSelect }: PagePreviewProps) {
+function PagePreview({ index, pageId, selected, excluded, onSelect, onToggleExcluded }: PagePreviewProps) {
+  const { t } = useTranslation()
   const src = pageId ? `${getGetPageThumbnailUrl(pageId)}?size=${200 * THUMBNAIL_DPR}` : undefined
 
   return (
-    <Button
-      variant='ghost'
-      onClick={onSelect}
-      data-testid={`navigator-page-${index}`}
-      data-page-index={index}
-      data-selected={selected}
-      className='flex h-full w-full flex-col gap-0.5 rounded border border-transparent bg-card p-1.5 text-left shadow-sm data-[selected=true]:border-primary'
-    >
-      <div className='flex min-h-0 flex-1 items-center justify-center overflow-hidden rounded'>
-        {src ? (
-          <img
-            src={src}
-            alt={`Page ${index + 1}`}
-            loading='lazy'
-            className='max-h-full max-w-full rounded object-contain'
-          />
-        ) : (
-          <div className='h-full w-full rounded bg-muted' />
-        )}
-      </div>
-      <div className='flex shrink-0 items-center text-xs text-muted-foreground'>
-        <div className='mx-auto font-semibold text-foreground'>{index + 1}</div>
-      </div>
-    </Button>
+    <ContextMenu>
+      <ContextMenuTrigger asChild>
+        <Button
+          variant='ghost'
+          onClick={onSelect}
+          data-testid={`navigator-page-${index}`}
+          data-page-index={index}
+          data-selected={selected}
+          className='flex h-full w-full flex-col gap-0.5 rounded border border-transparent bg-card p-1.5 text-left shadow-sm data-[selected=true]:border-primary'
+        >
+          <div className='flex min-h-0 flex-1 items-center justify-center overflow-hidden rounded'>
+            {src ? (
+              <img
+                src={src}
+                alt={`Page ${index + 1}`}
+                loading='lazy'
+                className={`max-h-full max-w-full rounded object-contain ${excluded ? 'opacity-30' : ''}`}
+              />
+            ) : (
+              <div className={`h-full w-full rounded bg-muted ${excluded ? 'opacity-30' : ''}`} />
+            )}
+          </div>
+          <div className='flex shrink-0 items-center text-xs text-muted-foreground'>
+            <div className='mx-auto font-semibold text-foreground'>
+              {index + 1} {excluded && <span className="ml-1 text-[10px] text-destructive uppercase">(Excluded)</span>}
+            </div>
+          </div>
+        </Button>
+      </ContextMenuTrigger>
+      <ContextMenuContent>
+        <ContextMenuItem onSelect={onToggleExcluded}>
+          {excluded ? 'Include in Batch' : 'Exclude from Batch'}
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
   )
 }

--- a/ui/lib/api/schemas/page.ts
+++ b/ui/lib/api/schemas/page.ts
@@ -7,6 +7,9 @@ import type { PageId } from './pageId'
 import type { PageNodes } from './pageNodes'
 
 export interface Page {
+  /** When true, this page is excluded from batch processing operations.
+   * @default false */
+  excluded?: boolean
   /** @minimum 0 */
   height: number
   id: PageId

--- a/ui/lib/api/schemas/pagePatch.ts
+++ b/ui/lib/api/schemas/pagePatch.ts
@@ -5,6 +5,8 @@
  */
 
 export interface PagePatch {
+  /** @nullable */
+  excluded?: boolean | null
   /**
    * @minimum 0
    * @nullable

--- a/ui/openapi.json
+++ b/ui/openapi.json
@@ -2412,6 +2412,11 @@
         "type": "object",
         "required": ["id", "name", "width", "height", "nodes"],
         "properties": {
+          "excluded": {
+            "type": "boolean",
+            "default": false,
+            "description": "When true, this page is excluded from batch processing operations."
+          },
           "height": {
             "type": "integer",
             "format": "int32",
@@ -2448,6 +2453,9 @@
       "PagePatch": {
         "type": "object",
         "properties": {
+          "excluded": {
+            "type": ["boolean", "null"]
+          },
           "height": {
             "type": ["integer", "null"],
             "format": "int32",


### PR DESCRIPTION
## Summary
Introduces a mechanism to exclude specific pages from the processing pipeline.

## Key Changes
- Added 'excluded' boolean field to ScenePage.
- Updated Page Manager UI with checkboxes.
- Modified backend pipeline driver to filter out excluded pages.
- Added localization support (zh-TW, en-US).