### PR TITLE
Add page completion state

### DIFF
--- a/koharu-app/src/pipeline/artifacts.rs
+++ b/koharu-app/src/pipeline/artifacts.rs
@@ -33,7 +33,7 @@ pub enum Artifact {
     FontPredictions,
     /// Every `Text` node has `translation` set (or has no OCR text).
     Translations,
-    /// Every `Text` node has a rendered sprite.
+    /// Every `Text` node with a non-empty translation has a rendered sprite.
     RenderedSprites,
     /// `Image { role: Rendered }` node present.
     FinalRender,
@@ -64,7 +64,11 @@ impl Artifact {
                 }
                 t.translation.as_ref().is_some_and(|s| !s.trim().is_empty())
             }),
-            Artifact::RenderedSprites => every_text(page, |t| t.sprite.is_some()),
+            Artifact::RenderedSprites => every_text(page, |t| {
+                // The renderer only emits sprites for non-empty translations.
+                let has_translation = t.translation.as_ref().is_some_and(|s| !s.trim().is_empty());
+                !has_translation || t.sprite.is_some()
+            }),
             Artifact::FinalRender => has_image_role(page, ImageRole::Rendered),
         }
     }
@@ -98,4 +102,67 @@ fn every_text(page: &Page, predicate: impl Fn(&koharu_core::TextData) -> bool) -
         return true;
     }
     texts.into_iter().all(predicate)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use koharu_core::{BlobRef, Node, NodeId, TextData, Transform};
+
+    #[test]
+    fn rendered_sprites_ignore_blank_translation_nodes() {
+        let mut page = Page::new("page", 100, 100);
+        page.nodes.insert(
+            node_id(1),
+            text_node(TextData {
+                text: Some(String::new()),
+                translation: Some("   ".to_string()),
+                ..Default::default()
+            }),
+        );
+
+        assert!(Artifact::RenderedSprites.ready(&page));
+    }
+
+    #[test]
+    fn rendered_sprites_require_sprite_for_nonblank_translation() {
+        let mut page = Page::new("page", 100, 100);
+        page.nodes.insert(
+            node_id(1),
+            text_node(TextData {
+                translation: Some("hello".to_string()),
+                ..Default::default()
+            }),
+        );
+
+        assert!(!Artifact::RenderedSprites.ready(&page));
+    }
+
+    #[test]
+    fn rendered_sprites_accept_nonblank_translation_with_sprite() {
+        let mut page = Page::new("page", 100, 100);
+        page.nodes.insert(
+            node_id(1),
+            text_node(TextData {
+                translation: Some("hello".to_string()),
+                sprite: Some(BlobRef::new("sprite")),
+                ..Default::default()
+            }),
+        );
+
+        assert!(Artifact::RenderedSprites.ready(&page));
+    }
+
+    fn node_id(_value: u128) -> NodeId {
+        NodeId::new()
+    }
+
+    fn text_node(data: TextData) -> Node {
+        Node {
+            id: NodeId::new(),
+            transform: Transform::default(),
+            visible: true,
+            kind: NodeKind::Text(data),
+        }
+    }
 }

--- a/koharu-app/src/pipeline/mod.rs
+++ b/koharu-app/src/pipeline/mod.rs
@@ -256,6 +256,32 @@ pub async fn run(
                 continue 'pages;
             }
         }
+
+        // Auto-mark the page as completed when all steps succeeded and the
+        // page is either textless (nothing to render) or fully rendered.
+        {
+            let scene_guard = session.scene.read();
+            let should_complete = scene_guard
+                .pages
+                .get(page_id)
+                .is_some_and(|page| !page.completed && page_completion_satisfied(page));
+            if should_complete {
+                drop(scene_guard);
+                if let Err(err) = session.apply(Op::UpdatePage {
+                    id: *page_id,
+                    patch: koharu_core::PagePatch {
+                        completed: Some(true),
+                        ..Default::default()
+                    },
+                    prev: koharu_core::PagePatch::default(),
+                }) {
+                    tracing::warn!(
+                        page = %page_id,
+                        "failed to mark page completed: {err:#}"
+                    );
+                }
+            }
+        }
     }
 
     if let Some(sink) = progress.as_ref() {
@@ -270,6 +296,30 @@ pub async fn run(
         });
     }
     Ok(RunOutcome { warning_count })
