### PR TITLE
feat(io): translation data import/export via XML

### DIFF
--- a/koharu-app/src/lib.rs
+++ b/koharu-app/src/lib.rs
@@ -17,6 +17,7 @@ pub mod pipeline;
 pub mod projects;
 pub mod renderer;
 pub mod session;
+pub mod translation_xml;
 pub mod utils;
 
 pub use ai::AiManager;

--- a/koharu-app/src/translation_xml.rs
+++ b/koharu-app/src/translation_xml.rs
@@ -1,26 +1,30 @@
 use anyhow::Result;
-use koharu_core::{NodeId, PageId};
-use std::str::FromStr;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TranslationXmlEntry {
-    pub page: PageId,
-    pub node: NodeId,
+    pub page_id: Option<String>,
+    pub node_id: Option<String>,
+    pub id: Option<usize>, // Legacy index-based ID
     pub text: String,
 }
 
-pub fn export_translation_xml(texts: &[(PageId, NodeId, String)]) -> String {
-    let mut out = String::from("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
-    out.push_str("<koharu-translations version=\"1.0\">\n");
-    for (page, node, text) in texts.iter() {
+pub struct TranslationXmlExportItem {
+    pub page_id: String,
+    pub node_id: String,
+    pub text: String,
+}
+
+pub fn export_translation_xml(items: &[TranslationXmlExportItem]) -> String {
+    let mut out = String::from("<translations version=\"1.0\">\n");
+    for item in items {
         out.push_str(&format!(
-            "  <p page=\"{}\" node=\"{}\">{}</p>\n",
-            page,
-            node,
-            escape_xml(text)
+            "  <entry page=\"{}\" node=\"{}\">{}</entry>\n",
+            item.page_id,
+            item.node_id,
+            escape_xml(&item.text)
         ));
     }
-    out.push_str("</koharu-translations>\n");
+    out.push_str("</translations>\n");
     out
 }
 
@@ -28,9 +32,39 @@ pub fn parse_translation_xml(xml: &str) -> Result<Vec<TranslationXmlEntry>> {
     let mut entries = Vec::new();
     let mut cursor = 0;
 
-    // If the file does not have the root tag, we could reject it or just skip.
-    // Given the request to break backwards compatibility if needed, we proceed by parsing `page` and `node`.
+    // Try V1 format first (<entry page="..." node="...">)
+    while let Some(open_rel) = xml[cursor..].find("<entry") {
+        let open = cursor + open_rel;
+        let tag_end = xml[open..]
+            .find('>')
+            .map(|offset| open + offset)
+            .ok_or_else(|| anyhow::anyhow!("unterminated <entry> tag"))?;
+        let tag = &xml[open..=tag_end];
+        
+        let page_id = parse_attr(tag, "page").ok();
+        let node_id = parse_attr(tag, "node").ok();
+        
+        let content_start = tag_end + 1;
+        let content_end = xml[content_start..]
+            .find("</entry>")
+            .map(|offset| content_start + offset)
+            .ok_or_else(|| anyhow::anyhow!("missing </entry> tag"))?;
 
+        entries.push(TranslationXmlEntry {
+            page_id,
+            node_id,
+            id: None,
+            text: unescape_xml(&xml[content_start..content_end])?,
+        });
+        cursor = content_end + "</entry>".len();
+    }
+
+    if !entries.is_empty() {
+        return Ok(entries);
+    }
+
+    // Fallback to V0 legacy format (<p id="...">)
+    cursor = 0;
     while let Some(open_rel) = xml[cursor..].find("<p") {
         let open = cursor + open_rel;
         let tag_end = xml[open..]
@@ -38,19 +72,17 @@ pub fn parse_translation_xml(xml: &str) -> Result<Vec<TranslationXmlEntry>> {
             .map(|offset| open + offset)
             .ok_or_else(|| anyhow::anyhow!("unterminated <p> tag"))?;
         let tag = &xml[open..=tag_end];
-        
-        let page = parse_uuid_attr(tag, "page")?;
-        let node = parse_uuid_attr(tag, "node")?;
-
+        let id = parse_attr(tag, "id")?.parse::<usize>().ok();
         let content_start = tag_end + 1;
         let content_end = xml[content_start..]
             .find("</p>")
             .map(|offset| content_start + offset)
-            .ok_or_else(|| anyhow::anyhow!("missing </p> tag for node {node}"))?;
+            .ok_or_else(|| anyhow::anyhow!("missing </p> tag"))?;
 
         entries.push(TranslationXmlEntry {
-            page: PageId(page),
-            node: NodeId(node),
+            page_id: None,
+            node_id: None,
+            id,
             text: unescape_xml(&xml[content_start..content_end])?,
         });
         cursor = content_end + "</p>".len();
@@ -59,19 +91,19 @@ pub fn parse_translation_xml(xml: &str) -> Result<Vec<TranslationXmlEntry>> {
     Ok(entries)
 }
 
-fn parse_uuid_attr(tag: &str, attr: &str) -> Result<uuid::Uuid> {
-    let prefix = format!("{attr}=\"");
-    let attr_start = tag
-        .find(&prefix)
-        .map(|offset| offset + prefix.len())
-        .ok_or_else(|| anyhow::anyhow!("translation paragraph missing {attr}"))?;
-    let attr_end = tag[attr_start..]
+fn parse_attr(tag: &str, name: &str) -> Result<String> {
+    let key = format!("{}=\"", name);
+    let start = tag
+        .find(&key)
+        .map(|offset| offset + key.len())
+        .ok_or_else(|| anyhow::anyhow!("attribute {} missing in tag", name))?;
+    let end = tag[start..]
         .find('"')
-        .map(|offset| attr_start + offset)
-        .ok_or_else(|| anyhow::anyhow!("unterminated {attr} attribute"))?;
-    let val = &tag[attr_start..attr_end];
-    uuid::Uuid::from_str(val).map_err(|_| anyhow::anyhow!("invalid uuid for {attr}: {val}"))
+        .map(|offset| start + offset)
+        .ok_or_else(|| anyhow::anyhow!("unterminated attribute {}", name))?;
+    Ok(tag[start..end].to_string())
 }
+
 
 fn escape_xml(text: &str) -> String {
     text.chars()
@@ -124,47 +156,65 @@ mod tests {
 
     #[test]
     fn export_escapes_translation_text() {
-        let page = PageId::from(uuid::Uuid::from_str("00000000-0000-0000-0000-000000000001").unwrap());
-        let node1 = NodeId::from(uuid::Uuid::from_str("00000000-0000-0000-0000-000000000002").unwrap());
-        let node2 = NodeId::from(uuid::Uuid::from_str("00000000-0000-0000-0000-000000000003").unwrap());
-        
         let xml = export_translation_xml(&[
-            (page, node1, "A&B".to_string()), 
-            (page, node2, "<hello>".to_string())
+            TranslationXmlExportItem {
+                page_id: "p1".into(),
+                node_id: "n1".into(),
+                text: "A&B".into(),
+            },
+            TranslationXmlExportItem {
+                page_id: "p1".into(),
+                node_id: "n2".into(),
+                text: "<hello>".into(),
+            },
         ]);
 
-        assert_eq!(
-            xml,
-            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<koharu-translations version=\"1.0\">\n  <p page=\"00000000-0000-0000-0000-000000000001\" node=\"00000000-0000-0000-0000-000000000002\">A&amp;B</p>\n  <p page=\"00000000-0000-0000-0000-000000000001\" node=\"00000000-0000-0000-0000-000000000003\">&lt;hello&gt;</p>\n</koharu-translations>\n"
-        );
+        assert!(xml.contains("version=\"1.0\""));
+        assert!(xml.contains("<entry page=\"p1\" node=\"n1\">A&amp;B</entry>"));
+        assert!(xml.contains("<entry page=\"p1\" node=\"n2\">&lt;hello&gt;</entry>"));
     }
 
     #[test]
-    fn import_parses_unescaped_text_by_id() -> Result<()> {
-        let page = PageId::from(uuid::Uuid::from_str("00000000-0000-0000-0000-000000000001").unwrap());
-        let node1 = NodeId::from(uuid::Uuid::from_str("00000000-0000-0000-0000-000000000002").unwrap());
-        let node2 = NodeId::from(uuid::Uuid::from_str("00000000-0000-0000-0000-000000000003").unwrap());
-
+    fn import_parses_unescaped_text_by_uuids() -> Result<()> {
         let parsed = parse_translation_xml(
-            "<koharu-translations version=\"1.0\">\n  <p page=\"00000000-0000-0000-0000-000000000001\" node=\"00000000-0000-0000-0000-000000000003\">&lt;world&gt;</p>\n  <p page=\"00000000-0000-0000-0000-000000000001\" node=\"00000000-0000-0000-0000-000000000002\">A&amp;B</p>\n</koharu-translations>",
+            "<translations><entry page=\"p1\" node=\"n1\">&lt;world&gt;</entry></translations>",
+        )?;
+
+        assert_eq!(
+            parsed,
+            vec![TranslationXmlEntry {
+                page_id: Some("p1".into()),
+                node_id: Some("n1".into()),
+                id: None,
+                text: "<world>".into(),
+            },]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn import_parses_legacy_v0_format() -> Result<()> {
+        let parsed = parse_translation_xml(
+            "<translations><p id=\"2\">&lt;world&gt;</p><p id=\"1\">A&amp;B</p></translations>",
         )?;
 
         assert_eq!(
             parsed,
             vec![
                 TranslationXmlEntry {
-                    page,
-                    node: node2,
-                    text: "<world>".to_string(),
+                    page_id: None,
+                    node_id: None,
+                    id: Some(2),
+                    text: "<world>".into(),
                 },
                 TranslationXmlEntry {
-                    page,
-                    node: node1,
-                    text: "A&B".to_string(),
+                    page_id: None,
+                    node_id: None,
+                    id: Some(1),
+                    text: "A&B".into(),
                 },
             ]
         );
         Ok(())
     }
 }
-

--- a/koharu-app/src/translation_xml.rs
+++ b/koharu-app/src/translation_xml.rs
@@ -1,0 +1,148 @@
+use anyhow::Result;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TranslationXmlEntry {
+    pub id: usize,
+    pub text: String,
+}
+
+pub fn export_translation_xml(texts: &[String]) -> String {
+    let mut out = String::from("<translations>\n");
+    for (index, text) in texts.iter().enumerate() {
+        out.push_str(&format!(
+            "  <p id=\"{}\">{}</p>\n",
+            index + 1,
+            escape_xml(text)
+        ));
+    }
+    out.push_str("</translations>\n");
+    out
+}
+
+pub fn parse_translation_xml(xml: &str) -> Result<Vec<TranslationXmlEntry>> {
+    let mut entries = Vec::new();
+    let mut cursor = 0;
+
+    while let Some(open_rel) = xml[cursor..].find("<p") {
+        let open = cursor + open_rel;
+        let tag_end = xml[open..]
+            .find('>')
+            .map(|offset| open + offset)
+            .ok_or_else(|| anyhow::anyhow!("unterminated <p> tag"))?;
+        let tag = &xml[open..=tag_end];
+        let id = parse_id_attr(tag)?;
+        let content_start = tag_end + 1;
+        let content_end = xml[content_start..]
+            .find("</p>")
+            .map(|offset| content_start + offset)
+            .ok_or_else(|| anyhow::anyhow!("missing </p> tag for id {id}"))?;
+
+        entries.push(TranslationXmlEntry {
+            id,
+            text: unescape_xml(&xml[content_start..content_end])?,
+        });
+        cursor = content_end + "</p>".len();
+    }
+
+    Ok(entries)
+}
+
+fn parse_id_attr(tag: &str) -> Result<usize> {
+    let id_start = tag
+        .find("id=\"")
+        .map(|offset| offset + "id=\"".len())
+        .ok_or_else(|| anyhow::anyhow!("translation paragraph missing id"))?;
+    let id_end = tag[id_start..]
+        .find('"')
+        .map(|offset| id_start + offset)
+        .ok_or_else(|| anyhow::anyhow!("unterminated id attribute"))?;
+    let id = tag[id_start..id_end]
+        .parse::<usize>()
+        .map_err(|_| anyhow::anyhow!("invalid translation id"))?;
+    if id == 0 {
+        anyhow::bail!("translation id must be >= 1");
+    }
+    Ok(id)
+}
+
+fn escape_xml(text: &str) -> String {
+    text.chars()
+        .flat_map(|ch| match ch {
+            '&' => "&amp;".chars().collect::<Vec<_>>(),
+            '<' => "&lt;".chars().collect::<Vec<_>>(),
+            '>' => "&gt;".chars().collect::<Vec<_>>(),
+            '"' => "&quot;".chars().collect::<Vec<_>>(),
+            '\'' => "&apos;".chars().collect::<Vec<_>>(),
+            _ => vec![ch],
+        })
+        .collect()
+}
+
+fn unescape_xml(text: &str) -> Result<String> {
+    let mut out = String::with_capacity(text.len());
+    let mut cursor = 0;
+    while cursor < text.len() {
+        let remaining = &text[cursor..];
+        if let Some(stripped) = remaining.strip_prefix('&') {
+            let Some(end) = stripped.find(';') else {
+                anyhow::bail!("unterminated XML entity");
+            };
+            let entity = &stripped[..end];
+            let decoded = match entity {
+                "amp" => '&',
+                "lt" => '<',
+                "gt" => '>',
+                "quot" => '"',
+                "apos" => '\'',
+                _ => anyhow::bail!("unsupported XML entity: &{entity};"),
+            };
+            out.push(decoded);
+            cursor += entity.len() + 2;
+        } else {
+            let ch = remaining
+                .chars()
+                .next()
+                .expect("cursor is always inside text");
+            out.push(ch);
+            cursor += ch.len_utf8();
+        }
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn export_escapes_translation_text() {
+        let xml = export_translation_xml(&["A&B".to_string(), "<hello>".to_string()]);
+
+        assert_eq!(
+            xml,
+            "<translations>\n  <p id=\"1\">A&amp;B</p>\n  <p id=\"2\">&lt;hello&gt;</p>\n</translations>\n"
+        );
+    }
+
+    #[test]
+    fn import_parses_unescaped_text_by_id() -> Result<()> {
+        let parsed = parse_translation_xml(
+            "<translations><p id=\"2\">&lt;world&gt;</p><p id=\"1\">A&amp;B</p></translations>",
+        )?;
+
+        assert_eq!(
+            parsed,
+            vec![
+                TranslationXmlEntry {
+                    id: 2,
+                    text: "<world>".to_string(),
+                },
+                TranslationXmlEntry {
+                    id: 1,
+                    text: "A&B".to_string(),
+                },
+            ]
+        );
+        Ok(())
+    }
+}

--- a/koharu-app/src/translation_xml.rs
+++ b/koharu-app/src/translation_xml.rs
@@ -1,27 +1,35 @@
 use anyhow::Result;
+use koharu_core::{NodeId, PageId};
+use std::str::FromStr;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TranslationXmlEntry {
-    pub id: usize,
+    pub page: PageId,
+    pub node: NodeId,
     pub text: String,
 }
 
-pub fn export_translation_xml(texts: &[String]) -> String {
-    let mut out = String::from("<translations>\n");
-    for (index, text) in texts.iter().enumerate() {
+pub fn export_translation_xml(texts: &[(PageId, NodeId, String)]) -> String {
+    let mut out = String::from("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+    out.push_str("<koharu-translations version=\"1.0\">\n");
+    for (page, node, text) in texts.iter() {
         out.push_str(&format!(
-            "  <p id=\"{}\">{}</p>\n",
-            index + 1,
+            "  <p page=\"{}\" node=\"{}\">{}</p>\n",
+            page,
+            node,
             escape_xml(text)
         ));
     }
-    out.push_str("</translations>\n");
+    out.push_str("</koharu-translations>\n");
     out
 }
 
 pub fn parse_translation_xml(xml: &str) -> Result<Vec<TranslationXmlEntry>> {
     let mut entries = Vec::new();
     let mut cursor = 0;
+
+    // If the file does not have the root tag, we could reject it or just skip.
+    // Given the request to break backwards compatibility if needed, we proceed by parsing `page` and `node`.
 
     while let Some(open_rel) = xml[cursor..].find("<p") {
         let open = cursor + open_rel;
@@ -30,15 +38,19 @@ pub fn parse_translation_xml(xml: &str) -> Result<Vec<TranslationXmlEntry>> {
             .map(|offset| open + offset)
             .ok_or_else(|| anyhow::anyhow!("unterminated <p> tag"))?;
         let tag = &xml[open..=tag_end];
-        let id = parse_id_attr(tag)?;
+        
+        let page = parse_uuid_attr(tag, "page")?;
+        let node = parse_uuid_attr(tag, "node")?;
+
         let content_start = tag_end + 1;
         let content_end = xml[content_start..]
             .find("</p>")
             .map(|offset| content_start + offset)
-            .ok_or_else(|| anyhow::anyhow!("missing </p> tag for id {id}"))?;
+            .ok_or_else(|| anyhow::anyhow!("missing </p> tag for node {node}"))?;
 
         entries.push(TranslationXmlEntry {
-            id,
+            page: PageId(page),
+            node: NodeId(node),
             text: unescape_xml(&xml[content_start..content_end])?,
         });
         cursor = content_end + "</p>".len();
@@ -47,22 +59,18 @@ pub fn parse_translation_xml(xml: &str) -> Result<Vec<TranslationXmlEntry>> {
     Ok(entries)
 }
 
-fn parse_id_attr(tag: &str) -> Result<usize> {
-    let id_start = tag
-        .find("id=\"")
-        .map(|offset| offset + "id=\"".len())
-        .ok_or_else(|| anyhow::anyhow!("translation paragraph missing id"))?;
-    let id_end = tag[id_start..]
+fn parse_uuid_attr(tag: &str, attr: &str) -> Result<uuid::Uuid> {
+    let prefix = format!("{attr}=\"");
+    let attr_start = tag
+        .find(&prefix)
+        .map(|offset| offset + prefix.len())
+        .ok_or_else(|| anyhow::anyhow!("translation paragraph missing {attr}"))?;
+    let attr_end = tag[attr_start..]
         .find('"')
-        .map(|offset| id_start + offset)
-        .ok_or_else(|| anyhow::anyhow!("unterminated id attribute"))?;
-    let id = tag[id_start..id_end]
-        .parse::<usize>()
-        .map_err(|_| anyhow::anyhow!("invalid translation id"))?;
-    if id == 0 {
-        anyhow::bail!("translation id must be >= 1");
-    }
-    Ok(id)
+        .map(|offset| attr_start + offset)
+        .ok_or_else(|| anyhow::anyhow!("unterminated {attr} attribute"))?;
+    let val = &tag[attr_start..attr_end];
+    uuid::Uuid::from_str(val).map_err(|_| anyhow::anyhow!("invalid uuid for {attr}: {val}"))
 }
 
 fn escape_xml(text: &str) -> String {
@@ -116,29 +124,42 @@ mod tests {
 
     #[test]
     fn export_escapes_translation_text() {
-        let xml = export_translation_xml(&["A&B".to_string(), "<hello>".to_string()]);
+        let page = PageId::from(uuid::Uuid::from_str("00000000-0000-0000-0000-000000000001").unwrap());
+        let node1 = NodeId::from(uuid::Uuid::from_str("00000000-0000-0000-0000-000000000002").unwrap());
+        let node2 = NodeId::from(uuid::Uuid::from_str("00000000-0000-0000-0000-000000000003").unwrap());
+        
+        let xml = export_translation_xml(&[
+            (page, node1, "A&B".to_string()), 
+            (page, node2, "<hello>".to_string())
+        ]);
 
         assert_eq!(
             xml,
-            "<translations>\n  <p id=\"1\">A&amp;B</p>\n  <p id=\"2\">&lt;hello&gt;</p>\n</translations>\n"
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<koharu-translations version=\"1.0\">\n  <p page=\"00000000-0000-0000-0000-000000000001\" node=\"00000000-0000-0000-0000-000000000002\">A&amp;B</p>\n  <p page=\"00000000-0000-0000-0000-000000000001\" node=\"00000000-0000-0000-0000-000000000003\">&lt;hello&gt;</p>\n</koharu-translations>\n"
         );
     }
 
     #[test]
     fn import_parses_unescaped_text_by_id() -> Result<()> {
+        let page = PageId::from(uuid::Uuid::from_str("00000000-0000-0000-0000-000000000001").unwrap());
+        let node1 = NodeId::from(uuid::Uuid::from_str("00000000-0000-0000-0000-000000000002").unwrap());
+        let node2 = NodeId::from(uuid::Uuid::from_str("00000000-0000-0000-0000-000000000003").unwrap());
+
         let parsed = parse_translation_xml(
-            "<translations><p id=\"2\">&lt;world&gt;</p><p id=\"1\">A&amp;B</p></translations>",
+            "<koharu-translations version=\"1.0\">\n  <p page=\"00000000-0000-0000-0000-000000000001\" node=\"00000000-0000-0000-0000-000000000003\">&lt;world&gt;</p>\n  <p page=\"00000000-0000-0000-0000-000000000001\" node=\"00000000-0000-0000-0000-000000000002\">A&amp;B</p>\n</koharu-translations>",
         )?;
 
         assert_eq!(
             parsed,
             vec![
                 TranslationXmlEntry {
-                    id: 2,
+                    page,
+                    node: node2,
                     text: "<world>".to_string(),
                 },
                 TranslationXmlEntry {
-                    id: 1,
+                    page,
+                    node: node1,
                     text: "A&B".to_string(),
                 },
             ]
@@ -146,3 +167,4 @@ mod tests {
         Ok(())
     }
 }
+

--- a/koharu-rpc/src/api.rs
+++ b/koharu-rpc/src/api.rs
@@ -39,6 +39,7 @@ fn app_api() -> OpenApiRouter<ApiState> {
         .merge(routes::llm::router())
         .merge(routes::ai::router())
         .merge(routes::pipelines::router())
+        .merge(routes::translation_xml::router())
         .merge(binary::router())
 }
 

--- a/koharu-rpc/src/routes/mod.rs
+++ b/koharu-rpc/src/routes/mod.rs
@@ -13,3 +13,4 @@ pub mod operations;
 pub mod pages;
 pub mod pipelines;
 pub mod projects;
+pub mod translation_xml;

--- a/koharu-rpc/src/routes/translation_xml.rs
+++ b/koharu-rpc/src/routes/translation_xml.rs
@@ -1,0 +1,150 @@
+//! Translation XML import/export routes.
+
+use axum::Json;
+use axum::body::Body;
+use axum::extract::State;
+use axum::http::{HeaderValue, header};
+use axum::response::{IntoResponse, Response};
+use koharu_app::translation_xml::{export_translation_xml, parse_translation_xml};
+use koharu_core::{NodeDataPatch, NodeId, NodeKind, NodePatch, Op, PageId, TextDataPatch};
+use serde::{Deserialize, Serialize};
+use utoipa_axum::{router::OpenApiRouter, routes};
+
+use crate::AppState;
+use crate::error::{ApiError, ApiResult};
+
+pub fn router() -> OpenApiRouter<AppState> {
+    OpenApiRouter::default()
+        .routes(routes!(export_translation_xml_route))
+        .routes(routes!(import_translation_xml_route))
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ImportTranslationXmlRequest {
+    pub xml: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ImportTranslationXmlResponse {
+    pub updated: usize,
+}
+
+#[utoipa::path(
+    get,
+    path = "/translations/xml",
+    responses((status = 200, content_type = "application/xml"))
+)]
+async fn export_translation_xml_route(State(app): State<AppState>) -> ApiResult<Response> {
+    let session = app
+        .current_session()
+        .ok_or_else(|| ApiError::bad_request("no project open"))?;
+    let scene = session.scene.read();
+    let translations = scene
+        .pages
+        .values()
+        .flat_map(|page| {
+            page.nodes.values().filter_map(|node| match &node.kind {
+                NodeKind::Text(text) => Some(text.translation.clone().unwrap_or_default()),
+                _ => None,
+            })
+        })
+        .collect::<Vec<_>>();
+    let project_name = sanitize_filename(&scene.project.name);
+    let xml = export_translation_xml(&translations);
+    Ok(xml_response(
+        xml,
+        &format!("{project_name}-translations.xml"),
+    ))
+}
+
+#[utoipa::path(
+    post,
+    path = "/translations/xml",
+    request_body = ImportTranslationXmlRequest,
+    responses((status = 200, body = ImportTranslationXmlResponse))
+)]
+async fn import_translation_xml_route(
+    State(app): State<AppState>,
+    Json(req): Json<ImportTranslationXmlRequest>,
+) -> ApiResult<Json<ImportTranslationXmlResponse>> {
+    let session = app
+        .current_session()
+        .ok_or_else(|| ApiError::bad_request("no project open"))?;
+    let parsed =
+        parse_translation_xml(&req.xml).map_err(|e| ApiError::bad_request(format!("{e:#}")))?;
+    let targets = translation_targets(&session);
+    let mut ops = Vec::with_capacity(parsed.len());
+
+    for entry in parsed {
+        let Some((page, node)) = targets.get(entry.id - 1).copied() else {
+            return Err(ApiError::bad_request(format!(
+                "translation id {} is out of range",
+                entry.id
+            )));
+        };
+        ops.push(Op::UpdateNode {
+            page,
+            id: node,
+            patch: NodePatch {
+                data: Some(NodeDataPatch::Text(TextDataPatch {
+                    translation: Some(Some(entry.text)),
+                    ..Default::default()
+                })),
+                transform: None,
+                visible: None,
+            },
+            prev: NodePatch::default(),
+        });
+    }
+
+    let updated = ops.len();
+    if !ops.is_empty() {
+        app.apply(Op::Batch {
+            ops,
+            label: "Import translation XML".into(),
+        })
+        .map_err(ApiError::internal)?;
+    }
+
+    Ok(Json(ImportTranslationXmlResponse { updated }))
+}
+
+fn translation_targets(session: &koharu_app::ProjectSession) -> Vec<(PageId, NodeId)> {
+    let scene = session.scene.read();
+    scene
+        .pages
+        .iter()
+        .flat_map(|(page_id, page)| {
+            page.nodes.iter().filter_map(|(node_id, node)| {
+                matches!(node.kind, NodeKind::Text(_)).then_some((*page_id, *node_id))
+            })
+        })
+        .collect()
+}
+
+fn xml_response(xml: String, filename: &str) -> Response {
+    let mut response = Response::new(Body::from(xml));
+    let headers = response.headers_mut();
+    headers.insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static("application/xml; charset=utf-8"),
+    );
+    if let Ok(value) = HeaderValue::from_str(&format!("attachment; filename=\"{filename}\"")) {
+        headers.insert(header::CONTENT_DISPOSITION, value);
+    }
+    response.into_response()
+}
+
+fn sanitize_filename(name: &str) -> String {
+    let out = name
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_'))
+        .collect::<String>();
+    if out.is_empty() {
+        "project".to_string()
+    } else {
+        out
+    }
+}

--- a/koharu-rpc/src/routes/translation_xml.rs
+++ b/koharu-rpc/src/routes/translation_xml.rs
@@ -43,10 +43,10 @@ async fn export_translation_xml_route(State(app): State<AppState>) -> ApiResult<
     let scene = session.scene.read();
     let translations = scene
         .pages
-        .values()
-        .flat_map(|page| {
-            page.nodes.values().filter_map(|node| match &node.kind {
-                NodeKind::Text(text) => Some(text.translation.clone().unwrap_or_default()),
+        .iter()
+        .flat_map(|(page_id, page)| {
+            page.nodes.iter().filter_map(|(node_id, node)| match &node.kind {
+                NodeKind::Text(text) => Some((*page_id, *node_id, text.translation.clone().unwrap_or_default())),
                 _ => None,
             })
         })
@@ -74,19 +74,27 @@ async fn import_translation_xml_route(
         .ok_or_else(|| ApiError::bad_request("no project open"))?;
     let parsed =
         parse_translation_xml(&req.xml).map_err(|e| ApiError::bad_request(format!("{e:#}")))?;
-    let targets = translation_targets(&session);
+    
+    let scene = session.scene.read();
     let mut ops = Vec::with_capacity(parsed.len());
 
     for entry in parsed {
-        let Some((page, node)) = targets.get(entry.id - 1).copied() else {
+        let Some(page) = scene.page(entry.page) else {
             return Err(ApiError::bad_request(format!(
-                "translation id {} is out of range",
-                entry.id
+                "translation references missing page {}",
+                entry.page
             )));
         };
+        if !page.nodes.contains_key(&entry.node) {
+            return Err(ApiError::bad_request(format!(
+                "translation references missing node {}",
+                entry.node
+            )));
+        }
+        
         ops.push(Op::UpdateNode {
-            page,
-            id: node,
+            page: entry.page,
+            id: entry.node,
             patch: NodePatch {
                 data: Some(NodeDataPatch::Text(TextDataPatch {
                     translation: Some(Some(entry.text)),
@@ -99,6 +107,9 @@ async fn import_translation_xml_route(
         });
     }
 
+    // drop the lock before applying the batch
+    drop(scene);
+
     let updated = ops.len();
     if !ops.is_empty() {
         app.apply(Op::Batch {
@@ -109,19 +120,6 @@ async fn import_translation_xml_route(
     }
 
     Ok(Json(ImportTranslationXmlResponse { updated }))
-}
-
-fn translation_targets(session: &koharu_app::ProjectSession) -> Vec<(PageId, NodeId)> {
-    let scene = session.scene.read();
-    scene
-        .pages
-        .iter()
-        .flat_map(|(page_id, page)| {
-            page.nodes.iter().filter_map(|(node_id, node)| {
-                matches!(node.kind, NodeKind::Text(_)).then_some((*page_id, *node_id))
-            })
-        })
-        .collect()
 }
 
 fn xml_response(xml: String, filename: &str) -> Response {

--- a/koharu-rpc/src/routes/translation_xml.rs
+++ b/koharu-rpc/src/routes/translation_xml.rs
@@ -5,10 +5,13 @@ use axum::body::Body;
 use axum::extract::State;
 use axum::http::{HeaderValue, header};
 use axum::response::{IntoResponse, Response};
-use koharu_app::translation_xml::{export_translation_xml, parse_translation_xml};
+use koharu_app::translation_xml::{
+    TranslationXmlExportItem, export_translation_xml, parse_translation_xml,
+};
 use koharu_core::{NodeDataPatch, NodeId, NodeKind, NodePatch, Op, PageId, TextDataPatch};
 use serde::{Deserialize, Serialize};
 use utoipa_axum::{router::OpenApiRouter, routes};
+use uuid::Uuid;
 
 use crate::AppState;
 use crate::error::{ApiError, ApiResult};
@@ -41,18 +44,23 @@ async fn export_translation_xml_route(State(app): State<AppState>) -> ApiResult<
         .current_session()
         .ok_or_else(|| ApiError::bad_request("no project open"))?;
     let scene = session.scene.read();
-    let translations = scene
+    let items = scene
         .pages
         .iter()
         .flat_map(|(page_id, page)| {
             page.nodes.iter().filter_map(|(node_id, node)| match &node.kind {
-                NodeKind::Text(text) => Some((*page_id, *node_id, text.translation.clone().unwrap_or_default())),
+                NodeKind::Text(text) => Some(TranslationXmlExportItem {
+                    page_id: page_id.to_string(),
+                    node_id: node_id.to_string(),
+                    text: text.translation.clone().unwrap_or_default(),
+                }),
                 _ => None,
             })
         })
         .collect::<Vec<_>>();
+
     let project_name = sanitize_filename(&scene.project.name);
-    let xml = export_translation_xml(&translations);
+    let xml = export_translation_xml(&items);
     Ok(xml_response(
         xml,
         &format!("{project_name}-translations.xml"),
@@ -74,27 +82,31 @@ async fn import_translation_xml_route(
         .ok_or_else(|| ApiError::bad_request("no project open"))?;
     let parsed =
         parse_translation_xml(&req.xml).map_err(|e| ApiError::bad_request(format!("{e:#}")))?;
-    
-    let scene = session.scene.read();
+    let targets = translation_targets(&session);
     let mut ops = Vec::with_capacity(parsed.len());
 
     for entry in parsed {
-        let Some(page) = scene.page(entry.page) else {
-            return Err(ApiError::bad_request(format!(
-                "translation references missing page {}",
-                entry.page
-            )));
+        let (page, node) = if let (Some(pid_str), Some(nid_str)) = (entry.page_id, entry.node_id) {
+            let pid = pid_str
+                .parse::<Uuid>()
+                .map(PageId)
+                .map_err(|_| ApiError::bad_request(format!("invalid page uuid: {pid_str}")))?;
+            let nid = nid_str
+                .parse::<Uuid>()
+                .map(NodeId)
+                .map_err(|_| ApiError::bad_request(format!("invalid node uuid: {nid_str}")))?;
+            (pid, nid)
+        } else if let Some(id) = entry.id {
+            *targets.get(id - 1).ok_or_else(|| {
+                ApiError::bad_request(format!("legacy translation id {} is out of range", id))
+            })?
+        } else {
+            continue;
         };
-        if !page.nodes.contains_key(&entry.node) {
-            return Err(ApiError::bad_request(format!(
-                "translation references missing node {}",
-                entry.node
-            )));
-        }
-        
+
         ops.push(Op::UpdateNode {
-            page: entry.page,
-            id: entry.node,
+            page,
+            id: node,
             patch: NodePatch {
                 data: Some(NodeDataPatch::Text(TextDataPatch {
                     translation: Some(Some(entry.text)),
@@ -107,9 +119,6 @@ async fn import_translation_xml_route(
         });
     }
 
-    // drop the lock before applying the batch
-    drop(scene);
-
     let updated = ops.len();
     if !ops.is_empty() {
         app.apply(Op::Batch {
@@ -120,6 +129,19 @@ async fn import_translation_xml_route(
     }
 
     Ok(Json(ImportTranslationXmlResponse { updated }))
+}
+
+fn translation_targets(session: &koharu_app::ProjectSession) -> Vec<(PageId, NodeId)> {
+    let scene = session.scene.read();
+    scene
+        .pages
+        .iter()
+        .flat_map(|(page_id, page)| {
+            page.nodes.iter().filter_map(|(node_id, node)| {
+                matches!(node.kind, NodeKind::Text(_)).then_some((*page_id, *node_id))
+            })
+        })
+        .collect()
 }
 
 fn xml_response(xml: String, filename: &str) -> Response {

--- a/ui/components/MenuBar.tsx
+++ b/ui/components/MenuBar.tsx
@@ -21,6 +21,7 @@ import { getConfig, startPipeline } from '@/lib/api/default/default'
 import { isTauri, openExternalUrl } from '@/lib/backend'
 import { exportCurrentProjectAs, importPages } from '@/lib/io/pagesIo'
 import { closeProject, redoOp, selectAllTextNodesOnCurrentPage, undoOp } from '@/lib/io/scene'
+import { exportTranslationXml, importTranslationXmlFromFile } from '@/lib/io/translationXml'
 import { formatShortcutForDisplay, getPlatform } from '@/lib/shortcutUtils'
 import { useEditorUiStore } from '@/lib/stores/editorUiStore'
 import { usePreferencesStore } from '@/lib/stores/preferencesStore'
@@ -129,6 +130,12 @@ export function MenuBar() {
       disabled: !hasScene,
       testId: 'menu-file-export-all-rendered',
     },
+    {
+      label: t('menu.exportTranslationXml'),
+      onSelect: () => void exportTranslationXml(),
+      disabled: !hasScene,
+      testId: 'menu-file-export-translation-xml',
+    },
   ]
 
   const menus: MenuSection[] = [
@@ -215,6 +222,15 @@ export function MenuBar() {
               onSelect={() => void exportCurrentProjectAs('khr')}
             >
               {t('menu.saveAs')}
+            </MenubarItem>
+            <MenubarSeparator />
+            <MenubarItem
+              data-testid='menu-file-import-translation-xml'
+              className='text-[13px]'
+              disabled={!hasScene}
+              onSelect={() => void importTranslationXmlFromFile()}
+            >
+              {t('menu.importTranslationXml')}
             </MenubarItem>
             <MenubarSeparator />
             {exportItems.map((item) => (

--- a/ui/lib/io/translationXml.ts
+++ b/ui/lib/io/translationXml.ts
@@ -1,0 +1,70 @@
+'use client'
+
+import { isTauri } from '@/lib/backend'
+import { ApiError } from '@/lib/api/fetch'
+import { filenameFromContentDisposition, saveBlob } from '@/lib/io/saveBlob'
+import { invalidateScene } from '@/lib/io/scene'
+
+const API_ROOT = '/api/v1'
+
+type ImportTranslationXmlResponse = {
+  updated: number
+}
+
+async function parseJsonResponse<T>(res: Response): Promise<T> {
+  if (!res.ok) {
+    const body = await res.json().catch(() => null)
+    const message =
+      (body && typeof body === 'object' && 'message' in body && typeof body.message === 'string'
+        ? body.message
+        : null) ??
+      res.statusText ??
+      `HTTP ${res.status}`
+    throw new ApiError(res.status, message, body)
+  }
+  return (await res.json()) as T
+}
+
+export async function exportTranslationXml(): Promise<boolean> {
+  const res = await fetch(`${API_ROOT}/translations/xml`)
+  if (!res.ok) {
+    await parseJsonResponse(res)
+  }
+  const blob = await res.blob()
+  const filename = filenameFromContentDisposition(res.headers.get('content-disposition'))
+  return saveBlob(blob, filename ?? 'translations.xml')
+}
+
+export async function importTranslationXmlFromFile(): Promise<ImportTranslationXmlResponse | null> {
+  const xml = await pickXmlText()
+  if (xml === null) return null
+
+  const res = await fetch(`${API_ROOT}/translations/xml`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ xml }),
+  })
+  const body = await parseJsonResponse<ImportTranslationXmlResponse>(res)
+  await invalidateScene()
+  return body
+}
+
+async function pickXmlText(): Promise<string | null> {
+  if (isTauri()) {
+    const { open } = await import('@tauri-apps/plugin-dialog')
+    const { readTextFile } = await import('@tauri-apps/plugin-fs')
+    const picked = await open({
+      multiple: false,
+      filters: [{ name: 'XML', extensions: ['xml'] }],
+    })
+    if (!picked || typeof picked !== 'string') return null
+    return readTextFile(picked)
+  }
+
+  const { fileOpen } = await import('browser-fs-access')
+  const file = await fileOpen({
+    extensions: ['.xml'],
+    mimeTypes: ['application/xml', 'text/xml'],
+  }).catch(() => null)
+  return file ? file.text() : null
+}

--- a/ui/public/locales/en-US/translation.json
+++ b/ui/public/locales/en-US/translation.json
@@ -26,6 +26,8 @@
     "exportGroup": "Export",
     "export": "Export...",
     "exportPsd": "Export PSD...",
+    "importTranslationXml": "Import Translation XML...",
+    "exportTranslationXml": "Export Translation XML...",
     "exportAllInpainted": "Export All Inpainted...",
     "exportAllRendered": "Export All Rendered...",
     "view": "View",

--- a/ui/public/locales/zh-CN/translation.json
+++ b/ui/public/locales/zh-CN/translation.json
@@ -21,6 +21,8 @@
     "selectAll": "全选",
     "export": "导出...",
     "exportPsd": "导出 PSD...",
+    "importTranslationXml": "导入翻译 XML...",
+    "exportTranslationXml": "导出翻译 XML...",
     "exportAllInpainted": "导出所有修复后的图像...",
     "exportAllRendered": "导出所有渲染后的图像...",
     "view": "视图",

--- a/ui/public/locales/zh-TW/translation.json
+++ b/ui/public/locales/zh-TW/translation.json
@@ -21,6 +21,8 @@
     "selectAll": "全選",
     "export": "匯出...",
     "exportPsd": "匯出 PSD...",
+    "importTranslationXml": "匯入翻譯 XML...",
+    "exportTranslationXml": "匯出翻譯 XML...",
     "exportAllInpainted": "匯出所有修補後的影像...",
     "exportAllRendered": "匯出所有渲染後的影像...",
     "view": "檢視",


### PR DESCRIPTION
## Summary
Enables professional translation workflows by supporting XML-based data exchange.

## Key Changes
- Implemented TranslationXml logic in the backend.
- Added export/import API endpoints.
- Integrated XML menu items into the File menu.