### PR TITLE
Skip already-satisfied pipeline steps

### DIFF
--- a/koharu-app/src/pipeline/mod.rs
+++ b/koharu-app/src/pipeline/mod.rs
@@ -180,6 +180,17 @@ pub async fn run(
                 continue 'pages;
             }
 
+            // Skip this step if its produced artifacts are already satisfied.
+            {
+                let scene_guard = session.scene.read();
+                if let Some(page) = scene_guard.pages.get(page_id) {
+                    if info.produces.iter().all(|a| a.ready(page)) {
+                        completed += 1;
+                        continue;
+                    }
+                }
+            }
+
             let engine = match registry.get(info.id, &runtime, cpu).await {
                 Ok(e) => e,
                 Err(err) => {


### PR DESCRIPTION
## Summary

Skip a pipeline step when all artifacts produced by that step are already present on the page.

This makes rerunning a pipeline less destructive and faster when earlier stages have already produced their expected outputs.

## Changes

- Check each engine step's declared `produces` artifacts before running it.
- If every produced artifact is already ready on the page, credit the step as complete and continue.
- Keep the existing pipeline order and failure behavior unchanged.

## Testing

- cargo test -p koharu-app pipeline