+}
+
+fn page_completion_satisfied(page: &koharu_core::Page) -> bool {
+    let has_processable_text = page.nodes.values().any(|node| match &node.kind {
+        koharu_core::NodeKind::Text(text) => text_has_content(text),
+        _ => false,
+    });
+    if !has_processable_text {
+        return true;
+    }
+
+    Artifact::Translations.ready(page)
+        && Artifact::FinalRender.ready(page)
+        && Artifact::RenderedSprites.ready(page)
+}
+
+fn text_has_content(text: &koharu_core::TextData) -> bool {
+    text.text.as_ref().is_some_and(|s| !s.trim().is_empty()) || text_has_translation(text)
+}
+
+fn text_has_translation(text: &koharu_core::TextData) -> bool {
+    text.translation
+        .as_ref()
+        .is_some_and(|s| !s.trim().is_empty())
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -354,6 +404,9 @@ pub fn catalog() -> EngineCatalog {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use koharu_core::{
+        BlobRef, ImageData, ImageRole, Node, NodeId, NodeKind, Page, TextData, Transform,
+    };
 
     #[test]
     fn catalog_includes_anime_text_detector() {
@@ -364,5 +417,85 @@ mod tests {
                 && engine.name == "Anime Text YOLO (N)"
                 && engine.produces.iter().map(String::as_str).eq(["TextBoxes"])
         }));
+    }
+
+    #[test]
+    fn completion_treats_blank_text_nodes_as_textless() {
+        let mut page = Page::new("page", 100, 100);
+        page.nodes.insert(
+            node_id(1),
+            text_node(TextData {
+                text: Some("   ".to_string()),
+                translation: Some(String::new()),
+                ..Default::default()
+            }),
+        );
+
+        assert!(page_completion_satisfied(&page));
+    }
+
+    #[test]
+    fn completion_requires_translation_before_rendered_page_counts_done() {
+        let mut page = Page::new("page", 100, 100);
+        page.nodes.insert(
+            node_id(1),
+            text_node(TextData {
+                text: Some("source".to_string()),
+                translation: Some(String::new()),
+                ..Default::default()
+            }),
+        );
+        add_rendered_image(&mut page);
+
+        assert!(!page_completion_satisfied(&page));
+    }
+
+    #[test]
+    fn completion_requires_sprite_for_nonblank_translation() {
+        let mut page = Page::new("page", 100, 100);
+        page.nodes.insert(
+            node_id(1),
+            text_node(TextData {
+                text: Some("source".to_string()),
+                translation: Some("translation".to_string()),
+                ..Default::default()
+            }),
+        );
+        add_rendered_image(&mut page);
+
+        assert!(!page_completion_satisfied(&page));
+    }
+
+    fn node_id(_value: u128) -> NodeId {
+        NodeId::new()
+    }
+
+    fn text_node(data: TextData) -> Node {
+        Node {
+            id: NodeId::new(),
+            transform: Transform::default(),
+            visible: true,
+            kind: NodeKind::Text(data),
+        }
+    }
+
+    fn add_rendered_image(page: &mut Page) {
+        let id = node_id(99);
+        page.nodes.insert(
+            id,
+            Node {
+                id,
+                transform: Transform::default(),
+                visible: true,
+                kind: NodeKind::Image(ImageData {
+                    role: ImageRole::Rendered,
+                    blob: BlobRef::new("rendered"),
+                    opacity: 1.0,
+                    natural_width: 100,
+                    natural_height: 100,
+                    name: None,
+                }),
+            },
+        );
     }
 }

