### PR TITLE
Fix: Centering Inconsistencies on Text Render

### DIFF
--- a/koharu-app/src/renderer.rs
+++ b/koharu-app/src/renderer.rs
@@ -252,6 +252,7 @@ impl Renderer {
             .text_align
             .map(core_align_to_renderer)
             .unwrap_or(RendererTextAlign::Center);
+        let seed_box = resolved_box.seed_box;
         let layout_box = resolved_box.layout_box;
 
         let mut layout_builder = TextLayout::new(&font, None)
@@ -284,7 +285,7 @@ impl Renderer {
                 },
             )?;
             let transform = centred_sprite_transform(
-                layout_box,
+                seed_box,
                 rendered.width(),
                 rendered.height(),
                 block.transform.rotation_deg,
@@ -350,10 +351,6 @@ impl Renderer {
         // the tail — so anchoring here keeps translations in the body
         // even when the bubble bbox extends into the tail area.
         //
-        // Deliberately no clamp to `expanded_box`: clamping to the
-        // segmentation bbox can pull the sprite toward the tail side
-        // when the bbox extends past the visible body. Trusting the
-        // seed position is both simpler and visually correct.
         Ok(Some(RenderedBlock {
             node_id: block.node_id,
             sprite: DynamicImage::ImageRgba8(candidate.image),
@@ -649,29 +646,14 @@ fn run_collision_layout_at<'a>(
 }
 
 fn ensure_center_aligned<'a>(
-    layout_builder: &TextLayout<'a>,
+    _layout_builder: &TextLayout<'a>,
     layout: LayoutRun<'a>,
-    text: &str,
-    container_width: f32,
-    container_height: f32,
+    _text: &str,
+    _container_width: f32,
+    _container_height: f32,
 ) -> Result<LayoutRun<'a>> {
-    // A narrow bubble can be narrower than individual words (manga tall-thin
-    // balloons frequently are). The layout engine's center-align step skips
-    // lines wider than `max_width`, leaving them at x=0 while shorter lines in
-    // the same block DO get centered at `max_width/2` — so shorter lines
-    // cluster on the left instead of being centred relative to the widest line.
-    // Re-run the layout with `max_width = actual_content_width` so every line
-    // is centred relative to the block's widest line.
-    if layout.width > container_width + FIT_EPSILON {
-        layout_builder
-            .clone()
-            .with_font_size(layout.font_size)
-            .with_max_width(layout.width)
-            .with_max_height(container_height)
-            .run(text)
-    } else {
-        Ok(layout)
-    }
+    // Pass-through now that tight-bounds centering is handled in the renderer.
+    Ok(layout)
 }
 
 fn layout_fits_collision_attempt(
@@ -993,8 +975,7 @@ fn centred_sprite_transform(
     sprite_height: u32,
     rotation_deg: f32,
 ) -> Transform {
-    // Place the sprite centred on the provided anchor (usually the bubble's
-    // interior safe area).
+    // Centering on seed_box maintains original positioning and avoids tail drift.
     let sprite_w = sprite_width as f32;
     let sprite_h = sprite_height as f32;
     let cx = anchor_box.x + anchor_box.width * 0.5;

--- a/koharu-app/src/renderer.rs
+++ b/koharu-app/src/renderer.rs
@@ -252,7 +252,6 @@ impl Renderer {
             .text_align
             .map(core_align_to_renderer)
             .unwrap_or(RendererTextAlign::Center);
-        let seed_box = resolved_box.seed_box;
         let layout_box = resolved_box.layout_box;
 
         let mut layout_builder = TextLayout::new(&font, None)
@@ -285,7 +284,7 @@ impl Renderer {
                 },
             )?;
             let transform = centred_sprite_transform(
-                seed_box,
+                layout_box,
                 rendered.width(),
                 rendered.height(),
                 block.transform.rotation_deg,
@@ -335,16 +334,13 @@ impl Renderer {
         // left instead of being centred relative to the widest line.
         // Re-run the layout with `max_width = actual_content_width` so
         // every line is centred relative to the block's widest line.
-        let layout = if layout.width > layout_box.width + 0.5 {
-            layout_builder
-                .clone()
-                .with_font_size(layout.font_size)
-                .with_max_width(layout.width)
-                .with_max_height(layout_box.height)
-                .run(translation)?
-        } else {
-            layout
-        };
+        let layout = ensure_center_aligned(
+            &layout_builder,
+            layout,
+            translation,
+            layout_box.width,
+            layout_box.height,
+        )?;
 
         let candidate = render_candidate(&layout)?;
 
@@ -577,6 +573,14 @@ where
         if !layout_fits_collision_attempt(&layout, writing_mode, layout_box, main_extent) {
             continue;
         }
+        let layout = ensure_center_aligned(
+            layout_builder,
+            layout,
+            text,
+            layout_box.width,
+            layout_box.height,
+        )?;
+
         let candidate = render_candidate(&layout)?;
         if sprite_collides_with_bubble_mask(&candidate.image, &candidate.transform, mask, bubble_id)
         {
@@ -614,6 +618,13 @@ where
         font_size,
         primary_collision_extent(layout_box, writing_mode),
     )?;
+    let layout = ensure_center_aligned(
+        layout_builder,
+        layout,
+        text,
+        layout_box.width,
+        layout_box.height,
+    )?;
     render_candidate(&layout)
 }
 
@@ -635,6 +646,32 @@ fn run_collision_layout_at<'a>(
         .with_max_width(max_width.max(1.0))
         .with_max_height(max_height.max(1.0))
         .run(text)
+}
+
+fn ensure_center_aligned<'a>(
+    layout_builder: &TextLayout<'a>,
+    layout: LayoutRun<'a>,
+    text: &str,
+    container_width: f32,
+    container_height: f32,
+) -> Result<LayoutRun<'a>> {
+    // A narrow bubble can be narrower than individual words (manga tall-thin
+    // balloons frequently are). The layout engine's center-align step skips
+    // lines wider than `max_width`, leaving them at x=0 while shorter lines in
+    // the same block DO get centered at `max_width/2` — so shorter lines
+    // cluster on the left instead of being centred relative to the widest line.
+    // Re-run the layout with `max_width = actual_content_width` so every line
+    // is centred relative to the block's widest line.
+    if layout.width > container_width + FIT_EPSILON {
+        layout_builder
+            .clone()
+            .with_font_size(layout.font_size)
+            .with_max_width(layout.width)
+            .with_max_height(container_height)
+            .run(text)
+    } else {
+        Ok(layout)
+    }
 }
 
 fn layout_fits_collision_attempt(
@@ -951,21 +988,20 @@ fn rendered_direction_for_writing_mode(writing_mode: WritingMode) -> TextDirecti
 // ---------------------------------------------------------------------------
 
 fn centred_sprite_transform(
-    seed_box: LayoutBox,
+    anchor_box: LayoutBox,
     sprite_width: u32,
     sprite_height: u32,
     rotation_deg: f32,
 ) -> Transform {
-    // Place the sprite centred on the seed (detector's original text bbox).
-    // The seed is inside the bubble body, so this avoids tail-side drift when
-    // the matched bubble bbox extends into a balloon tail.
+    // Place the sprite centred on the provided anchor (usually the bubble's
+    // interior safe area).
     let sprite_w = sprite_width as f32;
     let sprite_h = sprite_height as f32;
-    let seed_cx = seed_box.x + seed_box.width * 0.5;
-    let seed_cy = seed_box.y + seed_box.height * 0.5;
+    let cx = anchor_box.x + anchor_box.width * 0.5;
+    let cy = anchor_box.y + anchor_box.height * 0.5;
     Transform {
-        x: (seed_cx - sprite_w * 0.5).round(),
-        y: (seed_cy - sprite_h * 0.5).round(),
+        x: (cx - sprite_w * 0.5).round(),
+        y: (cy - sprite_h * 0.5).round(),
         width: sprite_w,
         height: sprite_h,
         rotation_deg,
@@ -1206,5 +1242,24 @@ mod tests {
                 img.put_pixel(x, y, Luma([value]));
             }
         }
+    }
+
+    #[test]
+    fn centred_sprite_transform_anchors_to_provided_box_center() {
+        let anchor = LayoutBox {
+            x: 100.0,
+            y: 100.0,
+            width: 200.0,
+            height: 100.0,
+        };
+        let sprite_w = 100;
+        let sprite_h = 50;
+
+        let transform = centred_sprite_transform(anchor, sprite_w, sprite_h, 0.0);
+
+        // Center of anchor is (200, 150).
+        // Sprite (100x50) centered on (200, 150) starts at (150, 125).
+        assert_eq!(transform.x, 150.0);
+        assert_eq!(transform.y, 125.0);
     }
 }

--- a/koharu-app/src/renderer.rs
+++ b/koharu-app/src/renderer.rs
@@ -327,22 +327,6 @@ impl Renderer {
             max_font,
         )?;
 
-        // A narrow bubble can be narrower than individual words (manga
-        // tall-thin balloons frequently are). The layout engine's
-        // center-align step skips lines wider than `max_width`, leaving
-        // them at x=0 while shorter lines in the same block DO get
-        // centered at `max_width/2` — so shorter lines cluster on the
-        // left instead of being centred relative to the widest line.
-        // Re-run the layout with `max_width = actual_content_width` so
-        // every line is centred relative to the block's widest line.
-        let layout = ensure_center_aligned(
-            &layout_builder,
-            layout,
-            translation,
-            layout_box.width,
-            layout_box.height,
-        )?;
-
         let candidate = render_candidate(&layout)?;
 
         // Place the sprite centred on the *seed* (detector's original
@@ -570,13 +554,6 @@ where
         if !layout_fits_collision_attempt(&layout, writing_mode, layout_box, main_extent) {
             continue;
         }
-        let layout = ensure_center_aligned(
-            layout_builder,
-            layout,
-            text,
-            layout_box.width,
-            layout_box.height,
-        )?;
 
         let candidate = render_candidate(&layout)?;
         if sprite_collides_with_bubble_mask(&candidate.image, &candidate.transform, mask, bubble_id)
@@ -615,13 +592,6 @@ where
         font_size,
         primary_collision_extent(layout_box, writing_mode),
     )?;
-    let layout = ensure_center_aligned(
-        layout_builder,
-        layout,
-        text,
-        layout_box.width,
-        layout_box.height,
-    )?;
     render_candidate(&layout)
 }
 
