### PR TITLE
feat(pipeline): decoupled segmentation stage to protect translations

### DIFF
--- a/koharu-app/src/pipeline/mod.rs
+++ b/koharu-app/src/pipeline/mod.rs
@@ -67,10 +67,8 @@ pub struct RunOutcome {
 /// matters, not the engine's string id.
 fn step_for(info: &EngineInfo) -> Option<PipelineStep> {
     info.produces.iter().find_map(|a| match a {
-        Artifact::TextBoxes
-        | Artifact::SegmentMask
-        | Artifact::FontPredictions
-        | Artifact::BubbleMask => Some(PipelineStep::Detect),
+        Artifact::TextBoxes | Artifact::FontPredictions => Some(PipelineStep::Detect),
+        Artifact::SegmentMask | Artifact::BubbleMask => Some(PipelineStep::Segment),
         Artifact::OcrText => Some(PipelineStep::Ocr),
         Artifact::Translations => Some(PipelineStep::LlmGenerate),
         Artifact::Inpainted => Some(PipelineStep::Inpaint),

--- a/koharu-core/src/events.rs
+++ b/koharu-core/src/events.rs
@@ -68,6 +68,7 @@ pub enum AppEvent {
 #[strum(serialize_all = "snake_case")]
 pub enum PipelineStep {
     Detect,
+    Segment,
     Ocr,
     Inpaint,
     LlmGenerate,
@@ -77,6 +78,7 @@ pub enum PipelineStep {
 impl PipelineStep {
     pub const ALL: &[PipelineStep] = &[
         PipelineStep::Detect,
+        PipelineStep::Segment,
         PipelineStep::Ocr,
         PipelineStep::Inpaint,
         PipelineStep::LlmGenerate,

--- a/ui/components/ActivityBubble.tsx
+++ b/ui/components/ActivityBubble.tsx
@@ -157,6 +157,7 @@ function JobCard({ job, onCancel, t }: { job: JobEntry; onCancel: () => void; t:
   const percent = clampProgress(progress?.overallPercent)
   const stepLabels: Record<string, string> = {
     detect: t('processing.detect'),
+    segment: t('processing.segment'),
     ocr: t('processing.ocr'),
     inpaint: t('mask.inpaint'),
     llmGenerate: t('llm.generate'),

--- a/ui/components/BatchProcessDialog.tsx
+++ b/ui/components/BatchProcessDialog.tsx
@@ -15,9 +15,9 @@ import {
 import { Switch } from '@/components/ui/switch'
 import { Label } from '@/components/ui/label'
 
-export type PipelineStageKey = 'detect' | 'ocr' | 'translate' | 'inpaint' | 'render'
+export type PipelineStageKey = 'detect' | 'segment' | 'ocr' | 'translate' | 'inpaint' | 'render'
 
-const STAGE_ORDER: PipelineStageKey[] = ['detect', 'ocr', 'translate', 'inpaint', 'render']
+const STAGE_ORDER: PipelineStageKey[] = ['detect', 'segment', 'ocr', 'translate', 'inpaint', 'render']
 
 type BatchProcessDialogProps = {
   open: boolean
@@ -29,6 +29,7 @@ export function BatchProcessDialog({ open, onOpenChange, onConfirm }: BatchProce
   const { t } = useTranslation()
   const [selected, setSelected] = useState<Record<PipelineStageKey, boolean>>({
     detect: true,
+    segment: false,
     ocr: true,
     translate: true,
     inpaint: true,
@@ -36,11 +37,20 @@ export function BatchProcessDialog({ open, onOpenChange, onConfirm }: BatchProce
   })
 
   const toggle = (key: PipelineStageKey) => {
-    setSelected((prev) => ({ ...prev, [key]: !prev[key] }))
+    setSelected((prev) => {
+      const next = { ...prev, [key]: !prev[key] }
+      if (key === 'detect' && next.detect) {
+        next.segment = false
+      } else if (key === 'segment' && next.segment) {
+        next.detect = false
+      }
+      return next
+    })
   }
 
   const stageLabels: Record<PipelineStageKey, string> = {
     detect: t('batchProcess.detect', '偵測'),
+    segment: t('processing.segment'),
     ocr: t('batchProcess.ocr', '辨識'),
     translate: t('batchProcess.translate', '翻譯'),
     inpaint: t('batchProcess.inpaint', '修補'),
@@ -49,6 +59,7 @@ export function BatchProcessDialog({ open, onOpenChange, onConfirm }: BatchProce
 
   const stageDescriptions: Record<PipelineStageKey, string> = {
     detect: t('batchProcess.detectDesc', '偵測文字區塊、分割遮罩和字體'),
+    segment: t('batchProcess.segmentDesc', '僅根據現有文字區塊產生分割遮罩（保護譯文）'),
     ocr: t('batchProcess.ocrDesc', '辨識已偵測區域中的文字'),
     translate: t('batchProcess.translateDesc', '使用 LLM 產生翻譯'),
     inpaint: t('batchProcess.inpaintDesc', '修補圖片以移除原文'),

--- a/ui/components/BatchProcessDialog.tsx
+++ b/ui/components/BatchProcessDialog.tsx
@@ -1,0 +1,112 @@
+'use client'
+
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Switch } from '@/components/ui/switch'
+import { Label } from '@/components/ui/label'
+
+export type PipelineStageKey = 'detect' | 'ocr' | 'translate' | 'inpaint' | 'render'
+
+const STAGE_ORDER: PipelineStageKey[] = ['detect', 'ocr', 'translate', 'inpaint', 'render']
+
+type BatchProcessDialogProps = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onConfirm: (stages: PipelineStageKey[]) => void
+}
+
+export function BatchProcessDialog({ open, onOpenChange, onConfirm }: BatchProcessDialogProps) {
+  const { t } = useTranslation()
+  const [selected, setSelected] = useState<Record<PipelineStageKey, boolean>>({
+    detect: true,
+    ocr: true,
+    translate: true,
+    inpaint: true,
+    render: true,
+  })
+
+  const toggle = (key: PipelineStageKey) => {
+    setSelected((prev) => ({ ...prev, [key]: !prev[key] }))
+  }
+
+  const stageLabels: Record<PipelineStageKey, string> = {
+    detect: t('batchProcess.detect', '偵測'),
+    ocr: t('batchProcess.ocr', '辨識'),
+    translate: t('batchProcess.translate', '翻譯'),
+    inpaint: t('batchProcess.inpaint', '修補'),
+    render: t('batchProcess.render', '渲染'),
+  }
+
+  const stageDescriptions: Record<PipelineStageKey, string> = {
+    detect: t('batchProcess.detectDesc', '偵測文字區塊、分割遮罩和字體'),
+    ocr: t('batchProcess.ocrDesc', '辨識已偵測區域中的文字'),
+    translate: t('batchProcess.translateDesc', '使用 LLM 產生翻譯'),
+    inpaint: t('batchProcess.inpaintDesc', '修補圖片以移除原文'),
+    render: t('batchProcess.renderDesc', '渲染翻譯文字到圖片'),
+  }
+
+  const anySelected = STAGE_ORDER.some((k) => selected[k])
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className='max-w-sm'>
+        <DialogHeader>
+          <DialogTitle>{t('batchProcess.title', '處理所有圖片')}</DialogTitle>
+          <DialogDescription>{t('batchProcess.description', '選擇要執行的處理步驟')}</DialogDescription>
+        </DialogHeader>
+
+        <div className='flex flex-col gap-3 py-2'>
+          {STAGE_ORDER.map((key) => (
+            <div
+              key={key}
+              className='flex items-center justify-between rounded-md border border-border/60 px-3 py-2.5'
+            >
+              <div className='flex flex-col gap-0.5'>
+                <Label htmlFor={`stage-${key}`} className='text-sm font-medium cursor-pointer'>
+                  {stageLabels[key]}
+                </Label>
+                <span className='text-[11px] text-muted-foreground'>
+                  {stageDescriptions[key]}
+                </span>
+              </div>
+              <Switch
+                id={`stage-${key}`}
+                checked={selected[key]}
+                onCheckedChange={() => toggle(key)}
+              />
+            </div>
+          ))}
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant='outline'
+            onClick={() => onOpenChange(false)}
+          >
+            {t('common.cancel', '取消')}
+          </Button>
+          <Button
+            disabled={!anySelected}
+            onClick={() => {
+              const stages = STAGE_ORDER.filter((k) => selected[k])
+              onConfirm(stages)
+              onOpenChange(false)
+            }}
+          >
+            {t('batchProcess.start', '開始處理')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/ui/components/MenuBar.tsx
+++ b/ui/components/MenuBar.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { BatchProcessDialog, type PipelineStageKey } from '@/components/BatchProcessDialog'
 import { fitCanvasToViewport, resetCanvasScale } from '@/components/Canvas'
 import { SettingsDialog, type TabId } from '@/components/SettingsDialog'
 import {
@@ -62,6 +63,7 @@ export function MenuBar() {
   const { t } = useTranslation()
   const [settingsOpen, setSettingsOpen] = useState(false)
   const [settingsTab, setSettingsTab] = useState<TabId>('appearance')
+  const [batchDialogOpen, setBatchDialogOpen] = useState(false)
   const hasPage = useSelectionStore((s) => s.pageId !== null)
   const hasScene = useScene().scene !== null
   const shortcuts = usePreferencesStore((state) => state.shortcuts)
@@ -92,6 +94,31 @@ export function MenuBar() {
     await startPipeline({
       steps,
       pages: opts.pageId ? [opts.pageId] : undefined,
+      targetLanguage: editor.selectedLanguage,
+      systemPrompt: prefs.customSystemPrompt,
+      defaultFont: prefs.defaultFont,
+    })
+  }
+
+  const runSelectivePipeline = async (stages: PipelineStageKey[]) => {
+    const cfg = await getConfig()
+    if (!cfg.pipeline) return
+    const p = cfg.pipeline
+    const stageToEngines: Record<PipelineStageKey, (string | undefined)[]> = {
+      detect: [p.detector, p.segmenter, p.bubble_segmenter, p.font_detector],
+      ocr: [p.ocr],
+      translate: [p.translator],
+      inpaint: [p.inpainter],
+      render: [p.renderer],
+    }
+    const steps = stages
+      .flatMap((s) => stageToEngines[s])
+      .filter((s): s is string => !!s)
+    if (steps.length === 0) return
+    const editor = useEditorUiStore.getState()
+    const prefs = usePreferencesStore.getState()
+    await startPipeline({
+      steps,
       targetLanguage: editor.selectedLanguage,
       systemPrompt: prefs.customSystemPrompt,
       defaultFont: prefs.defaultFont,
@@ -157,7 +184,7 @@ export function MenuBar() {
         },
         {
           label: t('menu.processAll'),
-          onSelect: () => void runPipeline({}),
+          onSelect: () => setBatchDialogOpen(true),
           disabled: !hasScene,
           testId: 'menu-process-all',
         },
@@ -341,6 +368,11 @@ export function MenuBar() {
       <div data-tauri-drag-region className='flex h-full flex-1 items-center justify-center' />
       {isWindowsTauri && <WindowControls />}
       <SettingsDialog open={settingsOpen} onOpenChange={setSettingsOpen} defaultTab={settingsTab} />
+      <BatchProcessDialog
+        open={batchDialogOpen}
+        onOpenChange={setBatchDialogOpen}
+        onConfirm={(stages) => void runSelectivePipeline(stages)}
+      />
     </div>
   )
 }

--- a/ui/components/MenuBar.tsx
+++ b/ui/components/MenuBar.tsx
@@ -106,6 +106,7 @@ export function MenuBar() {
     const p = cfg.pipeline
     const stageToEngines: Record<PipelineStageKey, (string | undefined)[]> = {
       detect: [p.detector, p.segmenter, p.bubble_segmenter, p.font_detector],
+      segment: [p.segmenter, p.bubble_segmenter],
       ocr: [p.ocr],
       translate: [p.translator],
       inpaint: [p.inpainter],

--- a/ui/components/canvas/CanvasToolbar.tsx
+++ b/ui/components/canvas/CanvasToolbar.tsx
@@ -2,6 +2,7 @@
 
 import {
   LanguagesIcon,
+  LayersIcon,
   LoaderCircleIcon,
   ScanIcon,
   ScanTextIcon,
@@ -141,12 +142,14 @@ function WorkflowButtons() {
     p.bubble_segmenter!,
     p.font_detector!,
   ]
+  const segmentChain: PipelinePick = (p) => [p.segmenter!, p.bubble_segmenter!]
   const ocrChain: PipelinePick = (p) => [p.ocr!]
   const translateChain: PipelinePick = (p) => [p.translator!]
   const inpaintChain: PipelinePick = (p) => [p.inpainter!]
   const renderChain: PipelinePick = (p) => [p.renderer!]
 
   const isDetecting = currentStep === 'detect'
+  const isSegmenting = currentStep === 'segment'
   const isOcr = currentStep === 'ocr'
   const isInpainting = currentStep === 'inpaint'
   const isTranslating = currentStep === 'llmGenerate'
@@ -167,6 +170,21 @@ function WorkflowButtons() {
           <ScanIcon className='size-4' />
         )}
         {t('processing.detect')}
+      </Button>
+      <Separator orientation='vertical' className='mx-0.5 h-4' />
+      <Button
+        variant='ghost'
+        size='xs'
+        onClick={() => void runStep(segmentChain)}
+        data-testid='toolbar-segment'
+        disabled={!hasPage || isProcessing}
+      >
+        {isSegmenting ? (
+          <LoaderCircleIcon className='size-4 animate-spin' />
+        ) : (
+          <LayersIcon className='size-4' />
+        )}
+        {t('processing.segment')}
       </Button>
       <Separator orientation='vertical' className='mx-0.5 h-4' />
       <Button

--- a/ui/public/locales/en-US/translation.json
+++ b/ui/public/locales/en-US/translation.json
@@ -410,6 +410,21 @@
     "shortcutConflict": "Key combination already in use",
     "shortcutInvalid": "This key cannot be used as a shortcut"
   },
+  "batchProcess": {
+    "title": "Process all images",
+    "description": "Select the processing steps to run",
+    "detect": "Detect",
+    "detectDesc": "Detect text blocks, segmentation masks, and fonts",
+    "ocr": "Recognize",
+    "ocrDesc": "Recognize text in detected regions",
+    "translate": "Translate",
+    "translateDesc": "Generate translations using LLM",
+    "inpaint": "Inpaint",
+    "inpaintDesc": "Inpaint images to remove original text",
+    "render": "Render",
+    "renderDesc": "Render translated text onto images",
+    "start": "Start"
+  },
   "updater": {
     "available": {
       "title": "Update available",

--- a/ui/public/locales/en-US/translation.json
+++ b/ui/public/locales/en-US/translation.json
@@ -113,9 +113,10 @@
   },
   "processing": {
     "detect": "Detect",
+    "segment": "Segment",
     "detectTooltip": "Run text detection on current page",
     "ocr": "OCR",
-    "ocrTooltip": "Recognize text for detected regions",
+    "ocrTooltip": "Run OCR on detected regions",
     "render": "Render"
   },
   "mask": {
@@ -414,8 +415,10 @@
     "title": "Process all images",
     "description": "Select the processing steps to run",
     "detect": "Detect",
-    "detectDesc": "Detect text blocks, segmentation masks, and fonts",
-    "ocr": "Recognize",
+    "detectDesc": "Detect text boxes, segment masks and fonts",
+    "segment": "Segment",
+    "segmentDesc": "Generate segment masks based on existing boxes (protects translations)",
+    "ocr": "OCR",
     "ocrDesc": "Recognize text in detected regions",
     "translate": "Translate",
     "translateDesc": "Generate translations using LLM",

--- a/ui/public/locales/zh-TW/translation.json
+++ b/ui/public/locales/zh-TW/translation.json
@@ -96,6 +96,7 @@
   },
   "processing": {
     "detect": "偵測",
+    "segment": "分割",
     "detectTooltip": "在目前頁面執行文字偵測",
     "ocr": "辨識",
     "ocrTooltip": "辨識已偵測區域中的文字",
@@ -378,6 +379,8 @@
     "description": "選擇要執行的處理步驟",
     "detect": "偵測",
     "detectDesc": "偵測文字區塊、分割遮罩和字體",
+    "segment": "分割",
+    "segmentDesc": "僅根據現有文字區塊產生分割遮罩（保護譯文）",
     "ocr": "辨識",
     "ocrDesc": "辨識已偵測區域中的文字",
     "translate": "翻譯",

--- a/ui/public/locales/zh-TW/translation.json
+++ b/ui/public/locales/zh-TW/translation.json
@@ -373,6 +373,21 @@
     "shortcutConflict": "按鍵組合已被使用",
     "shortcutInvalid": "此按鍵不能用作快捷鍵"
   },
+  "batchProcess": {
+    "title": "處理所有圖片",
+    "description": "選擇要執行的處理步驟",
+    "detect": "偵測",
+    "detectDesc": "偵測文字區塊、分割遮罩和字體",
+    "ocr": "辨識",
+    "ocrDesc": "辨識已偵測區域中的文字",
+    "translate": "翻譯",
+    "translateDesc": "使用 LLM 產生翻譯",
+    "inpaint": "修補",
+    "inpaintDesc": "修補圖片以移除原文",
+    "render": "渲染",
+    "renderDesc": "渲染翻譯文字到圖片",
+    "start": "開始處理"
+  },
   "updater": {
     "available": {
       "title": "有可用更新",


### PR DESCRIPTION
## Summary
Extracts 'Segmentation' as an independent pipeline stage to protect existing translations.

## Key Changes
- Added dedicated 'Segment' button to CanvasToolbar.
- Implemented mutual exclusivity between Detect and Segment.
- Updated pipeline engine mapping.
- Fixed UI progress reporting for the 'Segment' step.