--- a/koharu-app/src/pipeline/mod.rs
+++ b/koharu-app/src/pipeline/mod.rs
@@ -153,6 +153,32 @@ pub async fn run(
     let mut warning_count: usize = 0;
 
     'pages: for (page_index, page_id) in pages.iter().enumerate() {
+        if cancel.load(Ordering::Relaxed) {
+            bail!("cancelled");
+        }
+
+        // Skip pages already marked completed. Without this, textless pages
+        // re-run detectors forever (TextBoxes never becomes "ready" with
+        // zero text nodes, so the per-step skip check below can't help).
+        // Users can untick the green checkmark in the navigator to force
+        // re-processing.
+        {
+            let scene_guard = session.scene.read();
+            let already_completed = scene_guard
+                .pages
+                .get(page_id)
+                .is_some_and(|page| page.completed);
+            if already_completed {
+                tracing::info!(
+                    page = %page_id,
+                    page_index,
+                    "skipped: page already marked completed"
+                );
+                completed += total_steps as u64;
+                continue 'pages;
+            }
+        }
+
         for (seq, &i) in order.iter().enumerate() {
             if cancel.load(Ordering::Relaxed) {
                 bail!("cancelled");

--- a/koharu-core/src/op.rs
+++ b/koharu-core/src/op.rs
@@ -153,6 +153,8 @@ pub struct PagePatch {
     pub width: Option<u32>,
     #[serde(default)]
     pub height: Option<u32>,
+    #[serde(default)]
+    pub completed: Option<bool>,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema, ToSchema)]
@@ -311,6 +313,7 @@ impl Op {
                     name: patch.name.as_ref().map(|_| page.name.clone()),
                     width: patch.width.as_ref().map(|_| page.width),
                     height: patch.height.as_ref().map(|_| page.height),
+                    completed: patch.completed.as_ref().map(|_| page.completed),
                 };
                 if let Some(name) = &patch.name {
                     page.name = name.clone();
@@ -320,6 +323,9 @@ impl Op {
                 }
                 if let Some(h) = patch.height {
                     page.height = h;
+                }
+                if let Some(c) = patch.completed {
+                    page.completed = c;
                 }
             }
 

--- a/koharu-core/src/scene.rs
+++ b/koharu-core/src/scene.rs
@@ -153,6 +153,11 @@ pub struct Page {
     pub name: String,
     pub width: u32,
     pub height: u32,
+    /// Whether this page is considered fully processed / ready for export.
+    /// Auto-set by the pipeline when a page finishes all steps (or has no
+    /// text to process). Can also be toggled manually by the user.
+    #[serde(default)]
+    pub completed: bool,
     /// Stacking = insertion order. Bottom-first: `source` is typically first,
     /// `rendered` typically last.
     pub nodes: IndexMap<NodeId, Node>,
@@ -165,6 +170,7 @@ impl Page {
             name: name.into(),
             width,
             height,
+            completed: false,
             nodes: IndexMap::new(),
         }
     }

--- a/koharu-rpc/src/routes/pages.rs
+++ b/koharu-rpc/src/routes/pages.rs
@@ -14,11 +14,12 @@ use std::sync::atomic::AtomicBool;
 use axum::Json;
 use axum::body::Bytes;
 use axum::extract::{Multipart, Path, Query, State};
+use axum::http::StatusCode;
 use image::GenericImageView;
 use koharu_app::pipeline::{self, EngineCtx, PipelineRunOptions};
 use koharu_core::{
     BlobRef, ImageData, ImageRole, MaskRole, Node, NodeDataPatch, NodeId, NodeKind, Op, Page,
-    PageId, Region, Scene, Transform,
+    PageId, PagePatch, Region, Scene, Transform,
 };
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -43,6 +44,7 @@ pub fn router() -> OpenApiRouter<AppState> {
     OpenApiRouter::default()
         .routes(routes!(create_pages))
         .routes(routes!(create_pages_from_paths))
+        .routes(routes!(patch_page))
         .routes(routes!(add_image_layer))
         .routes(routes!(put_mask))
 }
@@ -326,6 +328,37 @@ async fn create_pages_from_paths(
     .map_err(ApiError::internal)?;
 
     Ok(Json(CreatePagesResponse { pages: created_ids }))
+}
+
+// ---------------------------------------------------------------------------
+// PATCH /pages/{id}  — update page metadata (e.g. completed flag)
+// ---------------------------------------------------------------------------
+
+#[utoipa::path(
+    patch,
+    path = "/pages/{id}",
+    params(("id" = PageId, Path, description = "Page id")),
+    request_body = PagePatch,
+    responses((status = 204))
+)]
+async fn patch_page(
+    State(app): State<AppState>,
+    Path(page_id): Path<PageId>,
+    Json(patch): Json<PagePatch>,
+) -> ApiResult<StatusCode> {
+    let session = app
+        .current_session()
+        .ok_or_else(|| ApiError::bad_request("no project open"))?;
+    if !session.scene.read().pages.contains_key(&page_id) {
+        return Err(ApiError::not_found(format!("page not found: {page_id}")));
+    }
+    app.apply(Op::UpdatePage {
+        id: page_id,
+        patch,
+        prev: PagePatch::default(),
+    })
+    .map_err(ApiError::internal)?;
+    Ok(StatusCode::NO_CONTENT)
 }
 
 // ---------------------------------------------------------------------------