@@ -643,17 +613,6 @@ fn run_collision_layout_at<'a>(
         .with_max_width(max_width.max(1.0))
         .with_max_height(max_height.max(1.0))
         .run(text)
-}
-
-fn ensure_center_aligned<'a>(
-    _layout_builder: &TextLayout<'a>,
-    layout: LayoutRun<'a>,
-    _text: &str,
-    _container_width: f32,
-    _container_height: f32,
-) -> Result<LayoutRun<'a>> {
-    // Pass-through now that tight-bounds centering is handled in the renderer.
-    Ok(layout)
 }
 
 fn layout_fits_collision_attempt(
@@ -975,7 +934,8 @@ fn centred_sprite_transform(
     sprite_height: u32,
     rotation_deg: f32,
 ) -> Transform {
-    // Centering on seed_box maintains original positioning and avoids tail drift.
+    // Centering on the anchor_box (usually the detector's seed_box)
+    // maintains original positioning and avoids tail drift.
     let sprite_w = sprite_width as f32;
     let sprite_h = sprite_height as f32;
     let cx = anchor_box.x + anchor_box.width * 0.5;

--- a/koharu-renderer/src/layout.rs
+++ b/koharu-renderer/src/layout.rs
@@ -563,7 +563,7 @@ impl<'a> TextLayout<'a> {
                 && effective_alignment != TextAlign::Left
             {
                 for line in &mut lines {
-                    let remaining = (max_extent - line.advance).max(0.0);
+                    let remaining = (width - line.advance).max(0.0);
                     let offset = match effective_alignment {
                         TextAlign::Left => 0.0,
                         TextAlign::Center => remaining * 0.5,
@@ -1084,5 +1084,33 @@ mod tests {
             normalize_vertical_emphasis_punctuation("Hello!?!"),
             "Hello⁉!"
         );
+    }
+
+    #[test]
+    fn horizontal_center_alignment_with_overflow_is_aligned_relative_to_widest()
+    -> anyhow::Result<()> {
+        let font = any_system_font();
+        // A container only 50px wide.
+        let max_width = 50.0;
+        // "VILLAGE," is one word, it won't wrap and will overflow the 50px constraint.
+        // "HI" is short and fits.
+        let layout = TextLayout::new(&font, Some(20.0))
+            .with_max_width(max_width)
+            .with_alignment(TextAlign::Center)
+            .run("VILLAGE,\nHI")?;
+
+        let w0 = layout.lines[0].advance;
+        let w1 = layout.lines[1].advance;
+
+        let c0 = layout.lines[0].baseline.0 + w0 * 0.5;
+        let c1 = layout.lines[1].baseline.0 + w1 * 0.5;
+
+        // In a fixed system, the center of the short line should match the center
+        // of the overflowing line, NOT the center of the original 50px constraint.
+        assert!(
+            (c0 - c1).abs() < 1.0,
+            "expected line centres to match even with overflow, got c0={c0} c1={c1} (max_width={max_width})",
+        );
+        Ok(())
     }
 }

--- a/koharu-renderer/src/layout.rs
+++ b/koharu-renderer/src/layout.rs
@@ -517,9 +517,20 @@ impl<'a> TextLayout<'a> {
             if self.writing_mode.is_vertical() {
                 let actual_width = (max_x - min_x).max(0.0);
                 if max_width_finite {
-                    width = actual_width.max(self.max_width.unwrap());
+                    // Use tight bounds for Center alignment to ensure visual balance.
+                    width = if effective_alignment == TextAlign::Center {
+                        actual_width
+                    } else {
+                        actual_width.max(self.max_width.unwrap())
+                    };
+
                     if effective_alignment != TextAlign::Left {
-                        let remaining = (width - actual_width).max(0.0);
+                        let anchor = if effective_alignment == TextAlign::Center {
+                            actual_width
+                        } else {
+                            width
+                        };
+                        let remaining = (anchor - actual_width).max(0.0);
                         let offset = match effective_alignment {
                             TextAlign::Center => remaining * 0.5,
                             TextAlign::Right => remaining,
@@ -535,11 +546,16 @@ impl<'a> TextLayout<'a> {
                     width = actual_width;
                 }
             } else {
-                width = (max_x - min_x).max(if max_extent.is_finite() {
-                    max_extent
+                let actual_width = (max_x - min_x).max(0.0);
+                width = if effective_alignment == TextAlign::Center && max_extent_finite {
+                    actual_width
                 } else {
-                    0.0
-                });
+                    actual_width.max(if max_extent.is_finite() {
+                        max_extent
+                    } else {
+                        0.0
+                    })
+                };
             }
             height = (max_y - min_y).max(0.0);
 
@@ -562,8 +578,11 @@ impl<'a> TextLayout<'a> {
                 && max_extent_finite
                 && effective_alignment != TextAlign::Left
             {
+                // Anchor to the run width. If Center, this is a tight width.
+                // If Right, this is the container width.
+                let anchor = width;
                 for line in &mut lines {
-                    let remaining = (width - line.advance).max(0.0);
+                    let remaining = (anchor - line.advance).max(0.0);
                     let offset = match effective_alignment {
                         TextAlign::Left => 0.0,
                         TextAlign::Center => remaining * 0.5,
@@ -960,10 +979,10 @@ mod tests {
             .with_alignment(TextAlign::Center)
             .run("A")?;
 
-        assert_eq!(layout.width, max_width);
-        // The block is centered horizontally.
-        assert!(layout.lines[0].baseline.0 > 40.0);
-        assert!(layout.lines[0].baseline.0 < 60.0);
+        // Under the new tight-bounds strategy, the run width is now the actual content width (tightly cropped).
+        // The visual centering on the page is handled by the renderer centering this tight sprite.
+        assert!(layout.width < max_width);
+        assert!(layout.width > 10.0); // Should be around one line height (16px+)
 
         Ok(())
     }

--- a/koharu-renderer/src/layout.rs
+++ b/koharu-renderer/src/layout.rs
@@ -1109,23 +1109,29 @@ mod tests {
     fn horizontal_center_alignment_with_overflow_is_aligned_relative_to_widest()
     -> anyhow::Result<()> {
         let font = any_system_font();
-        // A container only 50px wide.
-        let max_width = 50.0;
-        // "VILLAGE," is one word, it won't wrap and will overflow the 50px constraint.
-        // "HI" is short and fits.
+        // A very narrow container.
+        let max_width = 20.0;
+        // A very long word that is guaranteed to overflow 20px in any font.
+        let text = "LONGWORDTHATWILLOVERFLOW,\nHI";
         let layout = TextLayout::new(&font, Some(20.0))
             .with_max_width(max_width)
             .with_alignment(TextAlign::Center)
-            .run("VILLAGE,\nHI")?;
+            .run(text)?;
 
         let w0 = layout.lines[0].advance;
         let w1 = layout.lines[1].advance;
+
+        // Ensure we are actually testing the overflow case.
+        assert!(
+            w0 > max_width,
+            "Test error: widest line {w0} did not overflow max_width {max_width}"
+        );
 
         let c0 = layout.lines[0].baseline.0 + w0 * 0.5;
         let c1 = layout.lines[1].baseline.0 + w1 * 0.5;
 
         // In a fixed system, the center of the short line should match the center
-        // of the overflowing line, NOT the center of the original 50px constraint.
+        // of the overflowing line, NOT the center of the original max_width constraint.
         assert!(
             (c0 - c1).abs() < 1.0,
             "expected line centres to match even with overflow, got c0={c0} c1={c1} (max_width={max_width})",


### PR DESCRIPTION
## Summary:
This PR solves a regression in the centering logic where long words may cause the line to overflow and become left-aligned, while some lines remain centered, causing this jagged alignment and breaking the center alignment. The fix ensures that all lines align relative to the widest line in the text block, ensuring all lines have the same vertical center alignment.

## Changes:
- Updated layout logic to calculate line offsets relative to widest line
- Adjusted width/height calculation for `TextAlign::Center` to match exact bounding box of visible pixels
- Refactored centering to be handled directly in the layout engine
- Added tests for centering logic and coordinate stability

| Before | After |
| --- | --- | 
| <img width="113" height="322" alt="beforecenter3" src="https://github.com/user-attachments/assets/8ca24f8b-469d-4b0e-850b-c9000ca680a6" /> | <img width="65" height="180" alt="aftercenter3" src="https://github.com/user-attachments/assets/6ad460b5-2c27-4301-ad2f-a1b2f1aa5d3c" /> |
| <img width="240" height="411" alt="beforecenter2" src="https://github.com/user-attachments/assets/0cc283c1-c65e-4e78-80fb-5f066867af55" /> | <img width="130" height="252" alt="aftercenter2" src="https://github.com/user-attachments/assets/69f40208-c890-4832-8bd7-6cf2b6e9fd5c" /> |

