### PR TITLE
feat: huggingface mirror support

### DIFF
--- a/koharu-app/bin/pipeline.rs
+++ b/koharu-app/bin/pipeline.rs
@@ -144,6 +144,7 @@ async fn run() -> Result<()> {
         connect_timeout_secs: cfg.http.connect_timeout.max(1),
         read_timeout_secs: cfg.http.read_timeout.max(1),
         max_retries: cfg.http.max_retries,
+        huggingface_endpoint: cfg.http.huggingface_endpoint.clone(),
     };
     let compute = if cli.cpu {
         ComputePolicy::CpuOnly

--- a/koharu-app/src/config.rs
+++ b/koharu-app/src/config.rs
@@ -107,6 +107,8 @@ pub struct HttpConfig {
     pub connect_timeout: u64,
     pub read_timeout: u64,
     pub max_retries: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub huggingface_endpoint: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
@@ -135,6 +137,7 @@ impl Default for HttpConfig {
             connect_timeout: 20,
             read_timeout: 300,
             max_retries: 3,
+            huggingface_endpoint: None,
         }
     }
 }
@@ -208,6 +211,9 @@ pub fn apply_patch(config: &mut AppConfig, patch: koharu_core::ConfigPatch) {
         }
         if let Some(v) = http.max_retries {
             config.http.max_retries = v;
+        }
+        if let Some(v) = http.huggingface_endpoint {
+            config.http.huggingface_endpoint = normalize_huggingface_endpoint(&v);
         }
     }
     if let Some(p) = patch.pipeline {
@@ -348,6 +354,16 @@ fn validate_engine_name(
     true
 }
 
+fn normalize_huggingface_endpoint(value: &str) -> Option<String> {
+    let endpoint = value.trim().trim_end_matches('/');
+
+    if endpoint.is_empty() {
+        None
+    } else {
+        Some(endpoint.to_string())
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Secret handling
 // ---------------------------------------------------------------------------
@@ -384,7 +400,7 @@ fn provider_api_key_secret_key(provider_id: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use koharu_core::{ConfigPatch, PipelineConfigPatch};
+    use koharu_core::{ConfigPatch, HttpConfigPatch, PipelineConfigPatch};
 
     #[test]
     fn old_config_without_providers_still_loads() {
@@ -400,6 +416,7 @@ mod tests {
         assert_eq!(config.http.connect_timeout, 20);
         assert_eq!(config.http.read_timeout, 300);
         assert_eq!(config.http.max_retries, 3);
+        assert_eq!(config.http.huggingface_endpoint, None);
         assert!(config.providers.is_empty());
     }
 
@@ -416,6 +433,7 @@ mod tests {
         assert_eq!(config.http.connect_timeout, 45);
         assert_eq!(config.http.read_timeout, 300);
         assert_eq!(config.http.max_retries, 3);
+        assert_eq!(config.http.huggingface_endpoint, None);
     }
 
     #[test]
@@ -463,5 +481,44 @@ mod tests {
         );
 
         assert_eq!(config.pipeline.renderer, PipelineConfig::default().renderer);
+    }
+
+    #[test]
+    fn apply_patch_normalizes_huggingface_endpoint() {
+        let mut config = AppConfig::default();
+        apply_patch(
+            &mut config,
+            ConfigPatch {
+                http: Some(HttpConfigPatch {
+                    huggingface_endpoint: Some(" https://hf-mirror.com/// ".to_string()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+        );
+
+        assert_eq!(
+            config.http.huggingface_endpoint.as_deref(),
+            Some("https://hf-mirror.com")
+        );
+    }
+
+    #[test]
+    fn apply_patch_clears_huggingface_endpoint_with_empty_string() {
+        let mut config = AppConfig::default();
+        config.http.huggingface_endpoint = Some("https://hf-mirror.com".to_string());
+
+        apply_patch(
+            &mut config,
+            ConfigPatch {
+                http: Some(HttpConfigPatch {
+                    huggingface_endpoint: Some("   ".to_string()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+        );
+
+        assert_eq!(config.http.huggingface_endpoint, None);
     }
 }

--- a/koharu-core/src/protocol.rs
+++ b/koharu-core/src/protocol.rs
@@ -206,6 +206,7 @@ pub struct HttpConfigPatch {
     pub connect_timeout: Option<u64>,
     pub read_timeout: Option<u64>,
     pub max_retries: Option<u32>,
+    pub huggingface_endpoint: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema, ToSchema)]

--- a/koharu-runtime/src/downloads.rs
+++ b/koharu-runtime/src/downloads.rs
@@ -34,6 +34,7 @@ const HF_METADATA_TIMEOUT: Duration = Duration::from_secs(30);
 pub struct Downloads {
     downloads_root: PathBuf,
     huggingface_cache: Cache,
+    huggingface_endpoint: Option<String>,
     client: RuntimeHttpClient,
     tx: broadcast::Sender<DownloadProgress>,
     progress: Arc<MultiProgress>,
@@ -50,6 +51,10 @@ impl Downloads {
         Ok(Self {
             downloads_root,
             huggingface_cache: Cache::new(huggingface_root),
+            huggingface_endpoint: http
+                .huggingface_endpoint
+                .as_deref()
+                .and_then(normalize_hf_endpoint),
             client,
             tx: broadcast::channel(256).0,
             progress: Arc::new(MultiProgress::new()),
@@ -78,11 +83,15 @@ impl Downloads {
             return Ok(path);
         }
 
-        let api = ApiBuilder::from_cache(self.huggingface_cache.clone())
+        let mut api_builder = ApiBuilder::from_cache(self.huggingface_cache.clone())
             .with_progress(false)
-            .with_user_agent("koharu", env!("CARGO_PKG_VERSION"))
-            .build()
-            .context("failed to build HF Hub API")?;
+            .with_user_agent("koharu", env!("CARGO_PKG_VERSION"));
+
+        if let Some(endpoint) = effective_hf_endpoint(self.huggingface_endpoint.as_deref()) {
+            api_builder = api_builder.with_endpoint(endpoint);
+        }
+
+        let api = api_builder.build().context("failed to build HF Hub API")?;
         let repo_handle = api.model(repo.to_string());
         let url = repo_handle.url(filename);
 
@@ -368,15 +377,69 @@ fn part_path(destination: &Path) -> Result<PathBuf> {
     Ok(destination.with_file_name(format!("{}.part", file_name.to_string_lossy())))
 }
 
+fn normalize_hf_endpoint(value: &str) -> Option<String> {
+    let endpoint = value.trim().trim_end_matches('/');
+
+    if endpoint.is_empty() {
+        None
+    } else {
+        Some(endpoint.to_string())
+    }
+}
+
+fn effective_hf_endpoint(configured: Option<&str>) -> Option<String> {
+    hf_endpoint_from_sources(configured, std::env::var("HF_ENDPOINT").ok().as_deref())
+}
+
+fn hf_endpoint_from_sources(configured: Option<&str>, env: Option<&str>) -> Option<String> {
+    configured
+        .and_then(normalize_hf_endpoint)
+        .or_else(|| env.and_then(normalize_hf_endpoint))
+}
+
 #[cfg(test)]
 mod tests {
     use std::path::Path;
 
-    use super::part_path;
+    use super::{hf_endpoint_from_sources, normalize_hf_endpoint, part_path};
 
     #[test]
     fn partial_download_path_appends_suffix() {
         let part = part_path(Path::new("/tmp/models/config.json")).unwrap();
         assert_eq!(part, Path::new("/tmp/models/config.json.part"));
+    }
+
+    #[test]
+    fn normalizes_hf_endpoint() {
+        assert_eq!(
+            normalize_hf_endpoint(" https://hf-mirror.com/ "),
+            Some("https://hf-mirror.com".to_string())
+        );
+        assert_eq!(
+            normalize_hf_endpoint("https://hf-mirror.com///"),
+            Some("https://hf-mirror.com".to_string())
+        );
+        assert_eq!(normalize_hf_endpoint(""), None);
+        assert_eq!(normalize_hf_endpoint("   "), None);
+    }
+
+    #[test]
+    fn hf_endpoint_prefers_configured_value_over_env() {
+        assert_eq!(
+            hf_endpoint_from_sources(
+                Some(" https://configured.example/ "),
+                Some("https://env.example")
+            ),
+            Some("https://configured.example".to_string())
+        );
+    }
+
+    #[test]
+    fn hf_endpoint_falls_back_to_env() {
+        assert_eq!(
+            hf_endpoint_from_sources(None, Some(" https://env.example/ ")),
+            Some("https://env.example".to_string())
+        );
+        assert_eq!(hf_endpoint_from_sources(Some("   "), Some("   ")), None);
     }
 }

--- a/koharu-runtime/src/runtime.rs
+++ b/koharu-runtime/src/runtime.rs
@@ -26,6 +26,7 @@ pub struct RuntimeHttpConfig {
     pub connect_timeout_secs: u64,
     pub read_timeout_secs: u64,
     pub max_retries: u32,
+    pub huggingface_endpoint: Option<String>,
 }
 
 impl Default for RuntimeHttpConfig {
@@ -34,6 +35,7 @@ impl Default for RuntimeHttpConfig {
             connect_timeout_secs: 20,
             read_timeout_secs: 300,
             max_retries: 3,
+            huggingface_endpoint: None,
         }
     }
 }

--- a/koharu/src/app.rs
+++ b/koharu/src/app.rs
@@ -67,6 +67,7 @@ pub async fn run() -> Result<()> {
         connect_timeout_secs: config.http.connect_timeout.max(1),
         read_timeout_secs: config.http.read_timeout.max(1),
         max_retries: config.http.max_retries,
+        huggingface_endpoint: config.http.huggingface_endpoint.clone(),
     };
     let compute = if cli.cpu {
         ComputePolicy::CpuOnly

--- a/tests/integration-tests/src/harness.rs
+++ b/tests/integration-tests/src/harness.rs
@@ -44,6 +44,7 @@ async fn shared_runtime() -> Result<Arc<RuntimeManager>> {
                 connect_timeout_secs: 30,
                 read_timeout_secs: 600,
                 max_retries: 2,
+                huggingface_endpoint: None,
             };
             let runtime =
                 RuntimeManager::new_with_http(root.as_std_path(), ComputePolicy::CpuOnly, http)?;

--- a/ui/components/SettingsDialog.tsx
+++ b/ui/components/SettingsDialog.tsx
@@ -103,6 +103,7 @@ function appConfigToPatch(cfg: AppConfig): ConfigPatch {
       connectTimeout: cfg.http.connect_timeout,
       readTimeout: cfg.http.read_timeout,
       maxRetries: cfg.http.max_retries,
+      huggingfaceEndpoint: cfg.http.huggingface_endpoint ?? '',
     }
   }
   if (cfg.pipeline) {
@@ -155,6 +156,11 @@ const DEFAULT_HTTP_CONNECT_TIMEOUT = 20
 const DEFAULT_HTTP_READ_TIMEOUT = 300
 const DEFAULT_HTTP_MAX_RETRIES = 3
 
+function normalizeHuggingFaceEndpointDraft(value: string): string | null {
+  const endpoint = value.trim().replace(/\/+$/, '')
+  return endpoint ? endpoint : null
+}
+
 export function SettingsDialog({
   open,
   onOpenChange,
@@ -174,6 +180,7 @@ export function SettingsDialog({
   const [httpConnectTimeoutDraft, setHttpConnectTimeoutDraft] = useState('')
   const [httpReadTimeoutDraft, setHttpReadTimeoutDraft] = useState('')
   const [httpMaxRetriesDraft, setHttpMaxRetriesDraft] = useState('')
+  const [huggingfaceEndpointDraft, setHuggingfaceEndpointDraft] = useState('')
   const [storageSettingsError, setStorageSettingsError] = useState<string | null>(null)
   const [isSavingStorageSettings, setIsSavingStorageSettings] = useState(false)
   const [engineCatalog, setEngineCatalog] = useState<GetEngineCatalog200 | null>(null)
@@ -227,6 +234,7 @@ export function SettingsDialog({
     )
     setHttpReadTimeoutDraft(String(appConfig.http?.read_timeout ?? DEFAULT_HTTP_READ_TIMEOUT))
     setHttpMaxRetriesDraft(String(appConfig.http?.max_retries ?? DEFAULT_HTTP_MAX_RETRIES))
+    setHuggingfaceEndpointDraft(appConfig.http?.huggingface_endpoint ?? '')
     setStorageSettingsError(null)
   }, [appConfig])
 
@@ -275,6 +283,7 @@ export function SettingsDialog({
       setStorageSettingsError('Invalid HTTP max retries')
       return
     }
+    const huggingfaceEndpoint = normalizeHuggingFaceEndpointDraft(huggingfaceEndpointDraft)
 
     setIsSavingStorageSettings(true)
     setStorageSettingsError(null)
@@ -285,6 +294,7 @@ export function SettingsDialog({
         connect_timeout: connectTimeout,
         read_timeout: readTimeout,
         max_retries: maxRetries,
+        huggingface_endpoint: huggingfaceEndpoint,
       },
     })
     setIsSavingStorageSettings(false)
@@ -310,7 +320,9 @@ export function SettingsDialog({
       String(appConfig?.http?.connect_timeout ?? DEFAULT_HTTP_CONNECT_TIMEOUT) &&
     httpReadTimeoutDraft.trim() ===
       String(appConfig?.http?.read_timeout ?? DEFAULT_HTTP_READ_TIMEOUT) &&
-    httpMaxRetriesDraft.trim() === String(appConfig?.http?.max_retries ?? DEFAULT_HTTP_MAX_RETRIES)
+    httpMaxRetriesDraft.trim() === String(appConfig?.http?.max_retries ?? DEFAULT_HTTP_MAX_RETRIES) &&
+    (normalizeHuggingFaceEndpointDraft(huggingfaceEndpointDraft) ?? '') ===
+      (appConfig?.http?.huggingface_endpoint ?? '')
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -404,6 +416,7 @@ export function SettingsDialog({
                   httpConnectTimeout={httpConnectTimeoutDraft}
                   httpReadTimeout={httpReadTimeoutDraft}
                   httpMaxRetries={httpMaxRetriesDraft}
+                  huggingfaceEndpoint={huggingfaceEndpointDraft}
                   error={storageSettingsError}
                   saving={isSavingStorageSettings}
                   unchanged={storageSettingsUnchanged}
@@ -421,6 +434,10 @@ export function SettingsDialog({
                   }}
                   onHttpMaxRetriesChange={(v) => {
                     setHttpMaxRetriesDraft(v)
+                    setStorageSettingsError(null)
+                  }}
+                  onHuggingfaceEndpointChange={(v) => {
+                    setHuggingfaceEndpointDraft(v)
                     setStorageSettingsError(null)
                   }}
                   onApply={() => void handleApplyStorageSettings()}
@@ -1146,6 +1163,7 @@ function StoragePane({
   httpConnectTimeout,
   httpReadTimeout,
   httpMaxRetries,
+  huggingfaceEndpoint,
   error,
   saving,
   unchanged,
@@ -1153,12 +1171,14 @@ function StoragePane({
   onHttpConnectTimeoutChange,
   onHttpReadTimeoutChange,
   onHttpMaxRetriesChange,
+  onHuggingfaceEndpointChange,
   onApply,
 }: {
   dataPath: string
   httpConnectTimeout: string
   httpReadTimeout: string
   httpMaxRetries: string
+  huggingfaceEndpoint: string
   error: string | null
   saving: boolean
   unchanged: boolean
@@ -1166,6 +1186,7 @@ function StoragePane({
   onHttpConnectTimeoutChange: (v: string) => void
   onHttpReadTimeoutChange: (v: string) => void
   onHttpMaxRetriesChange: (v: string) => void
+  onHuggingfaceEndpointChange: (v: string) => void
   onApply: () => void
 }) {
   const { t } = useTranslation()
@@ -1226,6 +1247,19 @@ function StoragePane({
           />
           <p className='text-xs leading-relaxed text-muted-foreground'>
             {t('settings.httpMaxRetriesDescription')}
+          </p>
+        </div>
+
+        <div className='space-y-1.5'>
+          <Label className='text-xs'>{t('settings.huggingfaceEndpoint')}</Label>
+          <Input
+            type='url'
+            value={huggingfaceEndpoint}
+            placeholder='https://hf-mirror.com'
+            onChange={(e) => onHuggingfaceEndpointChange(e.target.value)}
+          />
+          <p className='text-xs leading-relaxed text-muted-foreground'>
+            {t('settings.huggingfaceEndpointDescription')}
           </p>
         </div>
 

--- a/ui/lib/api/default/default.msw.ts
+++ b/ui/lib/api/default/default.msw.ts
@@ -124,6 +124,10 @@ export const getGetConfigResponseHttpConfigMock = (
 ): HttpConfig => ({
   ...{
     connect_timeout: faker.number.int({ min: 0 }),
+    huggingface_endpoint: faker.helpers.arrayElement([
+      faker.helpers.arrayElement([faker.string.alpha({ length: { min: 10, max: 20 } }), null]),
+      null,
+    ]),
     max_retries: faker.number.int({ min: 0 }),
     read_timeout: faker.number.int({ min: 0 }),
   },
@@ -180,6 +184,10 @@ export const getPatchConfigResponseHttpConfigMock = (
 ): HttpConfig => ({
   ...{
     connect_timeout: faker.number.int({ min: 0 }),
+    huggingface_endpoint: faker.helpers.arrayElement([
+      faker.helpers.arrayElement([faker.string.alpha({ length: { min: 10, max: 20 } }), null]),
+      null,
+    ]),
     max_retries: faker.number.int({ min: 0 }),
     read_timeout: faker.number.int({ min: 0 }),
   },

--- a/ui/lib/api/schemas/httpConfig.ts
+++ b/ui/lib/api/schemas/httpConfig.ts
@@ -7,6 +7,8 @@
 export interface HttpConfig {
   /** @minimum 0 */
   connect_timeout?: number
+  /** @nullable */
+  huggingface_endpoint?: string | null
   /** @minimum 0 */
   max_retries?: number
   /** @minimum 0 */

--- a/ui/lib/api/schemas/httpConfigPatch.ts
+++ b/ui/lib/api/schemas/httpConfigPatch.ts
@@ -10,6 +10,8 @@ export interface HttpConfigPatch {
    * @nullable
    */
   connectTimeout?: number | null
+  /** @nullable */
+  huggingfaceEndpoint?: string | null
   /**
    * @minimum 0
    * @nullable

--- a/ui/openapi.json
+++ b/ui/openapi.json
@@ -1629,6 +1629,10 @@
             "default": 20,
             "minimum": 0
           },
+          "huggingface_endpoint": {
+            "type": ["string", "null"],
+            "default": null
+          },
           "max_retries": {
             "type": "integer",
             "format": "int32",
@@ -1650,6 +1654,9 @@
             "type": ["integer", "null"],
             "format": "int64",
             "minimum": 0
+          },
+          "huggingfaceEndpoint": {
+            "type": ["string", "null"]
           },
           "maxRetries": {
             "type": ["integer", "null"],

--- a/ui/public/locales/en-US/translation.json
+++ b/ui/public/locales/en-US/translation.json
@@ -387,6 +387,8 @@
     "httpReadTimeoutDescription": "Maximum time to wait for HTTP response reads before failing.",
     "httpMaxRetries": "HTTP Max Retries",
     "httpMaxRetriesDescription": "Number of automatic retries for transient HTTP failures.",
+    "huggingfaceEndpoint": "Hugging Face Mirror",
+    "huggingfaceEndpointDescription": "Optional mirror endpoint for Hugging Face model downloads. Leave blank to use the default endpoint or HF_ENDPOINT.",
     "restartApply": "Apply & Restart",
     "restartApplying": "Applying...",
     "restartRequiredDescription": "These settings are loaded at startup. Applying them will save the config and restart the app.",

--- a/ui/public/locales/es-ES/translation.json
+++ b/ui/public/locales/es-ES/translation.json
@@ -350,6 +350,8 @@
     "httpReadTimeoutDescription": "Tiempo máximo de espera para leer una respuesta HTTP antes de fallar.",
     "httpMaxRetries": "Máximo de reintentos HTTP",
     "httpMaxRetriesDescription": "Número de reintentos automáticos para fallos HTTP transitorios.",
+    "huggingfaceEndpoint": "Mirror de Hugging Face",
+    "huggingfaceEndpointDescription": "Endpoint mirror opcional para descargar modelos de Hugging Face. Déjalo vacío para usar el endpoint predeterminado o HF_ENDPOINT.",
     "restartApply": "Aplicar y reiniciar",
     "restartApplying": "Aplicando...",
     "restartRequiredDescription": "Estos ajustes se cargan al iniciar. Aplicarlos guardará la configuración y reiniciará la aplicación.",

--- a/ui/public/locales/ja-JP/translation.json
+++ b/ui/public/locales/ja-JP/translation.json
@@ -350,6 +350,8 @@
     "httpReadTimeoutDescription": "HTTP レスポンスの読み取りを待つ最大時間です。",
     "httpMaxRetries": "HTTP 最大リトライ回数",
     "httpMaxRetriesDescription": "一時的な HTTP 障害に対して自動再試行する回数です。",
+    "huggingfaceEndpoint": "Hugging Face ミラー",
+    "huggingfaceEndpointDescription": "Hugging Face モデルダウンロード用の任意のミラーエンドポイントです。空欄にすると既定のエンドポイントまたは HF_ENDPOINT を使います。",
     "restartApply": "適用して再起動",
     "restartApplying": "適用中...",
     "restartRequiredDescription": "これらの設定は起動時に読み込まれます。適用すると設定を保存してアプリを再起動します。",

--- a/ui/public/locales/ko-KR/translation.json
+++ b/ui/public/locales/ko-KR/translation.json
@@ -376,6 +376,8 @@
     "httpReadTimeoutDescription": "HTTP 응답을 읽을 때까지 기다리는 최대 시간입니다.",
     "httpMaxRetries": "HTTP 최대 재시도 횟수",
     "httpMaxRetriesDescription": "일시적인 HTTP 실패에 대한 자동 재시도 횟수입니다.",
+    "huggingfaceEndpoint": "Hugging Face 미러",
+    "huggingfaceEndpointDescription": "Hugging Face 모델 다운로드에 사용할 선택적 미러 엔드포인트입니다. 비워 두면 기본 엔드포인트 또는 HF_ENDPOINT를 사용합니다.",
     "restartApply": "적용 후 재시작",
     "restartApplying": "적용 중...",
     "restartRequiredDescription": "이 설정은 시작 시 로드됩니다. 적용하면 구성을 저장하고 앱을 다시 시작합니다.",

--- a/ui/public/locales/pt-BR/translation.json
+++ b/ui/public/locales/pt-BR/translation.json
@@ -351,6 +351,8 @@
     "httpReadTimeoutDescription": "Tempo máximo de espera para ler uma resposta HTTP antes de falhar.",
     "httpMaxRetries": "Máximo de tentativas HTTP",
     "httpMaxRetriesDescription": "Número de tentativas automáticas para falhas HTTP transitórias.",
+    "huggingfaceEndpoint": "Espelho do Hugging Face",
+    "huggingfaceEndpointDescription": "Endpoint de espelho opcional para downloads de modelos do Hugging Face. Deixe em branco para usar o endpoint padrão ou HF_ENDPOINT.",
     "restartApply": "Aplicar e reiniciar",
     "restartApplying": "Aplicando...",
     "restartRequiredDescription": "Essas configurações são carregadas na inicialização. Aplicá-las salvará a configuração e reiniciará o aplicativo.",

--- a/ui/public/locales/ru-RU/translation.json
+++ b/ui/public/locales/ru-RU/translation.json
@@ -350,6 +350,8 @@
     "httpReadTimeoutDescription": "Максимальное время ожидания чтения HTTP-ответа.",
     "httpMaxRetries": "Макс. число HTTP-повторов",
     "httpMaxRetriesDescription": "Количество автоматических повторных попыток при временных HTTP-сбоях.",
+    "huggingfaceEndpoint": "Зеркало Hugging Face",
+    "huggingfaceEndpointDescription": "Необязательный endpoint зеркала для загрузки моделей Hugging Face. Оставьте пустым, чтобы использовать endpoint по умолчанию или HF_ENDPOINT.",
     "restartApply": "Применить и перезапустить",
     "restartApplying": "Применение...",
     "restartRequiredDescription": "Эти настройки загружаются при запуске. Применение сохранит конфигурацию и перезапустит приложение.",

--- a/ui/public/locales/tr-TR/translation.json
+++ b/ui/public/locales/tr-TR/translation.json
@@ -350,6 +350,8 @@
     "httpReadTimeoutDescription": "Bir HTTP yanıtı okunurken beklenecek en uzun süre.",
     "httpMaxRetries": "HTTP Azami Yeniden Deneme",
     "httpMaxRetriesDescription": "Geçici HTTP hatalarında otomatik yeniden deneme sayısı.",
+    "huggingfaceEndpoint": "Hugging Face Aynası",
+    "huggingfaceEndpointDescription": "Hugging Face model indirmeleri için isteğe bağlı ayna uç noktası. Varsayılan uç noktayı veya HF_ENDPOINT değerini kullanmak için boş bırakın.",
     "restartApply": "Uygula ve Yeniden Başlat",
     "restartApplying": "Uygulanıyor...",
     "restartRequiredDescription": "Bu ayarlar başlangıçta yüklenir. Uygulamak yapılandırmayı kaydedip uygulamayı yeniden başlatır.",

--- a/ui/public/locales/zh-CN/translation.json
+++ b/ui/public/locales/zh-CN/translation.json
@@ -350,6 +350,8 @@
     "httpReadTimeoutDescription": "读取 HTTP 响应前允许等待的最长时间。",
     "httpMaxRetries": "HTTP 最大重试次数",
     "httpMaxRetriesDescription": "发生临时 HTTP 故障时自动重试的次数。",
+    "huggingfaceEndpoint": "Hugging Face 镜像",
+    "huggingfaceEndpointDescription": "用于 Hugging Face 模型下载的可选镜像端点。留空则使用默认端点或 HF_ENDPOINT。",
     "restartApply": "应用并重启",
     "restartApplying": "正在应用...",
     "restartRequiredDescription": "这些设置会在启动时加载。应用后会保存配置并重启应用。",

--- a/ui/public/locales/zh-TW/translation.json
+++ b/ui/public/locales/zh-TW/translation.json
@@ -350,6 +350,8 @@
     "httpReadTimeoutDescription": "讀取 HTTP 回應前允許等待的最長時間。",
     "httpMaxRetries": "HTTP 最大重試次數",
     "httpMaxRetriesDescription": "發生暫時性 HTTP 錯誤時自動重試的次數。",
+    "huggingfaceEndpoint": "Hugging Face 鏡像",
+    "huggingfaceEndpointDescription": "用於 Hugging Face 模型下載的可選鏡像端點。留空則使用預設端點或 HF_ENDPOINT。",
     "restartApply": "套用並重新啟動",
     "restartApplying": "套用中...",
     "restartRequiredDescription": "這些設定會在啟動時載入。套用後會儲存設定並重新啟動應用程式。",


### PR DESCRIPTION
## Summary

Add optional Hugging Face mirror support fror model downloads.

## Changes

- Add `huggingface_endpoint` to HTTP config and config patch handling.
- Pass the configured endpoint into runtime download setup.
- Update Hugging Face download code to prefer the app-configured endpoint, then fall back to `HF_ENDPOINT` from env variable.
- Add Runtime setting UI input for the Hugging Face mirror enddpoint.

## Known issue

Detector may failed to download without an error message, which may be related to missing package from the mirror site. But heavy model (like OCR / LLM) are tested to work fine.

Failure log as below, with `HF_ENDPOINT=https://hf-mirror.com`. Retrieved to default endpoint solve the problem.

```text
pipeline step failed: failed to download config.json from mayocream/speech-bubble-segmentation: failed to fetch HF metadata for mayocream/speech-bubble-segmentation/config.json: Header content-range is missing engine=speech-bubble-segmentation page=019df371-c7b7-77b2-b238-0b50a370e036 step_index=0
```