--- a/koharu-rpc/tests/snapshots/openapi__openapi_paths_snapshot.snap
+++ b/koharu-rpc/tests/snapshots/openapi__openapi_paths_snapshot.snap
@@ -154,6 +154,12 @@ expression: paths
         ],
     ),
     (
+        "/pages/{id}",
+        [
+            "patch",
+        ],
+    ),
+    (
         "/pages/{id}/image-layers",
         [
             "post",

--- a/tests/integration-tests/tests/scene.rs
+++ b/tests/integration-tests/tests/scene.rs
@@ -117,6 +117,7 @@ async fn update_page_then_undo_round_trips() -> anyhow::Result<()> {
             name: Some("renamed".into()),
             width: None,
             height: None,
+            completed: None,
         },
         prev: Default::default(),
     };

--- a/ui/components/Navigator.tsx
+++ b/ui/components/Navigator.tsx
@@ -1,8 +1,8 @@
 'use client'
 
 import { useVirtualizer } from '@tanstack/react-virtual'
-import { LayoutGridIcon } from 'lucide-react'
-import { useMemo, useRef, useState } from 'react'
+import { CheckCircleIcon, LayoutGridIcon } from 'lucide-react'
+import { useMemo, useRef, useState, type MouseEvent } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { PageManagerDialog } from '@/components/PageManagerDialog'
@@ -10,6 +10,8 @@ import { Button } from '@/components/ui/button'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { useScene } from '@/hooks/useScene'
 import { getGetPageThumbnailUrl } from '@/lib/api/default/default'
+import { updatePage } from '@/lib/io/scene'
+import { useEditorUiStore } from '@/lib/stores/editorUiStore'
 import { useSelectionStore } from '@/lib/stores/selectionStore'
 
 const THUMBNAIL_DPR =
@@ -93,6 +95,7 @@ export function Navigator() {
                 <PagePreview
                   index={virtualRow.index}
                   pageId={page?.id}
+                  completed={page?.completed ?? false}
                   selected={page?.id === pageId}
                   onSelect={() => page && setPage(page.id)}
                 />
@@ -110,37 +113,73 @@ export function Navigator() {
 type PagePreviewProps = {
   index: number
   pageId?: string
+  completed: boolean
   selected: boolean
   onSelect: () => void
 }
 
-function PagePreview({ index, pageId, selected, onSelect }: PagePreviewProps) {
+function PagePreview({ index, pageId, completed, selected, onSelect }: PagePreviewProps) {
+  const { t } = useTranslation()
   const src = pageId ? `${getGetPageThumbnailUrl(pageId)}?size=${200 * THUMBNAIL_DPR}` : undefined
+  const [completionPending, setCompletionPending] = useState(false)
+  const showError = useEditorUiStore((s) => s.showError)
+  const completionLabel = completed ? t('navigator.markIncomplete') : t('navigator.markComplete')
+
+  const handleToggleCompleted = async (e: MouseEvent) => {
+    e.stopPropagation()
+    if (!pageId || completionPending) return
+    setCompletionPending(true)
+    try {
+      await updatePage(pageId, { completed: !completed })
+    } catch (err) {
+      showError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setCompletionPending(false)
+    }
+  }
 
   return (
-    <Button
-      variant='ghost'
-      onClick={onSelect}
-      data-testid={`navigator-page-${index}`}
-      data-page-index={index}
-      data-selected={selected}
-      className='flex h-full w-full flex-col gap-0.5 rounded border border-transparent bg-card p-1.5 text-left shadow-sm data-[selected=true]:border-primary'
-    >
-      <div className='flex min-h-0 flex-1 items-center justify-center overflow-hidden rounded'>
-        {src ? (
-          <img
-            src={src}
-            alt={`Page ${index + 1}`}
-            loading='lazy'
-            className='max-h-full max-w-full rounded object-contain'
-          />
-        ) : (
-          <div className='h-full w-full rounded bg-muted' />
-        )}
-      </div>
-      <div className='flex shrink-0 items-center text-xs text-muted-foreground'>
-        <div className='mx-auto font-semibold text-foreground'>{index + 1}</div>
-      </div>
-    </Button>
+    <div className='relative h-full w-full'>
+      <Button
+        variant='ghost'
+        onClick={onSelect}
+        data-testid={`navigator-page-${index}`}
+        data-page-index={index}
+        data-selected={selected}
+        className='flex h-full w-full flex-col gap-0.5 rounded border border-transparent bg-card p-1.5 text-left shadow-sm data-[selected=true]:border-primary'
+      >
+        <div className='flex min-h-0 flex-1 items-center justify-center overflow-hidden rounded'>
+          {src ? (
+            <img
+              src={src}
+              alt={`Page ${index + 1}`}
+              loading='lazy'
+              className='max-h-full max-w-full rounded object-contain'
+            />
+          ) : (
+            <div className='h-full w-full rounded bg-muted' />
+          )}
+        </div>
+        <div className='flex shrink-0 items-center text-xs text-muted-foreground'>
+          <div className='mx-auto font-semibold text-foreground'>{index + 1}</div>
+        </div>
+      </Button>
+      {pageId && (
+        <button
+          type='button'
+          onClick={handleToggleCompleted}
+          disabled={completionPending}
+          aria-label={completionLabel}
+          title={completionLabel}
+          className={`absolute right-2 bottom-7 flex size-5 items-center justify-center rounded-full transition-colors ${
+            completed
+              ? 'bg-emerald-500/20 text-emerald-600 hover:bg-emerald-500/30'
+              : 'bg-muted/80 text-muted-foreground/40 hover:bg-muted hover:text-muted-foreground/70'
+          }`}
+        >
+          <CheckCircleIcon className='size-4' />
+        </button>
+      )}
+    </div>
   )
 }

--- a/ui/lib/api/default/default.msw.ts
+++ b/ui/lib/api/default/default.msw.ts
@@ -882,6 +882,7 @@ export const getGetSceneJsonResponseMock = (
   scene: {
     pages: {
       [faker.string.alphanumeric(5)]: {
+        completed: faker.datatype.boolean(),
         height: faker.number.int({ min: 0 }),
         id: faker.string.uuid(),
         name: faker.string.alpha({ length: { min: 10, max: 20 } }),

--- a/ui/lib/api/schemas/page.ts
+++ b/ui/lib/api/schemas/page.ts
@@ -7,6 +7,8 @@ import type { PageId } from './pageId'
 import type { PageNodes } from './pageNodes'
 
 export interface Page {
+  /** Whether this page is considered fully processed / ready for export. */
+  completed: boolean
   /** @minimum 0 */
   height: number
   id: PageId

--- a/ui/lib/api/schemas/pagePatch.ts
+++ b/ui/lib/api/schemas/pagePatch.ts
@@ -5,6 +5,8 @@
  */
 
 export interface PagePatch {
+  /** @nullable */
+  completed?: boolean | null
   /**
    * @minimum 0
    * @nullable

--- a/ui/lib/io/scene.ts
+++ b/ui/lib/io/scene.ts
@@ -19,12 +19,14 @@ import {
   undo,
 } from '@/lib/api/default/default'
 import { ApiError } from '@/lib/api/fetch'
+import { fetchApi } from '@/lib/api/fetch'
 import type {
   ConfigPatch,
   CreateProjectRequest,
   ExportProjectRequest,
   Op,
   OpenProjectRequest,
+  PagePatch,
   ProjectSummary,
   SceneSnapshot,
 } from '@/lib/api/schemas'
@@ -63,6 +65,17 @@ const enqueueHistoryMutation = (run: () => Promise<void>): Promise<void> => {
 export async function applyOp(op: Op): Promise<void> {
   await enqueueHistoryMutation(async () => {
     await applyCommand(op)
+    await invalidateScene()
+  })
+}
+
+export async function updatePage(id: string, patch: PagePatch): Promise<void> {
+  await enqueueHistoryMutation(async () => {
+    await fetchApi<void>(`/api/v1/pages/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(patch),
+    })
     await invalidateScene()
   })
 }

--- a/ui/public/locales/en-US/translation.json
+++ b/ui/public/locales/en-US/translation.json
@@ -90,6 +90,8 @@
     "pages_other": "{{count}} pages",
     "empty": "No documents",
     "prompt": "Select or import a page to begin",
+    "markComplete": "Mark as complete",
+    "markIncomplete": "Mark as incomplete",
     "pageManager": {
       "title": "Page Manager",
       "description": "Drag and drop pages to reorder them."

--- a/ui/tests/components/Navigator.test.tsx
+++ b/ui/tests/components/Navigator.test.tsx
@@ -27,9 +27,13 @@ import { server } from '../msw/server'
 
 beforeEach(() => useSelectionStore.getState().setPage(null))
 
-function sceneWithPages(ids: string[]) {
+function sceneWithPages(items: Array<string | { id: string; completed?: boolean }>) {
   const pages: Record<string, unknown> = {}
-  for (const id of ids) pages[id] = { id, name: id, width: 10, height: 10, nodes: {} }
+  for (const item of items) {
+    const id = typeof item === 'string' ? item : item.id
+    const completed = typeof item === 'string' ? false : (item.completed ?? false)
+    pages[id] = { id, completed, name: id, width: 10, height: 10, nodes: {} }
+  }
   return {
     epoch: 0,
     scene: { pages, project: { name: 'P' } as never },
@@ -80,5 +84,28 @@ describe('Navigator', () => {
     server.use(http.get('/api/v1/scene.json', () => HttpResponse.json(sceneWithPages(['a', 'b']))))
     renderWithQuery(<Navigator />)
     await waitFor(() => expect(screen.getByTestId('navigator-manage-pages')).toBeInTheDocument())
+  })
+
+  it('toggles page completion without selecting the page', async () => {
+    let completed = false
+    const patches: unknown[] = []
+    server.use(
+      http.get('/api/v1/scene.json', () =>
+        HttpResponse.json(sceneWithPages([{ id: 'a', completed }])),
+      ),
+      http.patch('/api/v1/pages/:id', async ({ request }) => {
+        const patch = await request.json()
+        patches.push(patch)
+        completed = Boolean((patch as { completed?: boolean }).completed)
+        return new HttpResponse(null, { status: 204 })
+      }),
+    )
+
+    renderWithQuery(<Navigator />)
+    await userEvent.click(await screen.findByTitle('navigator.markComplete'))
+
+    await waitFor(() => expect(patches).toEqual([{ completed: true }]))
+    await waitFor(() => expect(screen.getByTitle('navigator.markIncomplete')).toBeInTheDocument())
+    expect(useSelectionStore.getState().pageId).toBeNull()
   })
 })


### PR DESCRIPTION
## Summary

Add a persisted completion flag for pages so users can mark reviewed pages as done and skip them in later pipeline runs.

## Changes

- Add `completed` to page state and page patch handling.
- Show a completion checkmark in the page navigator.
- Allow toggling completion from the navigator.
- Auto-mark pages complete after successful pipeline runs when the page is textless or fully rendered.
- Skip pages already marked complete when running the pipeline.

## Testing

- cargo test -p koharu-app pipeline
- npm run lint:ui