### PR TITLE
feat: font favorite + weights/styles implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4548,6 +4548,7 @@ name = "koharu-renderer"
 version = "0.58.0"
 dependencies = [
  "anyhow",
+ "blake3",
  "criterion",
  "fontdb",
  "fontdue",

--- a/koharu-app/src/google_fonts.rs
+++ b/koharu-app/src/google_fonts.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use anyhow::{Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
-use koharu_core::{GoogleFontCatalog, GoogleFontEntry};
+use koharu_core::{GoogleFontCatalog, GoogleFontEntry, GoogleFontVariant};
 use tokio::sync::Mutex;
 use tracing::debug;
 
@@ -71,6 +71,12 @@ impl GoogleFontService {
         self.cached_families.lock().await.contains_key(family)
     }
 
+    /// Checks if a specific variant has been cached to disk.
+    pub fn is_variant_cached(&self, family: &str, variant: &GoogleFontVariant) -> bool {
+        let family_dir = self.cache_dir.join(normalize_family_dir(family));
+        family_dir.join(&variant.filename).exists()
+    }
+
     /// Downloads a font family's regular variant to disk cache.
     /// Returns the path to the cached .ttf file.
     /// No-op if already cached.
@@ -79,14 +85,17 @@ impl GoogleFontService {
         family: &str,
         http: &reqwest_middleware::ClientWithMiddleware,
     ) -> Result<Utf8PathBuf> {
-        // Check cache first
-        {
-            let cached = self.cached_families.lock().await;
-            if let Some(first) = cached.get(family).and_then(|p| p.first()) {
-                return Ok(first.clone());
-            }
-        }
+        self.fetch_variant(family, 400, "normal", http).await
+    }
 
+    /// Downloads a specific variant to disk cache.
+    pub async fn fetch_variant(
+        &self,
+        family: &str,
+        weight: u16,
+        style: &str,
+        http: &reqwest_middleware::ClientWithMiddleware,
+    ) -> Result<Utf8PathBuf> {
         let entry = self
             .catalog
             .fonts
@@ -94,51 +103,91 @@ impl GoogleFontService {
             .find(|e| e.family == family)
             .with_context(|| format!("font family not found in catalog: {family}"))?;
 
-        // Prefer regular weight, fallback to first variant
         let variant = entry
             .variants
             .iter()
-            .find(|v| v.weight == 400 && v.style == "normal")
+            .find(|v| v.weight == weight && v.style == style)
+            .or_else(|| {
+                // Fallback to regular if requested variant not found
+                entry
+                    .variants
+                    .iter()
+                    .find(|v| v.weight == 400 && v.style == "normal")
+            })
             .or_else(|| entry.variants.first())
             .context("font has no variants")?;
 
         let family_dir_name = normalize_family_dir(&entry.family);
-        let url = format!(
-            "https://raw.githubusercontent.com/google/fonts/main/ofl/{}/{}",
-            family_dir_name, variant.filename
-        );
+        let file_path = self
+            .cache_dir
+            .join(&family_dir_name)
+            .join(&variant.filename);
 
-        debug!(%family, %url, "downloading Google Font");
-        let response = http
-            .get(&url)
-            .send()
-            .await
-            .context("failed to fetch Google Font")?
-            .error_for_status()
-            .context("Google Fonts CDN returned an error")?;
-        let bytes = response
-            .bytes()
-            .await
-            .context("failed to read font bytes")?;
+        // Check cache first
+        if file_path.exists() {
+            return Ok(file_path);
+        }
 
-        // Write to disk cache
-        let family_dir = self.cache_dir.join(&family_dir_name);
-        std::fs::create_dir_all(family_dir.as_std_path())?;
-        let file_path = family_dir.join(&variant.filename);
-        std::fs::write(file_path.as_std_path(), &bytes)
-            .with_context(|| format!("failed to write cached font to {file_path}"))?;
+        // Try different license categories on Google Fonts GitHub
+        let categories = ["ofl", "apache", "ufl"];
+        let mut last_error = None;
 
-        // Update in-memory cache tracking
-        self.cached_families
-            .lock()
-            .await
-            .insert(family.to_string(), vec![file_path.clone()]);
+        for category in categories {
+            let url = format!(
+                "https://raw.githubusercontent.com/google/fonts/main/{}/{}/{}",
+                category, family_dir_name, variant.filename
+            );
 
-        Ok(file_path)
+            debug!(%family, %url, "trying to download Google Font");
+            match http.get(&url).send().await {
+                Ok(resp) if resp.status().is_success() => {
+                    let bytes = resp.bytes().await.context("failed to read font bytes")?;
+                    std::fs::create_dir_all(file_path.parent().unwrap())?;
+                    std::fs::write(&file_path, &bytes)?;
+
+                    // Update in-memory cache tracking
+                    let mut cached = self.cached_families.lock().await;
+                    let entries = cached.entry(family.to_string()).or_default();
+                    if !entries.contains(&file_path) {
+                        entries.push(file_path.clone());
+                    }
+
+                    return Ok(file_path);
+                }
+                Ok(resp) if resp.status() == 404 => {
+                    // If exact filename failed, it might be a naming mismatch on the CDN
+                    // This is rare for the main repo but happens with some older fonts
+                    last_error = Some(anyhow::anyhow!(
+                        "Font file {} not found in {}",
+                        variant.filename,
+                        category
+                    ));
+                    continue;
+                }
+                Ok(resp) => {
+                    last_error = Some(anyhow::anyhow!("CDN returned {}", resp.status()));
+                }
+                Err(e) => {
+                    last_error = Some(e.into());
+                }
+            }
+        }
+
+        Err(last_error.unwrap_or_else(|| anyhow::anyhow!("Font not found in any known category")))
     }
 
     /// Reads the cached font file bytes. Returns None if not cached.
     pub fn read_cached_file(&self, family: &str) -> Result<Option<Vec<u8>>> {
+        self.read_cached_variant(family, 400, "normal")
+    }
+
+    /// Reads a specific cached variant.
+    pub fn read_cached_variant(
+        &self,
+        family: &str,
+        weight: u16,
+        style: &str,
+    ) -> Result<Option<Vec<u8>>> {
         let entry = self.catalog.fonts.iter().find(|e| e.family == family);
         let Some(entry) = entry else {
             return Ok(None);
@@ -146,9 +195,10 @@ impl GoogleFontService {
         let variant = entry
             .variants
             .iter()
-            .find(|v| v.weight == 400 && v.style == "normal")
-            .or_else(|| entry.variants.first());
+            .find(|v| v.weight == weight && v.style == style);
+
         let Some(variant) = variant else {
+            // If the specific variant isn't in the catalog, we can't load it
             return Ok(None);
         };
         let file_path = self
@@ -172,4 +222,24 @@ impl GoogleFontService {
 /// e.g. "Comic Neue" -> "comicneue"
 fn normalize_family_dir(family: &str) -> String {
     family.to_lowercase().replace(' ', "")
+}
+
+/// Parses a variant query string like "Family:700i" into (family, weight, style).
+pub fn parse_variant_query(query: &str) -> (&str, u16, &str) {
+    if let Some((family, variant_str)) = query.split_once(':') {
+        let weight = variant_str
+            .chars()
+            .filter(|c| c.is_ascii_digit())
+            .collect::<String>()
+            .parse::<u16>()
+            .unwrap_or(400);
+        let style = if variant_str.contains('i') {
+            "italic"
+        } else {
+            "normal"
+        };
+        (family, weight, style)
+    } else {
+        (query, 400, "normal")
+    }
 }

--- a/koharu-app/src/renderer.rs
+++ b/koharu-app/src/renderer.rs
@@ -109,7 +109,6 @@ impl Renderer {
             .fontbook
             .lock()
             .map_err(|_| anyhow::anyhow!("failed to lock fontbook"))?;
-        let mut seen = std::collections::HashSet::new();
         let mut fonts = fontbook
             .all_families()
             .into_iter()
@@ -120,7 +119,6 @@ impl Renderer {
                     .first()
                     .map(|(family, _)| family.clone())
                     .unwrap_or_else(|| face.post_script_name.clone());
-                seen.insert(family_name.clone());
                 FontFaceInfo {
                     family_name,
                     post_script_name: face.post_script_name,
@@ -359,9 +357,10 @@ impl Renderer {
 
             // 2. Check if it's a Google Font variant (Family:WeightStyle)
             let (family, weight, style_str) = crate::google_fonts::parse_variant_query(candidate);
-            if candidate.contains(':') && let Some(data) = self
-                .google_fonts
-                .read_cached_variant(family, weight, style_str)?
+            if candidate.contains(':')
+                && let Some(data) = self
+                    .google_fonts
+                    .read_cached_variant(family, weight, style_str)?
             {
                 let mut font = fontbook.load_from_bytes(data)?;
 

--- a/koharu-app/src/renderer.rs
+++ b/koharu-app/src/renderer.rs
@@ -114,30 +114,39 @@ impl Renderer {
             .all_families()
             .into_iter()
             .filter(|face| !face.post_script_name.is_empty())
-            .filter_map(|face| {
+            .map(|face| {
                 let family_name = face
                     .families
                     .first()
                     .map(|(family, _)| family.clone())
                     .unwrap_or_else(|| face.post_script_name.clone());
-                seen.insert(family_name.clone()).then_some(FontFaceInfo {
+                seen.insert(family_name.clone());
+                FontFaceInfo {
                     family_name,
                     post_script_name: face.post_script_name,
                     source: FontSource::System,
                     category: None,
                     cached: true,
-                })
+                }
             })
             .collect::<Vec<_>>();
         let catalog = self.google_fonts.catalog();
         for entry in &catalog.fonts {
-            if seen.insert(entry.family.clone()) {
+            for variant in &entry.variants {
+                // Unique PS name for Google Fonts to identify the specific weight/style
+                let post_script_name = format!(
+                    "{}:{}{}",
+                    entry.family,
+                    variant.weight,
+                    if variant.style == "italic" { "i" } else { "" }
+                );
+
                 fonts.push(FontFaceInfo {
                     family_name: entry.family.clone(),
-                    post_script_name: entry.family.clone(),
+                    post_script_name,
                     source: FontSource::Google,
                     category: Some(entry.category.clone()),
-                    cached: false,
+                    cached: self.google_fonts.is_variant_cached(&entry.family, variant),
                 });
             }
         }
@@ -342,12 +351,35 @@ impl Renderer {
             .map_err(|_| anyhow::anyhow!("failed to lock fontbook"))?;
         for candidate in &style.font_families {
             let faces = fontbook.all_families();
+
+            // 1. Try exact PostScript name match first (most reliable for variants)
+            if let Some(face) = faces.iter().find(|f| f.post_script_name == *candidate) {
+                return fontbook.load_font(face.id);
+            }
+
+            // 2. Check if it's a Google Font variant (Family:WeightStyle)
+            let (family, weight, style_str) = crate::google_fonts::parse_variant_query(candidate);
+            if candidate.contains(':') && let Some(data) = self
+                .google_fonts
+                .read_cached_variant(family, weight, style_str)?
+            {
+                let mut font = fontbook.load_from_bytes(data)?;
+
+                // Explicitly set the weight and style for variable font instancing
+                font.weight = weight;
+                font.style = style_str.to_string();
+
+                return Ok(font);
+            }
+
+            // 3. Try fuzzy family name match
             if let Some(psn) = face_post_script_name(&faces, candidate) {
                 return fontbook.query(&psn);
             }
+
+            // 4. Try base Google Font file
             if let Some(data) = self.google_fonts.read_cached_file(candidate)? {
-                let font = fontbook.load_from_bytes(data)?;
-                return Ok(font);
+                return fontbook.load_from_bytes(data);
             }
         }
         Err(anyhow::anyhow!(
@@ -724,14 +756,15 @@ fn load_symbol_fallbacks(fontbook: &mut FontBook) -> Vec<Font> {
 }
 
 fn face_post_script_name(faces: &[FaceInfo], candidate: &str) -> Option<String> {
+    let candidate_lower = candidate.trim().to_lowercase();
     faces
         .iter()
         .find(|face| {
-            face.post_script_name == candidate
+            face.post_script_name.to_lowercase() == candidate_lower
                 || face
                     .families
                     .iter()
-                    .any(|(family, _)| family.as_str() == candidate)
+                    .any(|(family, _)| family.to_lowercase() == candidate_lower)
         })
         .map(|face| face.post_script_name.clone())
         .filter(|post_script_name| !post_script_name.is_empty())

--- a/koharu-renderer/Cargo.toml
+++ b/koharu-renderer/Cargo.toml
@@ -27,6 +27,7 @@ fontdb = { workspace = true }
 fontdue = { workspace = true }
 tiny-skia = { workspace = true }
 tracing = { workspace = true }
+blake3 = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/koharu-renderer/src/font.rs
+++ b/koharu-renderer/src/font.rs
@@ -11,6 +11,8 @@ pub struct Font {
     data: Arc<[u8]>,
     face: FaceInfo,
     fontdue: Arc<OnceCell<Arc<fontdue::Font>>>,
+    pub weight: u16,
+    pub style: String,
 }
 
 impl Font {
@@ -51,6 +53,14 @@ impl Font {
         &self.face.post_script_name
     }
 
+    pub fn weight(&self) -> u16 {
+        self.weight
+    }
+
+    pub fn style(&self) -> &str {
+        &self.style
+    }
+
     pub fn face_info(&self) -> &FaceInfo {
         &self.face
     }
@@ -64,6 +74,8 @@ pub(crate) fn font_key(font: &Font) -> usize {
 pub struct FontBook {
     database: Database,
     cache: HashMap<ID, Font>,
+    /// Maps data hash to font ID to avoid duplicate loading.
+    data_cache: HashMap<u64, ID>,
 }
 
 impl FontBook {
@@ -75,6 +87,7 @@ impl FontBook {
         Self {
             database,
             cache: HashMap::new(),
+            data_cache: HashMap::new(),
         }
     }
 
@@ -100,6 +113,17 @@ impl FontBook {
     /// Loads a font from raw bytes (e.g., downloaded from Google Fonts).
     /// Returns the loaded Font on success.
     pub fn load_from_bytes(&mut self, data: Vec<u8>) -> anyhow::Result<Font> {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+
+        let mut hasher = DefaultHasher::new();
+        data.hash(&mut hasher);
+        let hash = hasher.finish();
+
+        if let Some(&id) = self.data_cache.get(&hash) {
+            return self.load_font(id);
+        }
+
         let data: Arc<dyn AsRef<[u8]> + Send + Sync> = Arc::new(data);
         let source = fontdb::Source::Binary(data);
         let ids = self.database.load_font_source(source);
@@ -107,10 +131,12 @@ impl FontBook {
             .into_iter()
             .next()
             .context("font data contained no valid faces")?;
+
+        self.data_cache.insert(hash, id);
         self.load_font(id)
     }
 
-    fn load_font(&mut self, id: ID) -> anyhow::Result<Font> {
+    pub fn load_font(&mut self, id: ID) -> anyhow::Result<Font> {
         if let Some(font) = self.cache.get(&id) {
             return Ok(font.clone());
         }
@@ -125,10 +151,20 @@ impl FontBook {
             .with_face_data(id, |data, _| Arc::<[u8]>::from(data.to_vec()))
             .with_context(|| format!("failed to load font data for {:?}", id))?;
 
+        // Determine weight and style from face info
+        let fontdb::Weight(weight) = face.weight;
+        let style = match face.style {
+            fontdb::Style::Normal => "normal".to_string(),
+            fontdb::Style::Italic => "italic".to_string(),
+            fontdb::Style::Oblique => "oblique".to_string(),
+        };
+
         let font = Font {
             data,
             face,
             fontdue: Arc::new(OnceCell::new()),
+            weight,
+            style,
         };
         self.cache.insert(id, font.clone());
         Ok(font)

--- a/koharu-renderer/src/font.rs
+++ b/koharu-renderer/src/font.rs
@@ -75,7 +75,7 @@ pub struct FontBook {
     database: Database,
     cache: HashMap<ID, Font>,
     /// Maps data hash to font ID to avoid duplicate loading.
-    data_cache: HashMap<u64, ID>,
+    data_cache: HashMap<[u8; 32], ID>,
 }
 
 impl FontBook {
@@ -111,14 +111,8 @@ impl FontBook {
     }
 
     /// Loads a font from raw bytes (e.g., downloaded from Google Fonts).
-    /// Returns the loaded Font on success.
     pub fn load_from_bytes(&mut self, data: Vec<u8>) -> anyhow::Result<Font> {
-        use std::collections::hash_map::DefaultHasher;
-        use std::hash::{Hash, Hasher};
-
-        let mut hasher = DefaultHasher::new();
-        data.hash(&mut hasher);
-        let hash = hasher.finish();
+        let hash: [u8; 32] = blake3::hash(&data).into();
 
         if let Some(&id) = self.data_cache.get(&hash) {
             return self.load_font(id);

--- a/koharu-renderer/src/renderer.rs
+++ b/koharu-renderer/src/renderer.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result, bail};
 use image::{RgbaImage, imageops};
 use skrifa::{
     GlyphId, MetadataProvider, OutlineGlyph,
-    instance::{LocationRef, Size},
+    instance::Size,
     outline::{DrawSettings, OutlinePen},
 };
 use tiny_skia::{
@@ -300,8 +300,17 @@ fn load_glyph_source(
     anti_alias: bool,
 ) -> Result<GlyphRenderSource> {
     let font_ref = font.skrifa()?;
+
+    // Support variable font weights by instancing the wght axis
+    let mut location = skrifa::instance::Location::default();
+    let axes = font_ref.axes();
+    if let Some(axis) = axes.iter().find(|a| a.tag() == skrifa::Tag::new(b"wght")) {
+        let target = (font.weight as f32).clamp(axis.min_value(), axis.max_value());
+        location = axes.location([(skrifa::Tag::new(b"wght"), target)]);
+    }
+
     if let Some(outline) = font_ref.outline_glyphs().get(GlyphId::new(glyph_id as u32))
-        && let Some(path) = outline_to_path(&outline, font_size)
+        && let Some(path) = outline_to_path(&outline, font_size, &location)
     {
         let bounds = path.bounds();
         if bounds.width() > 0.0 && bounds.height() > 0.0 {
@@ -532,9 +541,13 @@ fn color_from_rgba(color: [u8; 4]) -> Color {
     Color::from_rgba8(color[0], color[1], color[2], color[3])
 }
 
-fn outline_to_path(outline: &OutlineGlyph<'_>, font_size: f32) -> Option<Path> {
+fn outline_to_path(
+    outline: &OutlineGlyph<'_>,
+    font_size: f32,
+    location: &skrifa::instance::Location,
+) -> Option<Path> {
     let mut pen = TinySkiaPathPen::new();
-    let settings = DrawSettings::unhinted(Size::new(font_size), LocationRef::default());
+    let settings = DrawSettings::unhinted(Size::new(font_size), location);
     outline.draw(settings, &mut pen).ok()?;
     pen.finish()
 }

--- a/koharu-rpc/src/routes/fonts.rs
+++ b/koharu-rpc/src/routes/fonts.rs
@@ -8,7 +8,7 @@
 use axum::body::Body;
 use axum::extract::{Path, State};
 use axum::http::{HeaderValue, StatusCode, header::CONTENT_TYPE};
-use axum::response::{IntoResponse, Json, Response};
+use axum::response::{Json, Response};
 use koharu_core::{FontFaceInfo, GoogleFontCatalog};
 use utoipa_axum::{router::OpenApiRouter, routes};
 
@@ -48,14 +48,17 @@ async fn get_google_fonts_catalog(
 )]
 async fn fetch_google_font(
     State(app): State<AppState>,
-    Path(family): Path<String>,
+    Path(family_query): Path<String>,
 ) -> ApiResult<StatusCode> {
     let http = app.runtime.http_client();
+    let (family, weight, style) = koharu_app::google_fonts::parse_variant_query(&family_query);
+
     app.renderer
         .google_fonts
-        .fetch_family(&family, &http)
+        .fetch_variant(family, weight, style, &http)
         .await
         .map_err(ApiError::internal)?;
+
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -70,16 +73,19 @@ async fn fetch_google_font(
 )]
 async fn get_google_font_file(
     State(app): State<AppState>,
-    Path((family, _file)): Path<(String, String)>,
+    Path((family_query, _file)): Path<(String, String)>,
 ) -> ApiResult<Response> {
+    let (family, weight, style) = koharu_app::google_fonts::parse_variant_query(&family_query);
     let bytes = app
         .renderer
         .google_fonts
-        .read_cached_file(&family)
-        .map_err(ApiError::internal)?
-        .ok_or_else(|| ApiError::not_found(format!("font {family} not cached")))?;
+        .read_cached_variant(family, weight, style)
+        .map_err(ApiError::internal)?;
+
+    let bytes =
+        bytes.ok_or_else(|| ApiError::not_found(format!("font {family_query} not cached")))?;
     let mut resp = Response::new(Body::from(bytes));
     resp.headers_mut()
         .insert(CONTENT_TYPE, HeaderValue::from_static("font/ttf"));
-    Ok(resp.into_response())
+    Ok(resp)
 }

--- a/ui/components/panels/RenderControlsPanel.tsx
+++ b/ui/components/panels/RenderControlsPanel.tsx
@@ -191,17 +191,6 @@ export function RenderControlsPanel() {
     return normalizeFamilyName(currentFontFace.familyName)
   }, [currentFontFace])
 
-  const groupedFonts = useMemo(() => {
-    const families = new Map<string, FontFaceInfo[]>()
-    fontCandidates.forEach((f) => {
-      const family = f.familyName.trim()
-      const existing = families.get(family) || []
-      existing.push(f)
-      families.set(family, existing)
-    })
-    return families
-  }, [fontCandidates])
-
   const familyOptions = useMemo(() => {
     const families = new Map<string, FontFaceInfo>()
     for (const f of fontCandidates) {
@@ -438,7 +427,9 @@ export function RenderControlsPanel() {
                 sectionWidth > 0 ? { width: sectionWidth, maxWidth: sectionWidth } : undefined
               }
               onChange={async (value) => {
-                const familyVariants = fontCandidates.filter((f) => f.familyName === value)
+                const familyVariants = fontCandidates.filter(
+                  (f) => normalizeFamilyName(f.familyName) === value,
+                )
                 // Try to find Regular/400 first
                 const regularFace =
                   familyVariants.find((f) => {
@@ -452,7 +443,7 @@ export function RenderControlsPanel() {
                 // Trigger fetch for Google Fonts if not cached
                 if (face.source === 'google' && !face.cached) {
                   try {
-                    await fetchGoogleFont(face.postScriptName)
+                    await fetchGoogleFont(encodeURIComponent(face.postScriptName))
                     invalidateScene()
                   } catch (e) {
                     console.error('Failed to fetch font:', e)
@@ -477,7 +468,7 @@ export function RenderControlsPanel() {
                   const variant = currentVariants.find((v) => v.postScriptName === value)
                   if (variant?.source === 'google' && !variant.cached) {
                     try {
-                      await fetchGoogleFont(value)
+                      await fetchGoogleFont(encodeURIComponent(value))
                       invalidateScene()
                     } catch (e) {
                       console.error('Failed to fetch font variant:', e)
@@ -500,7 +491,7 @@ export function RenderControlsPanel() {
                         : undefined,
                   }}
                 >
-                  <SelectValue placeholder='Style' />
+                  <SelectValue placeholder={t('render.fontStylePlaceholder')} />
                 </SelectTrigger>
                 <SelectContent
                   position='popper'

--- a/ui/components/panels/RenderControlsPanel.tsx
+++ b/ui/components/panels/RenderControlsPanel.tsx
@@ -10,14 +10,22 @@ import {
   PlusIcon,
   SquareIcon,
 } from 'lucide-react'
-import { type ComponentType, useMemo } from 'react'
+import { type ComponentType, useMemo, useRef, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { Button } from '@/components/ui/button'
 import { ColorPicker } from '@/components/ui/color-picker'
-import { FontSelect } from '@/components/ui/font-select'
+import { FontSelect, useGoogleFontPreview } from '@/components/ui/font-select'
 import { Input } from '@/components/ui/input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { VariantItem } from '@/components/ui/variant-item'
 import {
   useCurrentPage,
   useSelectedTextNode,
@@ -25,7 +33,7 @@ import {
   useTextNodes,
   type TextNodeEntry,
 } from '@/hooks/useCurrentPage'
-import { useGetGoogleFontsCatalog, useListFonts } from '@/lib/api/default/default'
+import { fetchGoogleFont, useGetGoogleFontsCatalog, useListFonts } from '@/lib/api/default/default'
 import type {
   FontFaceInfo,
   FontPrediction,
@@ -35,7 +43,14 @@ import type {
   TextStrokeStyle,
   TextStyle,
 } from '@/lib/api/schemas'
-import { applyOp, queueAutoRender } from '@/lib/io/scene'
+import {
+  findFontFace,
+  getLocalizedFontLabel,
+  normalizeFamilyName,
+  STYLE_KEYWORDS,
+  uniqueFontFaces,
+} from '@/lib/font-utils'
+import { applyOp, invalidateScene, queueAutoRender } from '@/lib/io/scene'
 import { ops } from '@/lib/ops'
 import { useEditorUiStore } from '@/lib/stores/editorUiStore'
 import { usePreferencesStore } from '@/lib/stores/preferencesStore'
@@ -75,23 +90,6 @@ const hexToColor = (value: string, alpha: number): number[] => {
   const b = Number.parseInt(normalized.slice(4, 6), 16)
   if ([r, g, b].some((c) => Number.isNaN(c))) return [0, 0, 0, clampByte(alpha)]
   return [r, g, b, clampByte(alpha)]
-}
-
-const uniqueFontFaces = (values: FontFaceInfo[]) => {
-  const seen = new Set<string>()
-  return values.filter((v) => {
-    if (!v.postScriptName || seen.has(v.postScriptName)) return false
-    seen.add(v.postScriptName)
-    return true
-  })
-}
-
-const findFontFace = (fonts: FontFaceInfo[], value?: string) => {
-  if (!value) return undefined
-  return fonts.find(
-    (f) =>
-      f.postScriptName === value || f.familyName === value || f.familyName.trim() === value.trim(),
-  )
 }
 
 const fallbackFontFace = (value?: string): FontFaceInfo | undefined => {
@@ -137,6 +135,8 @@ export function RenderControlsPanel() {
   const { data: availableFonts = [] } = useListFonts()
   useGetGoogleFontsCatalog() // prefetch catalog so picker can decorate Google entries
   const appDefaultFont = usePreferencesStore((s) => s.defaultFont)
+  const favoriteFonts = usePreferencesStore((s) => s.favoriteFonts)
+  const toggleFavoriteFont = usePreferencesStore((s) => s.toggleFavoriteFont)
   const renderEffect = useEditorUiStore((s) => s.renderEffect)
   const setRenderEffect = useEditorUiStore((s) => s.setRenderEffect)
   const setRenderStroke = useEditorUiStore((s) => s.setRenderStroke)
@@ -145,25 +145,33 @@ export function RenderControlsPanel() {
     return [...(availableFonts ?? [])].sort((a, b) => a.familyName.localeCompare(b.familyName))
   }, [availableFonts])
 
-  if (!page) {
-    return (
-      <div className='flex items-center justify-center py-6 text-xs text-muted-foreground'>
-        {t('textBlocks.emptyPrompt')}
-      </div>
-    )
-  }
+  const sectionRef = useRef<HTMLDivElement>(null)
+  const [sectionWidth, setSectionWidth] = useState<number>(0)
+
+  useEffect(() => {
+    if (!sectionRef.current) return
+    const observer = new ResizeObserver((entries) => {
+      setSectionWidth(entries[0].contentRect.width)
+    })
+    observer.observe(sectionRef.current)
+    return () => observer.disconnect()
+  }, [])
 
   const firstNode = textNodes[0]
   const hasNodes = textNodes.length > 0
 
-  const fontCandidates = uniqueFontFaces(
-    [
-      ...sortedFonts,
-      ...(appDefaultFont ? [fallbackFontFace(appDefaultFont)] : []),
-      ...(selectedNode?.data.style?.fontFamilies?.slice(0, 1)?.map(fallbackFontFace) ?? []),
-      ...(firstNode?.data.style?.fontFamilies?.slice(0, 1)?.map(fallbackFontFace) ?? []),
-      ...DEFAULT_FONT_FACES,
-    ].filter((v): v is FontFaceInfo => !!v),
+  const fontCandidates = useMemo(
+    () =>
+      uniqueFontFaces(
+        [
+          ...sortedFonts,
+          ...(appDefaultFont ? [fallbackFontFace(appDefaultFont)] : []),
+          ...(selectedNode?.data.style?.fontFamilies?.slice(0, 1)?.map(fallbackFontFace) ?? []),
+          ...(firstNode?.data.style?.fontFamilies?.slice(0, 1)?.map(fallbackFontFace) ?? []),
+          ...DEFAULT_FONT_FACES,
+        ].filter((v): v is FontFaceInfo => !!v),
+      ),
+    [sortedFonts, appDefaultFont, selectedNode?.id, selectedNode?.data.style?.fontFamilies],
   )
 
   const currentFontCandidate =
@@ -171,10 +179,93 @@ export function RenderControlsPanel() {
     appDefaultFont ??
     firstNode?.data.style?.fontFamilies?.[0] ??
     (hasNodes ? fontCandidates[0]?.postScriptName : '')
-  const currentFontFace =
-    findFontFace(fontCandidates, currentFontCandidate) ?? fallbackFontFace(currentFontCandidate)
+  const currentFontFace = useMemo(() => {
+    return (
+      findFontFace(fontCandidates, currentFontCandidate) || fallbackFontFace(currentFontCandidate)
+    )
+  }, [fontCandidates, currentFontCandidate])
+
   const currentFont = currentFontFace?.postScriptName ?? ''
-  const currentFontFamilyName = currentFontFace?.familyName
+  const currentFontFamilyName = useMemo(() => {
+    if (!currentFontFace) return undefined
+    return normalizeFamilyName(currentFontFace.familyName)
+  }, [currentFontFace])
+
+  const groupedFonts = useMemo(() => {
+    const families = new Map<string, FontFaceInfo[]>()
+    fontCandidates.forEach((f) => {
+      const family = f.familyName.trim()
+      const existing = families.get(family) || []
+      existing.push(f)
+      families.set(family, existing)
+    })
+    return families
+  }, [fontCandidates])
+
+  const familyOptions = useMemo(() => {
+    const families = new Map<string, FontFaceInfo>()
+    for (const f of fontCandidates) {
+      const name = normalizeFamilyName(f.familyName)
+      if (!families.has(name) || f.postScriptName === name) {
+        families.set(name, { ...f, familyName: name }) // Use normalized name for the option
+      }
+    }
+    return Array.from(families.values()).sort((a, b) => a.familyName.localeCompare(b.familyName))
+  }, [fontCandidates])
+
+  const currentVariants = useMemo(() => {
+    const name = normalizeFamilyName(currentFontFamilyName ?? '').toLowerCase()
+    if (!name) return []
+    const nameNoSpace = name.replace(/\s+/g, '')
+    return fontCandidates.filter((f) => {
+      const fFamilyNorm = normalizeFamilyName(f.familyName).toLowerCase()
+      if (fFamilyNorm === name) return true
+
+      const fPsNorm = f.postScriptName.toLowerCase()
+      if (fPsNorm.includes(nameNoSpace)) {
+        // Ensure the family part of the PS name is an EXACT match
+        const familyPart = f.postScriptName
+          .split(/[:\-_]/)[0]
+          .replace(/[\s\-_]+/g, '')
+          .toLowerCase()
+        if (familyPart !== nameNoSpace) return false
+
+        const rest = fPsNorm.replace(nameNoSpace, '')
+        const isStyleSuffix =
+          !rest ||
+          /^[-_\s]/.test(rest) ||
+          STYLE_KEYWORDS.some((k) => rest.toLowerCase().includes(k.toLowerCase()))
+
+        if (isStyleSuffix) return true
+      }
+      return false
+    })
+  }, [fontCandidates, currentFontFamilyName])
+
+  const currentVariantsWithLabels = useMemo(() => {
+    if (!currentVariants) return []
+
+    // First pass: generate all labels
+    const mapped = currentVariants.map((v) => ({
+      variant: v,
+      label: getLocalizedFontLabel(v, t),
+    }))
+
+    // Second pass: identify duplicates
+    return mapped.map((item) => {
+      const isDuplicate =
+        mapped.filter(
+          (other) =>
+            other.variant.postScriptName !== item.variant.postScriptName &&
+            other.label === item.label,
+        ).length > 0
+
+      return {
+        ...item,
+        isDuplicate,
+      }
+    })
+  }, [currentVariants, t])
 
   const selectedStyle = selectedNode?.data.style ?? firstNode?.data.style
   const colorSource = selectedNode ?? firstNode
@@ -192,6 +283,12 @@ export function RenderControlsPanel() {
     selectedNode?.data.style?.textAlign ??
     firstNode?.data.style?.textAlign ??
     (selectedNode?.data.translation ? 'center' : 'left')
+
+  const currentFontPreviewState = useGoogleFontPreview(
+    currentFontFace?.source === 'google' ? currentFont : (currentFontFamilyName ?? ''),
+    currentFontFace?.source ?? 'system',
+    true,
+  )
 
   // ---------------------------------------------------------------------------
   // Mutations
@@ -291,6 +388,14 @@ export function RenderControlsPanel() {
     ? 'border-primary/20 bg-primary/10 text-primary'
     : 'border-border/60 bg-muted text-muted-foreground'
 
+  if (!page) {
+    return (
+      <div className='flex items-center justify-center py-6 text-xs text-muted-foreground'>
+        {t('textBlocks.emptyPrompt')}
+      </div>
+    )
+  }
+
   return (
     <div className='flex w-full min-w-0 flex-col gap-2'>
       {/* Scope */}
@@ -307,7 +412,7 @@ export function RenderControlsPanel() {
       </div>
 
       {/* Font + Color */}
-      <div className='flex flex-col gap-0.5'>
+      <div className='flex flex-col gap-0.5' ref={sectionRef}>
         <div className='flex items-baseline justify-between'>
           <span className='text-[10px] font-medium text-muted-foreground uppercase'>
             {t('render.fontLabel')}
@@ -317,25 +422,110 @@ export function RenderControlsPanel() {
           </span>
         </div>
         <div className='flex min-w-0 items-center gap-1.5'>
-          <div className='min-w-0 flex-1'>
+          <div className='min-w-0 flex-[1.5]'>
             <FontSelect
               data-testid='render-font-select'
-              value={currentFont}
-              options={fontCandidates}
-              disabled={fontCandidates.length === 0}
+              value={currentFontFamilyName ?? ''}
+              options={familyOptions}
+              favoriteFonts={favoriteFonts}
+              onToggleFavorite={toggleFavoriteFont}
+              disabled={familyOptions.length === 0}
               placeholder={t('render.fontPlaceholder')}
               triggerStyle={
                 currentFontFamilyName ? { fontFamily: currentFontFamilyName } : undefined
               }
-              onChange={(value) => {
+              contentStyle={
+                sectionWidth > 0 ? { width: sectionWidth, maxWidth: sectionWidth } : undefined
+              }
+              onChange={async (value) => {
+                const familyVariants = fontCandidates.filter((f) => f.familyName === value)
+                // Try to find Regular/400 first
+                const regularFace =
+                  familyVariants.find((f) => {
+                    const ps = f.postScriptName.toLowerCase()
+                    return ps.includes('regular') || ps.includes('400') || ps.includes(':400')
+                  }) || familyVariants[0]
+
+                const face = regularFace || findFontFace(fontCandidates, value)
+                if (!face) return
+
+                // Trigger fetch for Google Fonts if not cached
+                if (face.source === 'google' && !face.cached) {
+                  try {
+                    await fetchGoogleFont(face.postScriptName)
+                    invalidateScene()
+                  } catch (e) {
+                    console.error('Failed to fetch font:', e)
+                  }
+                }
+
                 if (selectedNode) {
-                  applyStyleToSelected({ fontFamilies: [value] })
+                  applyStyleToSelected({ fontFamilies: [face.postScriptName] })
                   return
                 }
-                usePreferencesStore.getState().setDefaultFont(value)
+                usePreferencesStore.getState().setDefaultFont(face.postScriptName)
               }}
             />
           </div>
+          {currentVariants && currentVariants.length > 1 && (
+            <div className='min-w-0 flex-1'>
+              <Select
+                key={`${currentFontFamilyName}-${currentVariants.length}`}
+                value={currentFont}
+                onValueChange={async (value) => {
+                  // Trigger fetch for Google Fonts if not cached
+                  const variant = currentVariants.find((v) => v.postScriptName === value)
+                  if (variant?.source === 'google' && !variant.cached) {
+                    try {
+                      await fetchGoogleFont(value)
+                      invalidateScene()
+                    } catch (e) {
+                      console.error('Failed to fetch font variant:', e)
+                    }
+                  }
+
+                  if (selectedNode) {
+                    applyStyleToSelected({ fontFamilies: [value] })
+                    return
+                  }
+                  usePreferencesStore.getState().setDefaultFont(value)
+                }}
+              >
+                <SelectTrigger
+                  className='h-7 w-full px-2 text-xs'
+                  style={{
+                    fontFamily:
+                      currentFontPreviewState === 'ready'
+                        ? `"${(currentFontFace?.source === 'google' ? currentFont : (currentFontFamilyName ?? '')).replace(':', '-')}"`
+                        : undefined,
+                  }}
+                >
+                  <SelectValue placeholder='Style' />
+                </SelectTrigger>
+                <SelectContent
+                  position='popper'
+                  style={
+                    sectionWidth > 0 ? { width: sectionWidth, maxWidth: sectionWidth } : undefined
+                  }
+                  className='overflow-hidden p-0'
+                  align='start'
+                  sideOffset={4}
+                >
+                  {currentVariantsWithLabels.map(({ variant, label, isDuplicate }) => (
+                    <VariantItem
+                      key={variant.postScriptName}
+                      variant={variant}
+                      label={
+                        isDuplicate
+                          ? `${label} (${variant.source === 'google' ? 'Google' : 'System'})`
+                          : label
+                      }
+                    />
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
           <ColorPicker
             value={currentColorHex}
             disabled={!hasNodes}

--- a/ui/components/ui/font-select.tsx
+++ b/ui/components/ui/font-select.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useVirtualizer } from '@tanstack/react-virtual'
-import { CheckIcon, ChevronDownIcon } from 'lucide-react'
+import { CheckIcon, ChevronDownIcon, StarIcon } from 'lucide-react'
 import { useRef, useState, useMemo, useCallback, useEffect } from 'react'
 
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
@@ -25,16 +25,19 @@ type FontLoadState = 'idle' | 'loading' | 'ready' | 'error'
 type FontSelectProps = {
   value: string
   options: FontOption[]
+  favoriteFonts?: string[]
+  onToggleFavorite?: (font: string) => void
   disabled?: boolean
   placeholder?: string
   className?: string
   triggerClassName?: string
   triggerStyle?: React.CSSProperties
+  contentStyle?: React.CSSProperties
   onChange: (value: string) => void
   'data-testid'?: string
 }
 
-function useGoogleFontPreview(family: string, source: string, isVisible: boolean) {
+export function useGoogleFontPreview(family: string, source: string, isVisible: boolean) {
   const [state, setState] = useState<FontLoadState>(source === 'system' ? 'ready' : 'idle')
   const stateRef = useRef(state)
   stateRef.current = state
@@ -49,7 +52,9 @@ function useGoogleFontPreview(family: string, source: string, isVisible: boolean
       .then(() => {
         if (cancelled) return
         const url = getGetGoogleFontFileUrl(encodeURIComponent(family), 'file')
-        const face = new FontFace(family, `url(${url})`)
+        // Sanitize name for browser (replace : with -)
+        const safeName = family.replace(':', '-')
+        const face = new FontFace(safeName, `url(${url})`)
         return face.load()
       })
       .then((face) => {
@@ -73,41 +78,89 @@ function useGoogleFontPreview(family: string, source: string, isVisible: boolean
 function FontRow({
   font,
   selected,
+  isFavorite,
   style,
   isVisible,
   onClick,
+  onToggleFavorite,
 }: {
   font: FontOption
   selected: boolean
+  isFavorite: boolean
   style: React.CSSProperties
   isVisible: boolean
   onClick: () => void
+  onToggleFavorite?: (font: string) => void
 }) {
-  const loadState = useGoogleFontPreview(font.familyName, font.source, isVisible)
+  const loadState = useGoogleFontPreview(
+    font.source === 'google' ? font.postScriptName : font.familyName,
+    font.source,
+    isVisible,
+  )
+
+  const variantInfo = useMemo(() => {
+    const { postScriptName } = font
+    const parts = postScriptName.split(':')
+    if (parts.length < 2) return { weight: 'normal', style: 'normal' }
+    const variantStr = parts[1]
+    const weight = variantStr.replace(/\D/g, '') || '400'
+    const style = variantStr.includes('i') ? 'italic' : 'normal'
+    return { weight, style }
+  }, [font])
+
+  const variantLabel = useMemo(() => {
+    const { familyName, postScriptName } = font
+    if (postScriptName === familyName) return undefined
+    let s = font.postScriptName
+    if (s.startsWith(font.familyName)) {
+      s = s.slice(font.familyName.length).replace(/^[:\-_\s]+/, '')
+    }
+    s = s.replace(/MT$/, '').replace(/PS$/, '')
+    return s || undefined
+  }, [font])
+
+  const effectiveFontFamily = useMemo(() => {
+    if (loadState !== 'ready') return undefined
+    const name = font.source === 'google' ? font.postScriptName.replace(':', '-') : font.familyName
+    return `"${name}"`
+  }, [loadState, font])
 
   return (
-    <button
-      type='button'
+    <div
       className={cn(
         'absolute left-0 flex w-full cursor-default items-center gap-1.5 rounded-sm px-2 text-xs select-none hover:bg-accent hover:text-accent-foreground',
         selected && 'bg-accent',
       )}
       style={{
         ...style,
-        fontFamily: loadState === 'ready' ? font.familyName : undefined,
+        fontFamily: effectiveFontFamily,
+        fontWeight:
+          loadState === 'ready' && font.source === 'system' ? variantInfo.weight : undefined,
+        fontStyle:
+          loadState === 'ready' && font.source === 'system' ? variantInfo.style : undefined,
       }}
       onClick={onClick}
     >
       <span className='flex size-3 shrink-0 items-center justify-center'>
         {selected && <CheckIcon className='size-3' />}
       </span>
-      <span className='truncate'>{font.familyName}</span>
-      {font.source === 'google' && (
-        <span className='ml-auto shrink-0 text-[9px] text-muted-foreground'>
-          {loadState === 'loading' ? '...' : 'G'}
-        </span>
+      <span className='flex-1 truncate text-left'>{font.familyName}</span>
+      {onToggleFavorite && (
+        <button
+          type='button'
+          className={cn(
+            'flex size-5 shrink-0 items-center justify-center rounded-md hover:bg-muted-foreground/10',
+            isFavorite ? 'text-yellow-500' : 'text-muted-foreground/30 hover:text-muted-foreground',
+          )}
+          onClick={(e) => {
+            e.stopPropagation()
+            onToggleFavorite(font.postScriptName)
+          }}
+        >
+          <StarIcon className={cn('size-3', isFavorite && 'fill-current')} />
+        </button>
       )}
-    </button>
+    </div>
   )
 }
 
@@ -130,15 +183,21 @@ export function FontSelect({
 
   const filtered = useMemo(() => {
     let result = options
-    if (categoryFilter) {
+    if (categoryFilter === 'favs') {
+      result = result.filter((f) => props.favoriteFonts?.includes(f.postScriptName))
+    } else if (categoryFilter) {
       result = result.filter((f) => f.source === 'system' || f.category === categoryFilter)
     }
     if (search) {
       const lower = search.toLowerCase()
-      result = result.filter((f) => f.familyName.toLowerCase().includes(lower))
+      result = result.filter(
+        (f) =>
+          f.familyName.toLowerCase().includes(lower) ||
+          f.postScriptName.toLowerCase().includes(lower),
+      )
     }
     return result
-  }, [options, search, categoryFilter])
+  }, [options, search, categoryFilter, props.favoriteFonts])
 
   const virtualizer = useVirtualizer({
     count: filtered.length,
@@ -157,9 +216,11 @@ export function FontSelect({
     [open],
   )
 
-  const selectedLabel = options.find(
-    (f) => f.postScriptName === value || f.familyName === value,
-  )?.familyName
+  const selectedLabel = useMemo(() => {
+    const found =
+      options.find((f) => f.postScriptName === value) || options.find((f) => f.familyName === value)
+    return found?.familyName
+  }, [options, value])
 
   const listHeight = Math.min(filtered.length, MAX_VISIBLE) * ITEM_HEIGHT
 
@@ -184,7 +245,8 @@ export function FontSelect({
         <ChevronDownIcon className='size-3.5 shrink-0 opacity-50' />
       </PopoverTrigger>
       <PopoverContent
-        className={cn('w-(--radix-popover-trigger-width) p-0', className)}
+        className={cn('overflow-hidden p-0', className)}
+        style={props.contentStyle}
         align='start'
         onOpenAutoFocus={(e) => {
           e.preventDefault()
@@ -200,8 +262,16 @@ export function FontSelect({
         />
         <ScrollArea className='border-b'>
           <div className='flex gap-0.5 px-1.5 py-1'>
-            {['all', 'hand', 'display', 'sans', 'serif', 'mono'].map((cat, i) => {
-              const full = ['all', 'handwriting', 'display', 'sans-serif', 'serif', 'monospace'][i]
+            {['favs', 'all', 'hand', 'display', 'sans', 'serif', 'mono'].map((cat, i) => {
+              const full = [
+                'favs',
+                'all',
+                'handwriting',
+                'display',
+                'sans-serif',
+                'serif',
+                'monospace',
+              ][i]
               const active = cat === 'all' ? !categoryFilter : categoryFilter === full
               return (
                 <button
@@ -215,7 +285,11 @@ export function FontSelect({
                   )}
                   onClick={() => setCategoryFilter(cat === 'all' ? null : full)}
                 >
-                  {cat.charAt(0).toUpperCase() + cat.slice(1)}
+                  {cat === 'favs' ? (
+                    <StarIcon className='size-2.5 fill-current' />
+                  ) : (
+                    cat.charAt(0).toUpperCase() + cat.slice(1)
+                  )}
                 </button>
               )
             })}
@@ -232,11 +306,13 @@ export function FontSelect({
             {virtualizer.getVirtualItems().map((vi) => {
               const font = filtered[vi.index]
               const selected = font.postScriptName === value || font.familyName === value
+              const isFavorite = props.favoriteFonts?.includes(font.postScriptName) ?? false
               return (
                 <FontRow
                   key={vi.key}
                   font={font}
                   selected={selected}
+                  isFavorite={isFavorite}
                   style={{ height: ITEM_HEIGHT, top: vi.start }}
                   isVisible={true}
                   onClick={() => {
@@ -244,6 +320,7 @@ export function FontSelect({
                     setOpen(false)
                     setSearch('')
                   }}
+                  onToggleFavorite={props.onToggleFavorite}
                 />
               )
             })}

--- a/ui/components/ui/font-select.tsx
+++ b/ui/components/ui/font-select.tsx
@@ -108,17 +108,6 @@ function FontRow({
     return { weight, style }
   }, [font])
 
-  const variantLabel = useMemo(() => {
-    const { familyName, postScriptName } = font
-    if (postScriptName === familyName) return undefined
-    let s = font.postScriptName
-    if (s.startsWith(font.familyName)) {
-      s = s.slice(font.familyName.length).replace(/^[:\-_\s]+/, '')
-    }
-    s = s.replace(/MT$/, '').replace(/PS$/, '')
-    return s || undefined
-  }, [font])
-
   const effectiveFontFamily = useMemo(() => {
     if (loadState !== 'ready') return undefined
     const name = font.source === 'google' ? font.postScriptName.replace(':', '-') : font.familyName
@@ -127,8 +116,10 @@ function FontRow({
 
   return (
     <div
+      role='button'
+      tabIndex={0}
       className={cn(
-        'absolute left-0 flex w-full cursor-default items-center gap-1.5 rounded-sm px-2 text-xs select-none hover:bg-accent hover:text-accent-foreground',
+        'absolute left-0 flex w-full cursor-default items-center gap-1.5 rounded-sm px-2 text-xs outline-none select-none hover:bg-accent hover:text-accent-foreground focus-visible:bg-accent focus-visible:text-accent-foreground',
         selected && 'bg-accent',
       )}
       style={{
@@ -140,6 +131,12 @@ function FontRow({
           loadState === 'ready' && font.source === 'system' ? variantInfo.style : undefined,
       }}
       onClick={onClick}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          onClick()
+        }
+      }}
     >
       <span className='flex size-3 shrink-0 items-center justify-center'>
         {selected && <CheckIcon className='size-3' />}

--- a/ui/components/ui/variant-item.tsx
+++ b/ui/components/ui/variant-item.tsx
@@ -1,12 +1,10 @@
 'use client'
 
 import React, { useMemo } from 'react'
-import { useTranslation } from 'react-i18next'
 
 import { useGoogleFontPreview } from '@/components/ui/font-select'
 import { SelectItem } from '@/components/ui/select'
 import { type FontFaceInfo } from '@/lib/api/schemas'
-import { getLocalizedFontLabel } from '@/lib/font-utils'
 
 interface VariantItemProps {
   variant: FontFaceInfo

--- a/ui/components/ui/variant-item.tsx
+++ b/ui/components/ui/variant-item.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+import React, { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { useGoogleFontPreview } from '@/components/ui/font-select'
+import { SelectItem } from '@/components/ui/select'
+import { type FontFaceInfo } from '@/lib/api/schemas'
+import { getLocalizedFontLabel } from '@/lib/font-utils'
+
+interface VariantItemProps {
+  variant: FontFaceInfo
+  label: string
+}
+
+export function VariantItem({ variant, label }: VariantItemProps) {
+  const loadState = useGoogleFontPreview(
+    variant.source === 'google' ? variant.postScriptName : variant.familyName,
+    variant.source,
+    true,
+  )
+
+  const variantInfo = useMemo(() => {
+    const { postScriptName } = variant
+    const parts = postScriptName.split(':')
+    if (parts.length < 2) return { weight: 'normal', style: 'normal' }
+    const variantStr = parts[1]
+    const weight = variantStr.replace(/\D/g, '') || '400'
+    const style = variantStr.includes('i') ? 'italic' : 'normal'
+    return { weight, style }
+  }, [variant])
+
+  const effectiveFontFamily = useMemo(() => {
+    if (loadState !== 'ready') return undefined
+    const name =
+      variant.source === 'google' ? variant.postScriptName.replace(':', '-') : variant.familyName
+    return `"${name}"`
+  }, [loadState, variant])
+
+  return (
+    <SelectItem
+      value={variant.postScriptName}
+      className='overflow-hidden text-xs'
+      style={{
+        fontFamily: effectiveFontFamily,
+        fontWeight:
+          loadState === 'ready' && variant.source === 'system' ? variantInfo.weight : undefined,
+        fontStyle:
+          loadState === 'ready' && variant.source === 'system' ? variantInfo.style : undefined,
+      }}
+    >
+      <span className='block w-full truncate'>{label}</span>
+    </SelectItem>
+  )
+}

--- a/ui/lib/font-utils.ts
+++ b/ui/lib/font-utils.ts
@@ -1,0 +1,105 @@
+import { type FontFaceInfo } from '@/lib/api/schemas'
+
+export const STYLE_KEYWORDS = [
+  'Bold',
+  'Italic',
+  'Light',
+  'Medium',
+  'Regular',
+  'Condensed',
+  'Black',
+  'Thin',
+  'ExtraBold',
+  'ExtraLight',
+  'Semibold',
+  'Semilight',
+  'DemiBold',
+  'Demibold',
+  'Extra',
+  'Ultra',
+  'UltraBold',
+  'UltraLight',
+  'Heavy',
+  'Book',
+  'Normal',
+  'Oblique',
+]
+
+export const WEIGHT_NAMES: Record<string, string> = {
+  '100': 'render.fontWeights.thin',
+  '200': 'render.fontWeights.extraLight',
+  '300': 'render.fontWeights.light',
+  '400': 'render.fontWeights.regular',
+  '500': 'render.fontWeights.medium',
+  '600': 'render.fontWeights.semiBold',
+  '700': 'render.fontWeights.bold',
+  '800': 'render.fontWeights.extraBold',
+  '900': 'render.fontWeights.black',
+}
+
+export const normalizeFamilyName = (name: string) => {
+  let normalized = name.trim()
+  // Sort keywords by length descending to match longer ones (ExtraBold) before shorter ones (Bold)
+  const keywords = [...STYLE_KEYWORDS].sort((a, b) => b.length - a.length)
+  // Remove common style suffixes. Handles "Arial Bold", "Arial-Bold", and "ArialBold".
+  const regex = new RegExp(`[\\s\\-_]?(${keywords.join('|')})$`, 'i')
+  normalized = normalized.replace(regex, '').trim()
+  return normalized
+}
+
+export const uniqueFontFaces = (values: FontFaceInfo[]) => {
+  const seen = new Set<string>()
+  return values.filter((v) => {
+    if (!v.postScriptName || seen.has(v.postScriptName)) return false
+    seen.add(v.postScriptName)
+    return true
+  })
+}
+
+export const findFontFace = (fonts: FontFaceInfo[], value?: string) => {
+  if (!value) return undefined
+  return fonts.find(
+    (f) =>
+      f.postScriptName === value || f.familyName === value || f.familyName.trim() === value.trim(),
+  )
+}
+
+/**
+ * Generates a localized label for a font variant.
+ * @param face The font face info
+ * @param t The translation function (i18next)
+ */
+export const getLocalizedFontLabel = (
+  face: FontFaceInfo,
+  t: (key: string, options?: any) => string,
+) => {
+  const familyNorm = face.familyName.replace(/[\s\-_]+/g, '').toLowerCase()
+  const familyRegex = new RegExp(`^${familyNorm}`, 'i')
+  let psNorm = face.postScriptName.replace(/[\s\-_]+/g, '')
+
+  // Try stripping by family name (space-agnostic)
+  let l = psNorm.replace(familyRegex, '')
+
+  // If it didn't strip properly, fallback to colon split
+  if (l === psNorm && face.postScriptName.includes(':')) {
+    l = face.postScriptName.split(':').pop() || l
+  }
+
+  l = l.replace(/^[:\-_]+/, '')
+
+  // Map numeric weights to human names
+  const weightMatch = l.match(/(\d+)/)
+  if (weightMatch) {
+    const weight = weightMatch[1]
+    const isItalic = /i(talic)?$/i.test(l)
+    const key = WEIGHT_NAMES[weight]
+    if (key) {
+      const name = t(key)
+      return isItalic ? t('render.fontStyles.italicWithName', { name }) : name
+    }
+  }
+
+  let res = l.replace(/MT$/, '').replace(/PS$/, '') || t('render.fontWeights.regular')
+  if (res.toLowerCase() === 'italic') res = t('render.fontStyles.regularItalic')
+  return res
+}

--- a/ui/lib/font-utils.ts
+++ b/ui/lib/font-utils.ts
@@ -64,6 +64,10 @@ export const findFontFace = (fonts: FontFaceInfo[], value?: string) => {
   )
 }
 
+export const escapeRegExp = (string: string) => {
+  return string.replace(/[.*+?^${}$()|[\]\\]/g, '\\$&')
+}
+
 /**
  * Generates a localized label for a font variant.
  * @param face The font face info
@@ -74,7 +78,7 @@ export const getLocalizedFontLabel = (
   t: (key: string, options?: any) => string,
 ) => {
   const familyNorm = face.familyName.replace(/[\s\-_]+/g, '').toLowerCase()
-  const familyRegex = new RegExp(`^${familyNorm}`, 'i')
+  const familyRegex = new RegExp(`^${escapeRegExp(familyNorm)}`, 'i')
   let psNorm = face.postScriptName.replace(/[\s\-_]+/g, '')
 
   // Try stripping by family name (space-agnostic)

--- a/ui/lib/stores/preferencesStore.ts
+++ b/ui/lib/stores/preferencesStore.ts
@@ -13,6 +13,8 @@ type PreferencesState = {
   setBrushConfig: (config: Partial<PreferencesState['brushConfig']>) => void
   defaultFont?: string
   setDefaultFont: (font?: string) => void
+  favoriteFonts: string[]
+  toggleFavoriteFont: (font: string) => void
   customSystemPrompt?: string
   setCustomSystemPrompt: (prompt?: string) => void
   codexImagePrompt?: string
@@ -40,6 +42,7 @@ const initialPreferences = {
     size: 36,
     color: '#ffffff',
   },
+  favoriteFonts: [],
   shortcuts: {
     select: 'V',
     block: 'M',
@@ -68,6 +71,12 @@ export const usePreferencesStore = create<PreferencesState>()(
           },
         })),
       setDefaultFont: (font) => set({ defaultFont: font }),
+      toggleFavoriteFont: (font) =>
+        set((state) => ({
+          favoriteFonts: state.favoriteFonts.includes(font)
+            ? state.favoriteFonts.filter((f) => f !== font)
+            : [...state.favoriteFonts, font],
+        })),
       setCustomSystemPrompt: (prompt) => set({ customSystemPrompt: prompt }),
       setCodexImagePrompt: (prompt) => set({ codexImagePrompt: prompt }),
       setCodexImageModel: (model) => set({ codexImageModel: model }),
@@ -125,6 +134,7 @@ export const usePreferencesStore = create<PreferencesState>()(
       partialize: (state) => ({
         brushConfig: state.brushConfig,
         defaultFont: state.defaultFont,
+        favoriteFonts: state.favoriteFonts,
         customSystemPrompt: state.customSystemPrompt,
         codexImagePrompt: state.codexImagePrompt,
         codexImageModel: state.codexImageModel,

--- a/ui/public/locales/en-US/translation.json
+++ b/ui/public/locales/en-US/translation.json
@@ -231,7 +231,22 @@
     "fontScopeGlobal": "Global",
     "fontScopeBlock": "Per block",
     "fontScopeBlockIndex": "Block {{index}}",
-    "fontScopeBlocksCount": "{{count}} blocks"
+    "fontScopeBlocksCount": "{{count}} blocks",
+    "fontWeights": {
+      "thin": "Thin",
+      "extraLight": "Extra Light",
+      "light": "Light",
+      "regular": "Regular",
+      "medium": "Medium",
+      "semiBold": "Semi Bold",
+      "bold": "Bold",
+      "extraBold": "Extra Bold",
+      "black": "Black"
+    },
+    "fontStyles": {
+      "italicWithName": "{{name}} Italic",
+      "regularItalic": "Regular Italic"
+    }
   },
   "textBlocks": {
     "emptyPrompt": "Open an image to see text blocks.",

--- a/ui/public/locales/en-US/translation.json
+++ b/ui/public/locales/en-US/translation.json
@@ -228,6 +228,7 @@
     "fontPlaceholder": "Select font",
     "fontColorLabel": "Font color",
     "fontSizeLabel": "Size",
+    "fontStylePlaceholder": "Style",
     "fontScopeGlobal": "Global",
     "fontScopeBlock": "Per block",
     "fontScopeBlockIndex": "Block {{index}}",

--- a/ui/public/locales/es-ES/translation.json
+++ b/ui/public/locales/es-ES/translation.json
@@ -190,6 +190,7 @@
     "fontPlaceholder": "Seleccionar fuente",
     "fontColorLabel": "Color de fuente",
     "fontSizeLabel": "Tamaño",
+    "fontStylePlaceholder": "Estilo",
     "fontScopeGlobal": "Global",
     "fontScopeBlock": "Por bloque",
     "fontScopeBlockIndex": "Bloque {{index}}",

--- a/ui/public/locales/es-ES/translation.json
+++ b/ui/public/locales/es-ES/translation.json
@@ -198,7 +198,22 @@
     "effectBold": "Negrita",
     "effectBorder": "Borde",
     "strokeColorLabel": "Color del borde",
-    "strokeWidthLabel": "Grosor del borde"
+    "strokeWidthLabel": "Grosor del borde",
+    "fontWeights": {
+      "thin": "Fino",
+      "extraLight": "Extra ligero",
+      "light": "Ligero",
+      "regular": "Regular",
+      "medium": "Medio",
+      "semiBold": "Seminegrilla",
+      "bold": "Negrilla",
+      "extraBold": "Extranegrilla",
+      "black": "Negro"
+    },
+    "fontStyles": {
+      "italicWithName": "{{name}} cursiva",
+      "regularItalic": "Regular cursiva"
+    }
   },
   "textBlocks": {
     "emptyPrompt": "Abre una imagen para ver los bloques de texto.",

--- a/ui/public/locales/ja-JP/translation.json
+++ b/ui/public/locales/ja-JP/translation.json
@@ -198,7 +198,22 @@
     "effectBold": "太字",
     "effectBorder": "縁取り",
     "strokeColorLabel": "縁取りの色",
-    "strokeWidthLabel": "縁取りの太さ"
+    "strokeWidthLabel": "縁取りの太さ",
+    "fontWeights": {
+      "thin": "極細",
+      "extraLight": "特細",
+      "light": "細字",
+      "regular": "標準",
+      "medium": "中字",
+      "semiBold": "中太",
+      "bold": "太字",
+      "extraBold": "極太",
+      "black": "超極太"
+    },
+    "fontStyles": {
+      "italicWithName": "{{name}} イタリック",
+      "regularItalic": "標準 イタリック"
+    }
   },
   "textBlocks": {
     "emptyPrompt": "画像を開くとテキストブロックが表示されます。",

--- a/ui/public/locales/ja-JP/translation.json
+++ b/ui/public/locales/ja-JP/translation.json
@@ -190,6 +190,7 @@
     "fontPlaceholder": "フォントを選択",
     "fontColorLabel": "フォントカラー",
     "fontSizeLabel": "サイズ",
+    "fontStylePlaceholder": "スタイル",
     "fontScopeGlobal": "全体",
     "fontScopeBlock": "ブロックごと",
     "fontScopeBlockIndex": "ブロック {{index}}",

--- a/ui/public/locales/ko-KR/translation.json
+++ b/ui/public/locales/ko-KR/translation.json
@@ -220,7 +220,22 @@
     "fontScopeGlobal": "전역",
     "fontScopeBlock": "블록별",
     "fontScopeBlockIndex": "블록 {{index}}",
-    "fontScopeBlocksCount": "블록 {{count}}개"
+    "fontScopeBlocksCount": "블록 {{count}}개",
+    "fontWeights": {
+      "thin": "가늘게",
+      "extraLight": "매우 얇게",
+      "light": "얇게",
+      "regular": "보통",
+      "medium": "중간",
+      "semiBold": "세미 볼드",
+      "bold": "굵게",
+      "extraBold": "매우 굵게",
+      "black": "가장 굵게"
+    },
+    "fontStyles": {
+      "italicWithName": "{{name}} 이탤릭",
+      "regularItalic": "레귤러 이탤릭"
+    }
   },
   "textBlocks": {
     "emptyPrompt": "텍스트 블록을 보려면 이미지를 열어주세요.",

--- a/ui/public/locales/ko-KR/translation.json
+++ b/ui/public/locales/ko-KR/translation.json
@@ -217,6 +217,7 @@
     "fontPlaceholder": "글꼴 선택",
     "fontColorLabel": "글꼴 색상",
     "fontSizeLabel": "크기",
+    "fontStylePlaceholder": "스타일",
     "fontScopeGlobal": "전역",
     "fontScopeBlock": "블록별",
     "fontScopeBlockIndex": "블록 {{index}}",

--- a/ui/public/locales/pt-BR/translation.json
+++ b/ui/public/locales/pt-BR/translation.json
@@ -199,7 +199,22 @@
     "fontScopeGlobal": "Global",
     "fontScopeBlock": "Por bloco",
     "fontScopeBlockIndex": "Bloco {{index}}",
-    "fontScopeBlocksCount": "{{count}} blocos"
+    "fontScopeBlocksCount": "{{count}} blocos",
+    "fontWeights": {
+      "thin": "Fino",
+      "extraLight": "Extra Leve",
+      "light": "Leve",
+      "regular": "Regular",
+      "medium": "Médio",
+      "semiBold": "Semi Negrito",
+      "bold": "Negrito",
+      "extraBold": "Extra Negrito",
+      "black": "Preto"
+    },
+    "fontStyles": {
+      "italicWithName": "{{name}} Itálico",
+      "regularItalic": "Regular Itálico"
+    }
   },
   "textBlocks": {
     "emptyPrompt": "Abra uma imagem para ver os blocos de texto.",

--- a/ui/public/locales/pt-BR/translation.json
+++ b/ui/public/locales/pt-BR/translation.json
@@ -196,6 +196,7 @@
     "fontPlaceholder": "Selecionar fonte",
     "fontColorLabel": "Cor da fonte",
     "fontSizeLabel": "Tamanho",
+    "fontStylePlaceholder": "Estilo",
     "fontScopeGlobal": "Global",
     "fontScopeBlock": "Por bloco",
     "fontScopeBlockIndex": "Bloco {{index}}",

--- a/ui/public/locales/ru-RU/translation.json
+++ b/ui/public/locales/ru-RU/translation.json
@@ -190,6 +190,7 @@
     "fontPlaceholder": "Выберите шрифт",
     "fontColorLabel": "Цвет шрифта",
     "fontSizeLabel": "Размер",
+    "fontStylePlaceholder": "Стиль",
     "fontScopeGlobal": "Глобально",
     "fontScopeBlock": "Для блока",
     "fontScopeBlockIndex": "Блок {{index}}",

--- a/ui/public/locales/ru-RU/translation.json
+++ b/ui/public/locales/ru-RU/translation.json
@@ -198,7 +198,22 @@
     "effectBold": "Жирный",
     "effectBorder": "Обводка",
     "strokeColorLabel": "Цвет обводки",
-    "strokeWidthLabel": "Толщина обводки"
+    "strokeWidthLabel": "Толщина обводки",
+    "fontWeights": {
+      "thin": "Тонкий",
+      "extraLight": "Сверхсветлый",
+      "light": "Светлый",
+      "regular": "Обычный",
+      "medium": "Средний",
+      "semiBold": "Полужирный",
+      "bold": "Жирный",
+      "extraBold": "Сверхжирный",
+      "black": "Черный"
+    },
+    "fontStyles": {
+      "italicWithName": "{{name}} Курсив",
+      "regularItalic": "Обычный Курсив"
+    }
   },
   "textBlocks": {
     "emptyPrompt": "Откройте изображение, чтобы увидеть текстовые блоки.",

--- a/ui/public/locales/tr-TR/translation.json
+++ b/ui/public/locales/tr-TR/translation.json
@@ -198,7 +198,22 @@
     "fontScopeGlobal": "Genel",
     "fontScopeBlock": "Blok bazında",
     "fontScopeBlockIndex": "Blok {{index}}",
-    "fontScopeBlocksCount": "{{count}} blok"
+    "fontScopeBlocksCount": "{{count}} blok",
+    "fontWeights": {
+      "thin": "İnce",
+      "extraLight": "Ekstra Hafif",
+      "light": "Hafif",
+      "regular": "Normal",
+      "medium": "Orta",
+      "semiBold": "Yarı Kalın",
+      "bold": "Kalın",
+      "extraBold": "Ekstra Kalın",
+      "black": "Siyah"
+    },
+    "fontStyles": {
+      "italicWithName": "{{name}} İtalik",
+      "regularItalic": "Normal İtalik"
+    }
   },
   "textBlocks": {
     "emptyPrompt": "Metin bloklarını görmek için bir görsel açın.",

--- a/ui/public/locales/tr-TR/translation.json
+++ b/ui/public/locales/tr-TR/translation.json
@@ -195,6 +195,7 @@
     "fontPlaceholder": "Yazı tipi seç",
     "fontColorLabel": "Yazı rengi",
     "fontSizeLabel": "Boyut",
+    "fontStylePlaceholder": "Stil",
     "fontScopeGlobal": "Genel",
     "fontScopeBlock": "Blok bazında",
     "fontScopeBlockIndex": "Blok {{index}}",

--- a/ui/public/locales/zh-CN/translation.json
+++ b/ui/public/locales/zh-CN/translation.json
@@ -190,6 +190,7 @@
     "fontPlaceholder": "选择字体",
     "fontColorLabel": "字体颜色",
     "fontSizeLabel": "大小",
+    "fontStylePlaceholder": "样式",
     "fontScopeGlobal": "全局",
     "fontScopeBlock": "按文本块",
     "fontScopeBlockIndex": "文本块 {{index}}",

--- a/ui/public/locales/zh-CN/translation.json
+++ b/ui/public/locales/zh-CN/translation.json
@@ -198,7 +198,22 @@
     "effectBold": "粗体",
     "effectBorder": "描边",
     "strokeColorLabel": "描边颜色",
-    "strokeWidthLabel": "描边宽度"
+    "strokeWidthLabel": "描边宽度",
+    "fontWeights": {
+      "thin": "极细",
+      "extraLight": "特细",
+      "light": "细体",
+      "regular": "常规",
+      "medium": "中等",
+      "semiBold": "半粗",
+      "bold": "粗体",
+      "extraBold": "特粗",
+      "black": "极粗"
+    },
+    "fontStyles": {
+      "italicWithName": "{{name}} 斜体",
+      "regularItalic": "常规斜体"
+    }
   },
   "textBlocks": {
     "emptyPrompt": "打开图像以查看文本块。",

--- a/ui/public/locales/zh-TW/translation.json
+++ b/ui/public/locales/zh-TW/translation.json
@@ -190,6 +190,7 @@
     "fontPlaceholder": "選擇字體",
     "fontColorLabel": "字體顏色",
     "fontSizeLabel": "大小",
+    "fontStylePlaceholder": "樣式",
     "fontScopeGlobal": "全域",
     "fontScopeBlock": "依文字區塊",
     "fontScopeBlockIndex": "文字區塊 {{index}}",

--- a/ui/public/locales/zh-TW/translation.json
+++ b/ui/public/locales/zh-TW/translation.json
@@ -198,7 +198,22 @@
     "effectBold": "粗體",
     "effectBorder": "描邊",
     "strokeColorLabel": "描邊顏色",
-    "strokeWidthLabel": "描邊寬度"
+    "strokeWidthLabel": "描邊寬度",
+    "fontWeights": {
+      "thin": "極細",
+      "extraLight": "特細",
+      "light": "細體",
+      "regular": "正規",
+      "medium": "中等",
+      "semiBold": "半粗",
+      "bold": "粗體",
+      "extraBold": "特粗",
+      "black": "極粗"
+    },
+    "fontStyles": {
+      "italicWithName": "{{name}} 斜體",
+      "regularItalic": "正規斜體"
+    }
   },
   "textBlocks": {
     "emptyPrompt": "開啟影像以查看文字區塊。",


### PR DESCRIPTION
## Summary
This PR implements the ability to save favorite fonts, as well as allows for the selection of different weights and styles for a font family. This also extends to modifying the way google fonts are retrieved to also be able to receive weights and styles.

https://github.com/user-attachments/assets/e7fc22f5-4873-4357-a3ae-97b05445cb7f

## Changes
- `preferencesStore` now stores favorite fonts set by the user.
- Restructured the `RenderControlsPanel` to ensure the new font styles dropdown is seamlessly implemented into the UI
- `variant-item.tsx` component to provide previews of each font style in the menu.
- Added `font-utils.ts` to handle Google Font style/weight naming compatibility by parsing the PostScipt names into more readable names for the user.
- Modified `google_fonts.ts` to included targeted cache retrieval and to decode the new font identifiers
- Standardized google font PostScript naming convention in the `available_fonts` RPC  in `renderer.rs` to allow frontend to identify specific weight and style combinations
- Subsequently updated `select_font` to ensure system correctly routes requests to google font cache