### PR TITLE
feat: improve text block management and navigation UX

### DIFF
--- a/koharu-app/Cargo.toml
+++ b/koharu-app/Cargo.toml
@@ -53,6 +53,7 @@ utoipa = { workspace = true }
 uuid = { workspace = true }
 walkdir = { workspace = true }
 zip = { workspace = true }
+indexmap = { workspace = true }
 
 [features]
 cuda = ["koharu-ml/cuda"]

--- a/koharu-app/src/session.rs
+++ b/koharu-app/src/session.rs
@@ -181,14 +181,172 @@ impl ProjectSession {
 // Snapshot loading / TOML metadata
 // ---------------------------------------------------------------------------
 
+mod v1 {
+    //! Legacy schema mirror before `speaker` field was added to TextData.
+    //! Field order must exactly match the original scene.rs declaration.
+    use indexmap::IndexMap;
+    use koharu_core::font::{FontPrediction, TextDirection};
+    use koharu_core::style::TextStyle;
+    use koharu_core::{BlobRef, ImageData, MaskData, NodeId, PageId, ProjectMeta, Transform};
+    use serde::Deserialize;
+
+    #[derive(Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct TextData {
+        #[serde(default)]
+        pub confidence: f32,
+        #[serde(default)]
+        pub source_lang: Option<String>,
+        #[serde(default)]
+        pub source_direction: Option<TextDirection>,
+        #[serde(default)]
+        pub rendered_direction: Option<TextDirection>,
+        #[serde(default)]
+        pub line_polygons: Option<Vec<[[f32; 2]; 4]>>,
+        #[serde(default)]
+        pub rotation_deg: Option<f32>,
+        #[serde(default)]
+        pub detected_font_size_px: Option<f32>,
+        #[serde(default)]
+        pub detector: Option<String>,
+        #[serde(default)]
+        pub text: Option<String>,
+        #[serde(default)]
+        pub translation: Option<String>,
+        #[serde(default)]
+        pub style: Option<TextStyle>,
+        #[serde(default)]
+        pub font_prediction: Option<FontPrediction>,
+        #[serde(default)]
+        pub sprite: Option<BlobRef>,
+        #[serde(default)]
+        pub sprite_transform: Option<Transform>,
+        #[serde(default)]
+        pub lock_layout_box: bool,
+        // speaker field absent — this is the whole point
+    }
+
+    #[derive(Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub enum NodeKind {
+        Image(ImageData),
+        Text(Box<TextData>),
+        Mask(MaskData),
+    }
+
+    #[derive(Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct Node {
+        pub id: NodeId,
+        #[serde(default)]
+        pub transform: Transform,
+        pub visible: bool,
+        pub kind: NodeKind,
+    }
+
+    #[derive(Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct Page {
+        pub id: PageId,
+        pub name: String,
+        pub width: u32,
+        pub height: u32,
+        pub nodes: IndexMap<NodeId, Node>,
+    }
+
+    #[derive(Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct Scene {
+        pub project: ProjectMeta,
+        pub pages: IndexMap<PageId, Page>,
+    }
+
+    #[derive(Deserialize)]
+    pub struct Snapshot {
+        pub epoch: u64,
+        pub scene: Scene,
+    }
+}
+
+fn migrate_v1(v1: v1::Scene) -> Scene {
+    use koharu_core::{Node, NodeKind, Page, TextData};
+
+    let pages = v1
+        .pages
+        .into_iter()
+        .map(|(pid, p)| {
+            let nodes = p
+                .nodes
+                .into_iter()
+                .map(|(nid, n)| {
+                    let kind = match n.kind {
+                        v1::NodeKind::Image(d) => NodeKind::Image(d),
+                        v1::NodeKind::Mask(d) => NodeKind::Mask(d),
+                        v1::NodeKind::Text(d) => NodeKind::Text(TextData {
+                            confidence: d.confidence,
+                            source_lang: d.source_lang,
+                            source_direction: d.source_direction,
+                            rendered_direction: d.rendered_direction,
+                            line_polygons: d.line_polygons,
+                            rotation_deg: d.rotation_deg,
+                            detected_font_size_px: d.detected_font_size_px,
+                            detector: d.detector,
+                            text: d.text,
+                            translation: d.translation,
+                            style: d.style,
+                            font_prediction: d.font_prediction,
+                            sprite: d.sprite,
+                            sprite_transform: d.sprite_transform,
+                            lock_layout_box: d.lock_layout_box,
+                            speaker: None,
+                        }),
+                    };
+                    (
+                        nid,
+                        Node {
+                            id: n.id,
+                            transform: n.transform,
+                            visible: n.visible,
+                            kind,
+                        },
+                    )
+                })
+                .collect();
+            (
+                pid,
+                Page {
+                    id: p.id,
+                    name: p.name,
+                    width: p.width,
+                    height: p.height,
+                    nodes,
+                },
+            )
+        })
+        .collect();
+
+    Scene {
+        project: v1.project,
+        pages,
+    }
+}
+
 fn load_snapshot(dir: &Utf8Path, creating: bool) -> Result<(Scene, u64)> {
     let scene_path = dir.join(SCENE_FILE);
     if scene_path.exists() {
         let bytes = std::fs::read(scene_path.as_std_path())
             .with_context(|| format!("read {}", scene_path))?;
-        let snap: Snapshot =
+
+        // Try current schema first.
+        if let Ok(snap) = postcard::from_bytes::<Snapshot>(&bytes) {
+            return Ok((snap.scene, snap.epoch));
+        }
+
+        // Fall back to v1 schema (pre-speaker).
+        tracing::info!(path = %scene_path, "falling back to v1 schema migration");
+        let snap: v1::Snapshot =
             postcard::from_bytes(&bytes).with_context(|| format!("decode {}", scene_path))?;
-        return Ok((snap.scene, snap.epoch));
+        return Ok((migrate_v1(snap.scene), snap.epoch));
     }
 
     // No snapshot — build one from `project.toml` (or defaults for creation).

--- a/koharu-core/src/op.rs
+++ b/koharu-core/src/op.rs
@@ -219,6 +219,8 @@ pub struct TextDataPatch {
     pub sprite_transform: Option<Option<Transform>>,
     #[serde(default)]
     pub lock_layout_box: Option<bool>,
+    #[serde(default)]
+    pub speaker: Option<Option<String>>,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema, ToSchema)]
@@ -696,6 +698,7 @@ fn capture_prev_text(kind: &NodeKind, p: &TextDataPatch) -> TextDataPatch {
         sprite: p.sprite.as_ref().map(|_| data.sprite.clone()),
         sprite_transform: p.sprite_transform.as_ref().map(|_| data.sprite_transform),
         lock_layout_box: p.lock_layout_box.as_ref().map(|_| data.lock_layout_box),
+        speaker: p.speaker.as_ref().map(|_| data.speaker.clone()),
     }
 }
 
@@ -785,6 +788,9 @@ fn apply_text_patch(t: &mut TextData, p: &TextDataPatch) {
     }
     if let Some(v) = p.lock_layout_box {
         t.lock_layout_box = v;
+    }
+    if let Some(v) = &p.speaker {
+        t.speaker = v.clone();
     }
 }
 

--- a/koharu-core/src/scene.rs
+++ b/koharu-core/src/scene.rs
@@ -309,6 +309,8 @@ pub struct TextData {
     pub sprite_transform: Option<Transform>,
     #[serde(default)]
     pub lock_layout_box: bool,
+    #[serde(default)]
+    pub speaker: Option<String>,
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/integration-tests/client/src/models/text_data.rs
+++ b/tests/integration-tests/client/src/models/text_data.rs
@@ -97,6 +97,13 @@ pub struct TextData {
     )]
     pub style: Option<Option<Box<models::TextStyle>>>,
     #[serde(
+        rename = "speaker",
+        default,
+        with = "::serde_with::rust::double_option",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub speaker: Option<Option<String>>,
+    #[serde(
         rename = "text",
         default,
         with = "::serde_with::rust::double_option",
@@ -128,6 +135,7 @@ impl TextData {
             sprite: None,
             sprite_transform: None,
             style: None,
+            speaker: None,
             text: None,
             translation: None,
         }

--- a/tests/integration-tests/client/src/models/text_data_patch.rs
+++ b/tests/integration-tests/client/src/models/text_data_patch.rs
@@ -107,6 +107,13 @@ pub struct TextDataPatch {
     )]
     pub style: Option<Option<Box<models::TextStyle>>>,
     #[serde(
+        rename = "speaker",
+        default,
+        with = "::serde_with::rust::double_option",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub speaker: Option<Option<String>>,
+    #[serde(
         rename = "text",
         default,
         with = "::serde_with::rust::double_option",
@@ -139,6 +146,7 @@ impl TextDataPatch {
             sprite: None,
             sprite_transform: None,
             style: None,
+            speaker: None,
             text: None,
             translation: None,
         }

--- a/ui/components/MenuBar.tsx
+++ b/ui/components/MenuBar.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from 'react-i18next'
 
 import { fitCanvasToViewport, resetCanvasScale } from '@/components/Canvas'
 import { SettingsDialog, type TabId } from '@/components/SettingsDialog'
+import { TextExportDialog } from '@/components/TextExportDialog'
 import {
   Menubar,
   MenubarContent,
@@ -62,6 +63,7 @@ export function MenuBar() {
   const { t } = useTranslation()
   const [settingsOpen, setSettingsOpen] = useState(false)
   const [settingsTab, setSettingsTab] = useState<TabId>('appearance')
+  const [textExportOpen, setTextExportOpen] = useState(false)
   const hasPage = useSelectionStore((s) => s.pageId !== null)
   const hasScene = useScene().scene !== null
   const shortcuts = usePreferencesStore((state) => state.shortcuts)
@@ -231,6 +233,15 @@ export function MenuBar() {
             ))}
             <MenubarSeparator />
             <MenubarItem
+              data-testid='menu-file-export-text'
+              className='text-[13px]'
+              disabled={!hasScene}
+              onSelect={() => setTextExportOpen(true)}
+            >
+              {t('menu.exportText')}
+            </MenubarItem>
+            <MenubarSeparator />
+            <MenubarItem
               data-testid='menu-file-close-project'
               className='text-[13px]'
               disabled={!hasScene}
@@ -342,6 +353,7 @@ export function MenuBar() {
       <div data-tauri-drag-region className='flex h-full flex-1 items-center justify-center' />
       {isWindowsTauri && <WindowControls />}
       <SettingsDialog open={settingsOpen} onOpenChange={setSettingsOpen} defaultTab={settingsTab} />
+      <TextExportDialog open={textExportOpen} onOpenChange={setTextExportOpen} />
     </div>
   )
 }

--- a/ui/components/SettingsDialog.tsx
+++ b/ui/components/SettingsDialog.tsx
@@ -86,6 +86,8 @@ import {
   isModifierKey,
 } from '@/lib/shortcutUtils'
 import { usePreferencesStore } from '@/lib/stores/preferencesStore'
+import { Slider } from '@/components/ui/slider'
+import { Switch } from '@/components/ui/switch'
 
 // Dialog state models `AppConfig` (what `GET /config` returns — snake_case).
 // But `PATCH /config` expects a `ConfigPatch` with camelCase fields because
@@ -885,6 +887,13 @@ const SHORTCUT_ITEMS = [
   },
   { key: 'undo', labelKey: 'menu.undo' },
   { key: 'redo', labelKey: 'menu.redo' },
+  { key: 'prevPage', labelKey: 'settings.shortcutPrevPage' },
+  { key: 'nextPage', labelKey: 'settings.shortcutNextPage' },
+  { key: 'resetView', labelKey: 'settings.shortcutResetView' },
+  { key: 'zoomIn',    labelKey: 'settings.shortcutZoomIn' },
+  { key: 'zoomOut',   labelKey: 'settings.shortcutZoomOut' },
+  { key: 'nextBlock', labelKey: 'settings.shortcutNextBlock' },
+  { key: 'prevBlock', labelKey: 'settings.shortcutPrevBlock' },
 ] as const
 
 function KeybindsPane() {
@@ -898,6 +907,17 @@ function KeybindsPane() {
   const [isSaved, setIsSaved] = useState(false)
   const [liveShortcut, setLiveShortcut] = useState<string | null>(null)
   const isMac = useMemo(() => getPlatform() === 'mac', [])
+
+  const wheelZoomOnly = usePreferencesStore((s) => s.wheelZoomOnly)
+  const setWheelZoomOnly = usePreferencesStore((s) => s.setWheelZoomOnly)
+  const wheelZoomSpeed = usePreferencesStore((s) => s.wheelZoomSpeed)
+  const setWheelZoomSpeed = usePreferencesStore((s) => s.setWheelZoomSpeed)
+  const zoomStep = usePreferencesStore((s) => s.zoomStep)
+  const setZoomStep = usePreferencesStore((s) => s.setZoomStep)
+  const blockNavWrapAround = usePreferencesStore((s) => s.blockNavWrapAround)
+  const setBlockNavWrapAround = usePreferencesStore((s) => s.setBlockNavWrapAround)
+  const panningButton = usePreferencesStore((s) => s.panningButton)
+  const setPanningButton = usePreferencesStore((s) => s.setPanningButton)
 
   // Optimized conflict detection
   const conflictCounts = useMemo(() => {
@@ -1087,6 +1107,66 @@ function KeybindsPane() {
                 </div>
               )
             })}
+          </div>
+        </Section>
+      <Section title={t('settings.canvasControls')}>
+          <div className='flex items-center justify-between'>
+            <Label className='text-sm'>{t('settings.wheelZoomOnly')}</Label>
+            <Switch
+              checked={wheelZoomOnly}
+              onCheckedChange={(v) => setWheelZoomOnly(v)}
+            />
+          </div>
+
+          <div className='space-y-2'>
+            <div className='flex items-center justify-between'>
+              <Label className='text-sm'>{t('settings.wheelZoomSpeed')}</Label>
+              <span className='text-xs text-muted-foreground'>{wheelZoomSpeed}</span>
+            </div>
+            <Slider
+              min={1}
+              max={10}
+              step={1}
+              value={[wheelZoomSpeed]}
+              onValueChange={([v]) => setWheelZoomSpeed(v)}
+            />
+          </div>
+
+          <div className='space-y-2'>
+            <div className='flex items-center justify-between'>
+              <Label className='text-sm'>{t('settings.zoomStep')}</Label>
+              <span className='text-xs text-muted-foreground'>{zoomStep}%</span>
+            </div>
+            <Slider
+              min={1}
+              max={50}
+              step={1}
+              value={[zoomStep]}
+              onValueChange={([v]) => setZoomStep(v)}
+            />
+          </div>
+
+          <div className='flex items-center justify-between'>
+            <Label className='text-sm'>{t('settings.blockNavWrapAround')}</Label>
+            <Switch
+              checked={blockNavWrapAround}
+              onCheckedChange={(v) => setBlockNavWrapAround(v)}
+            />
+          </div>
+
+          <div className='space-y-1.5'>
+            <Label className='text-xs'>{t('settings.panningButton')}</Label>
+            <Select
+              value={panningButton}
+              onValueChange={(v) => setPanningButton(v as 'right')}
+            >
+              <SelectTrigger className='w-full'>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value='right'>{t('settings.panningRight')}</SelectItem>
+              </SelectContent>
+            </Select>
           </div>
         </Section>
       </div>

--- a/ui/components/TextExportDialog.tsx
+++ b/ui/components/TextExportDialog.tsx
@@ -1,0 +1,216 @@
+'use client'
+
+import { LoaderCircleIcon } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Separator } from '@/components/ui/separator'
+import { getGetSceneJsonQueryKey } from '@/lib/api/default/default'
+import type { SceneSnapshot } from '@/lib/api/schemas'
+import { saveBlob } from '@/lib/io/saveBlob'
+import { buildExportData, toJson, toTxt } from '@/lib/io/textExport'
+import { queryClient } from '@/lib/queryClient'
+import { useSelectionStore } from '@/lib/stores/selectionStore'
+
+type Props = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function TextExportDialog({ open, onOpenChange }: Props) {
+  const { t } = useTranslation()
+  const currentPageId = useSelectionStore((s) => s.pageId)
+
+  const [scope, setScope] = useState<'current' | 'selected' | 'all'>('current')
+  const [format, setFormat] = useState<'json' | 'txt'>('json')
+  const [selectedPageIds, setSelectedPageIds] = useState<Set<string>>(new Set())
+  const [filename, setFilename] = useState('')
+  const [exporting, setExporting] = useState(false)
+
+  const getSnap = () =>
+    queryClient.getQueryData<SceneSnapshot>(getGetSceneJsonQueryKey())
+
+  useEffect(() => {
+    if (open) {
+      const project = getSnap()?.scene?.project?.name ?? 'export'
+      setFilename(`${project}_${scope}`)
+    }
+  }, [open, scope])
+
+  const handleScopeChange = (next: 'current' | 'selected' | 'all') => {
+    setScope(next)
+    const project = getSnap()?.scene?.project?.name ?? 'export'
+    setFilename(`${project}_${next}`)
+  }
+
+  const togglePage = (pid: string) =>
+  setSelectedPageIds((prev) => {
+    const next = new Set(prev)
+    if (next.has(pid)) {
+      next.delete(pid)
+    } else {
+      next.add(pid)
+    }
+    return next
+  })
+
+  const handleExport = async () => {
+    const snap = getSnap()
+    if (!snap?.scene || !currentPageId) return
+
+    const scene = snap.scene
+    const allPageIds = Object.keys(scene.pages)
+
+    let targetIds: string[]
+    if (scope === 'current') {
+      targetIds = [currentPageId]
+    } else if (scope === 'selected') {
+      targetIds = allPageIds.filter((id) => selectedPageIds.has(id))
+      if (targetIds.length === 0) return
+    } else {
+      targetIds = allPageIds
+    }
+
+    setExporting(true)
+    try {
+      const data = buildExportData(scene, targetIds, scope)
+      const content = format === 'json' ? toJson(data) : toTxt(data, t)
+      const mime = format === 'json' ? 'application/json' : 'text/plain'
+      const safeFilename = (filename.trim() || 'export') + '.' + format
+      const blob = new Blob([content], { type: `${mime};charset=utf-8` })
+      const saved = await saveBlob(blob, safeFilename)
+      if (saved) onOpenChange(false)
+    } catch (e) {
+      console.error('Export failed:', e)
+    } finally {
+      setExporting(false)
+    }
+  }
+
+  const snap = open ? getSnap() : null
+  const allPageIds = snap ? Object.keys(snap.scene.pages) : []
+  const canExport = !!currentPageId && (scope !== 'selected' || selectedPageIds.size > 0)
+  
+  return (
+  <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className='w-[26rem] p-4'>
+        <DialogHeader className='mb-3'>
+          <DialogTitle className='text-sm'>{t('export.dialogTitle')}</DialogTitle>
+        </DialogHeader>
+
+        <div className='grid grid-cols-2 gap-x-0 items-start'>
+          {/* Left column — Scope */}
+          <div className='space-y-1.5 pr-4 border-r border-border'>
+            <span className='text-[10px] font-medium text-muted-foreground uppercase'>
+              {t('export.scope')}
+            </span>
+            <div className='flex flex-col gap-1'>
+              {(
+                [
+                  ['current', t('export.scopeCurrent')],
+                  ['selected', t('export.scopeSelected')],
+                  ['all', t('export.scopeAll')],
+                ] as ['current' | 'selected' | 'all', string][]
+              ).map(([val, label]) => (
+                <label
+                  key={val}
+                  className='flex items-center gap-2 cursor-pointer select-none text-xs'
+                >
+                  <input
+                    type='radio'
+                    name='export-scope'
+                    checked={scope === val}
+                    onChange={() => handleScopeChange(val)}
+                    className='accent-primary'
+                  />
+                  {label}
+                </label>
+              ))}
+            </div>
+            {scope === 'selected' && allPageIds.length > 0 && (
+              <div className='mt-1 max-h-40 overflow-y-auto rounded border border-border p-1.5 space-y-1'>
+                {allPageIds.map((pid, i) => (
+                  <label
+                    key={pid}
+                    className='flex items-center gap-2 cursor-pointer select-none text-xs'
+                  >
+                    <input
+                      type='checkbox'
+                      checked={selectedPageIds.has(pid)}
+                      onChange={() => togglePage(pid)}
+                      className='accent-primary'
+                    />
+                    <span className='truncate'>
+                      {i + 1}. {snap?.scene.pages[pid]?.name ?? pid}
+                    </span>
+                  </label>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* Right column — Format + Filename */}
+          <div className='flex flex-col gap-3 pl-4'>
+            <div className='space-y-1.5'>
+              <span className='text-[10px] font-medium text-muted-foreground uppercase'>
+                {t('export.format')}
+              </span>
+              <div className='flex gap-4'>
+                {(['json', 'txt'] as const).map((f) => (
+                  <label
+                    key={f}
+                    className='flex items-center gap-1.5 cursor-pointer select-none text-xs'
+                  >
+                    <input
+                      type='radio'
+                      name='export-format'
+                      checked={format === f}
+                      onChange={() => setFormat(f)}
+                      className='accent-primary'
+                    />
+                    {f.toUpperCase()}
+                  </label>
+                ))}
+              </div>
+            </div>
+
+            <Separator />
+
+            <div className='space-y-1.5'>
+              <span className='text-[10px] font-medium text-muted-foreground uppercase'>
+                {t('export.filename')}
+              </span>
+              <div className='flex items-center gap-1'>
+                <input
+                  type='text'
+                  value={filename}
+                  onChange={(e) => setFilename(e.target.value)}
+                  className='h-6 min-w-0 flex-1 rounded-md border border-border bg-transparent px-1.5 text-xs focus:outline-none focus:ring-1 focus:ring-primary'
+                  spellCheck={false}
+                />
+                <span className='shrink-0 text-xs text-muted-foreground'>.{format}</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <Button
+          size='sm'
+          className='w-full h-7 text-xs mt-4'
+          disabled={!canExport || exporting}
+          onClick={() => void handleExport()}
+        >
+          {exporting && <LoaderCircleIcon className='size-3 animate-spin mr-1.5' />}
+          {t('export.save')}
+        </Button>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/ui/components/canvas/TextBlockLayer.tsx
+++ b/ui/components/canvas/TextBlockLayer.tsx
@@ -121,7 +121,7 @@ const isAdditiveEvent = (event: unknown): boolean => {
   return !!(e.shiftKey || e.metaKey || e.ctrlKey)
 }
 
-const RESIZE_HANDLE_SIZE = 8
+const RESIZE_HANDLE_SIZE = 6
 
 type ResizeEdge = { top: boolean; bottom: boolean; left: boolean; right: boolean }
 
@@ -250,14 +250,14 @@ function TextBlockItem({
       }}
     >
       <div
-        className={`absolute inset-0 rounded-md ${
+        className={`absolute inset-0 rounded-sm ${
           selected
-            ? 'border-[3px] border-primary bg-primary/15'
-            : 'border-2 border-rose-400/60 bg-rose-400/5'
+            ? 'border-[2px] border-dashed border-primary'
+            : 'border border-dashed border-rose-400/60'
         }`}
       />
       <div
-        className={`pointer-events-none absolute -top-1.5 -left-1.5 flex h-4 w-4 items-center justify-center rounded-full text-[9px] font-semibold text-white shadow ${
+        className={`pointer-events-none absolute -top-5 left-1/2 -translate-x-1/2 flex h-4 w-4 items-center justify-center rounded-full text-[9px] font-semibold text-white shadow ${
           selected ? 'bg-primary' : 'bg-rose-400'
         }`}
       >
@@ -295,46 +295,54 @@ function ResizeHandles({ onEdgePointerDown }: { onEdgePointerDown: (edge: Resize
   const s = RESIZE_HANDLE_SIZE
   const half = s / 2
 
-  const edges: { edge: ResizeEdge; style: React.CSSProperties; cursor: string }[] = [
+  const edges: { edge: ResizeEdge; style: React.CSSProperties; cursor: string; corner: boolean }[] = [
     {
       edge: { top: true, left: true, bottom: false, right: false },
       cursor: 'nwse-resize',
       style: { top: -half, left: -half, width: s, height: s },
+      corner: true,
     },
     {
       edge: { top: true, left: false, bottom: false, right: true },
       cursor: 'nesw-resize',
       style: { top: -half, right: -half, width: s, height: s },
+      corner: true,
     },
     {
       edge: { top: false, left: true, bottom: true, right: false },
       cursor: 'nesw-resize',
       style: { bottom: -half, left: -half, width: s, height: s },
+      corner: true,
     },
     {
       edge: { top: false, left: false, bottom: true, right: true },
       cursor: 'nwse-resize',
       style: { bottom: -half, right: -half, width: s, height: s },
+      corner: true,
     },
     {
       edge: { top: true, left: false, bottom: false, right: false },
       cursor: 'ns-resize',
-      style: { top: -half, left: s, right: s, height: s },
+      style: { top: -half, left: '50%', transform: 'translateX(-50%)', width: s, height: s },
+      corner: false,
     },
     {
       edge: { top: false, left: false, bottom: true, right: false },
       cursor: 'ns-resize',
-      style: { bottom: -half, left: s, right: s, height: s },
+      style: { bottom: -half, left: '50%', transform: 'translateX(-50%)', width: s, height: s },
+      corner: false,
     },
     {
       edge: { top: false, left: true, bottom: false, right: false },
       cursor: 'ew-resize',
-      style: { left: -half, top: s, bottom: s, width: s },
+      style: { left: -half, top: '50%', transform: 'translateY(-50%)', width: s, height: s },
+      corner: false,
     },
     {
       edge: { top: false, left: false, bottom: false, right: true },
       cursor: 'ew-resize',
-      style: { right: -half, top: s, bottom: s, width: s },
+      style: { right: -half, top: '50%', transform: 'translateY(-50%)', width: s, height: s },
+      corner: false,
     },
   ]
 
@@ -344,7 +352,17 @@ function ResizeHandles({ onEdgePointerDown }: { onEdgePointerDown: (edge: Resize
         <div
           key={i}
           onPointerDown={() => onEdgePointerDown(e.edge)}
-          style={{ position: 'absolute', ...e.style, cursor: e.cursor, zIndex: 30 }}
+          className="bg-primary border border-primary"
+          style={{
+            position: 'absolute',
+            ...e.style,
+            cursor: e.cursor,
+            zIndex: 30,
+            borderRadius: '50%',
+            boxShadow: '0 1px 3px rgba(0,0,0,0.35)',
+            boxSizing: 'border-box',
+            opacity: 0.7,
+          }}
         />
       ))}
     </>

--- a/ui/components/canvas/Workspace.tsx
+++ b/ui/components/canvas/Workspace.tsx
@@ -43,6 +43,7 @@ import { applyOp } from '@/lib/io/scene'
 import { ops } from '@/lib/ops'
 import { useEditorUiStore } from '@/lib/stores/editorUiStore'
 import { useSelectionStore } from '@/lib/stores/selectionStore'
+import { usePreferencesStore } from '@/lib/stores/preferencesStore'
 
 const BRUSH_CURSOR = 'none'
 
@@ -99,6 +100,10 @@ export function Workspace() {
   useEffect(() => {
     if (page) setCanvasDocumentSize(page.width, page.height)
   }, [page?.width, page?.height])
+
+  useEffect(() => {
+    if (page) fitCanvasToViewport()
+  }, [page?.id])
 
   const viewportRef = useRef<HTMLDivElement | null>(null)
   const canvasRef = useRef<HTMLDivElement | null>(null)
@@ -214,9 +219,11 @@ export function Workspace() {
 
   useGesture(
     {
-      onDrag: ({ first, movement: [mx, my], memo, cancel, ctrlKey }) => {
+      onDrag: ({ first, movement: [mx, my], memo, cancel, event }) => {
         if (!page) return memo
-        if (!ctrlKey) {
+        const mouseEvent = event as MouseEvent
+        const pressed = mouseEvent?.buttons ?? 0
+        if ((pressed & 2) === 0) {
           if (first && cancel) cancel()
           return memo
         }
@@ -230,12 +237,69 @@ export function Workspace() {
         viewport.scrollTop = memo.scrollTop - my
         return memo
       },
-      onWheel: ({ ctrlKey, delta: [, dy], event }) => {
-        if (!page || !ctrlKey) return
+      onWheel: ({ ctrlKey, metaKey, delta: [dx, dy], event }) => {
+        if (!page) return
+        const { wheelZoomOnly, wheelZoomSpeed } = usePreferencesStore.getState()
+        const modKey = ctrlKey || metaKey
+
+        if (event.shiftKey && !modKey) {
+          if (event.cancelable) event.preventDefault()
+          const viewport = viewportRef.current
+          if (viewport) viewport.scrollLeft += dx || dy
+          return
+        }
+        
+        const wantsZoom = wheelZoomOnly ? modKey : !modKey
+        if (!wantsZoom) {
+          if (event.cancelable) event.preventDefault()
+            const viewport = viewportRef.current
+          if (viewport) {
+            viewport.scrollTop += dy
+          }
+          return
+        }
         if (event.cancelable) event.preventDefault()
         const direction = Math.sign(dy)
         if (!direction) return
-        applyScale(useEditorUiStore.getState().scale - direction)
+
+        const viewport = viewportRef.current
+        const currentScale = useEditorUiStore.getState().scale
+        const newScale = Math.max(10, Math.min(400, Math.round(currentScale - direction * wheelZoomSpeed)))
+        if (newScale === currentScale || !viewport) return
+
+        const wheelEvent = event as WheelEvent
+        const viewportRect = viewport.getBoundingClientRect()
+        const mouseX = wheelEvent.clientX - viewportRect.left
+        const mouseY = wheelEvent.clientY - viewportRect.top
+
+        const wrapperW = viewport.scrollWidth
+        const wrapperH = viewport.scrollHeight
+
+        const oldCanvasW = page.width * currentScale / 100
+        const oldCanvasH = page.height * currentScale / 100
+        const canvasLeftInWrapper = (wrapperW - oldCanvasW) / 2
+        const canvasTopInWrapper = (wrapperH - oldCanvasH) / 2
+
+        const cursorInWrapperX = viewport.scrollLeft + mouseX
+        const cursorInWrapperY = viewport.scrollTop + mouseY
+
+        const cursorInCanvasX = cursorInWrapperX - canvasLeftInWrapper
+        const cursorInCanvasY = cursorInWrapperY - canvasTopInWrapper
+
+        const ratio = newScale / currentScale
+        const newCanvasW = page.width * newScale / 100
+        const newCanvasH = page.height * newScale / 100
+        const newCanvasLeftInWrapper = (wrapperW - newCanvasW) / 2
+        const newCanvasTopInWrapper = (wrapperH - newCanvasH) / 2
+
+        const newScrollLeft = newCanvasLeftInWrapper + cursorInCanvasX * ratio - mouseX
+        const newScrollTop = newCanvasTopInWrapper + cursorInCanvasY * ratio - mouseY
+
+        applyScale(newScale)
+        requestAnimationFrame(() => {
+          viewport.scrollLeft = newScrollLeft
+          viewport.scrollTop = newScrollTop
+        })
       },
       onPinch: ({ canceled, movement: [movementScale], memo }) => {
         if (!page || canceled) return memo
@@ -251,7 +315,7 @@ export function Workspace() {
     {
       target: viewportRef,
       eventOptions: { passive: false },
-      drag: { filterTaps: true, pointer: { mouse: true } },
+      drag: { filterTaps: true, pointer: { mouse: true, buttons: [2] } },
       wheel: { preventDefault: false },
       pinch: {
         threshold: 0.1,
@@ -296,8 +360,9 @@ export function Workspace() {
           <ScrollAreaPrimitive.Viewport
             ref={handleViewportRef}
             data-testid='workspace-viewport'
-            className='grid size-full place-content-center-safe'
+            className='size-full overflow-auto'
           >
+            <div className='flex min-h-[200vh] min-w-[200vw] items-center justify-center'>
             {page ? (
               <ContextMenu
                 onOpenChange={(open) => {
@@ -428,6 +493,7 @@ export function Workspace() {
                 {t('workspace.importPrompt')}
               </div>
             )}
+            </div>
           </ScrollAreaPrimitive.Viewport>
           <ScrollAreaPrimitive.Scrollbar
             orientation='vertical'

--- a/ui/components/canvas/canvasViewport.ts
+++ b/ui/components/canvas/canvasViewport.ts
@@ -20,12 +20,72 @@ export function fitCanvasToViewport() {
   if (!rect.width || !rect.height || !docSize.width || !docSize.height) return
   const scaleW = ((rect.width - 10) / docSize.width) * 100
   const scaleH = ((rect.height - 10) / docSize.height) * 100
-  const fit = Math.max(10, Math.min(100, Math.min(scaleW, scaleH)))
+  const fit = Math.max(10, Math.min(400, Math.min(scaleW, scaleH)))
   useEditorUiStore.getState().setAutoFitEnabled(true)
   useEditorUiStore.getState().setScale(fit)
+  requestAnimationFrame(() => {
+    const vp = canvasViewportRef.current
+    if (!vp) return
+    vp.scrollLeft = (vp.scrollWidth - vp.clientWidth) / 2
+    vp.scrollTop = (vp.scrollHeight - vp.clientHeight) / 2
+  })
 }
 
 export function resetCanvasScale() {
   useEditorUiStore.getState().setAutoFitEnabled(false)
   useEditorUiStore.getState().setScale(100)
+}
+
+export function zoomAroundViewportCenter(nextScale: number) {
+  const viewport = canvasViewportRef.current
+  const store = useEditorUiStore.getState()
+
+  if (!viewport || !docSize) {
+    store.setAutoFitEnabled(false)
+    store.setScale(nextScale)
+    return
+  }
+
+  const oldScale = store.scale
+  const clamped = Math.max(10, Math.min(400, Math.round(nextScale)))
+
+  // Capture all values before zooming
+  const scrollLeft     = viewport.scrollLeft
+  const scrollTop      = viewport.scrollTop
+  const clientWidth    = viewport.clientWidth
+  const clientHeight   = viewport.clientHeight
+  const oldScrollWidth = viewport.scrollWidth
+  const oldScrollHeight = viewport.scrollHeight
+
+  // Scroll space coordinates for the viewport center
+  const centerX = scrollLeft + clientWidth / 2
+  const centerY = scrollTop  + clientHeight / 2
+
+  // Scroll space coordinates of the canvas top-left before zooming (canvas is centered)
+  const oldCanvasW = docSize.width  * (oldScale / 100)
+  const oldCanvasH = docSize.height * (oldScale / 100)
+  const oldCanvasLeft = (oldScrollWidth  - oldCanvasW) / 2
+  const oldCanvasTop  = (oldScrollHeight - oldCanvasH) / 2
+
+  // Canvas pixel coordinates pointed to by the viewport center
+  const pixelX = (centerX - oldCanvasLeft) / (oldScale / 100)
+  const pixelY = (centerY - oldCanvasTop)  / (oldScale / 100)
+
+  store.setAutoFitEnabled(false)
+  store.setScale(clamped)
+
+  requestAnimationFrame(() => {
+    const vp = canvasViewportRef.current
+    if (!vp || !docSize) return
+
+    // Canvas position after zooming
+    const newCanvasW = docSize.width  * (clamped / 100)
+    const newCanvasH = docSize.height * (clamped / 100)
+    const newCanvasLeft = (vp.scrollWidth  - newCanvasW) / 2
+    const newCanvasTop  = (vp.scrollHeight - newCanvasH) / 2
+
+    // Correct scroll position so the same canvas pixel stays at the center
+    vp.scrollLeft = pixelX * (clamped / 100) + newCanvasLeft - clientWidth  / 2
+    vp.scrollTop  = pixelY * (clamped / 100) + newCanvasTop  - clientHeight / 2
+  })
 }

--- a/ui/components/panels/RenderControlsPanel.tsx
+++ b/ui/components/panels/RenderControlsPanel.tsx
@@ -20,7 +20,6 @@ import { Input } from '@/components/ui/input'
 import {
   Select,
   SelectContent,
-  SelectItem,
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'

--- a/ui/components/panels/TextBlocksPanel.tsx
+++ b/ui/components/panels/TextBlocksPanel.tsx
@@ -1,8 +1,23 @@
 'use client'
 
-import { Languages, LoaderCircleIcon, Trash2Icon } from 'lucide-react'
-import { motion } from 'motion/react'
-import { useEffect } from 'react'
+import { GripVertical, Languages, LoaderCircleIcon, PlusIcon, Trash2Icon, UserIcon, XIcon } from 'lucide-react'
+import {
+  DndContext,
+  DragOverlay,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core'
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import {
@@ -13,6 +28,7 @@ import {
 } from '@/components/ui/accordion'
 import { Button } from '@/components/ui/button'
 import { DraftTextarea } from '@/components/ui/draft-textarea'
+import { DraftInput } from '@/components/ui/draft-input'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import {
   Select,
@@ -22,12 +38,23 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { Input } from '@/components/ui/input'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
+import { renameSpeakerInScene } from '@/lib/io/speakerSync'
 import { useCurrentPage, useTextNodes, type TextNodeEntry } from '@/hooks/useCurrentPage'
 import { useScene } from '@/hooks/useScene'
+import { useSpeakersStore } from '@/lib/stores/speakersStore'
 import { getConfig, startPipeline, useGetCurrentLlm } from '@/lib/api/default/default'
-import { fetchApi } from '@/lib/api/fetch'
 import type { TextDataPatch } from '@/lib/api/schemas'
-import { applyOp, invalidateScene, queueAutoRender, reorderPageTextNodes } from '@/lib/io/scene'
+import { applyOp, queueAutoRender, reorderPageTextNodes } from '@/lib/io/scene'
 import { ops } from '@/lib/ops'
 import { useEditorUiStore } from '@/lib/stores/editorUiStore'
 import { useJobsStore } from '@/lib/stores/jobsStore'
@@ -37,7 +64,7 @@ import { useSelectionStore } from '@/lib/stores/selectionStore'
 export function TextBlocksPanel() {
   const { t } = useTranslation()
   const page = useCurrentPage()
-  const { epoch } = useScene()
+  const { scene } = useScene()
   const textNodes = useTextNodes()
   useEffect(() => {
     if (process.env.NODE_ENV !== 'production') {
@@ -57,6 +84,62 @@ export function TextBlocksPanel() {
   )
   const readingOrder = useEditorUiStore((s) => s.readingOrder)
   const setReadingOrder = useEditorUiStore((s) => s.setReadingOrder)
+  const blockFocusTarget    = useEditorUiStore((s) => s.blockFocusTarget)
+  const setBlockFocusTarget = useEditorUiStore((s) => s.setBlockFocusTarget)
+
+  // Reference each AccordionItem's DOM element by nodeId
+  const itemRefs = useRef<Map<string, HTMLElement>>(new Map())
+  const [pendingFocusId, setPendingFocusId] = useState<string | null>(null)
+
+  // Drag-and-drop reordering state
+  const [activeId, setActiveId] = useState<string | null>(null)
+  const dragWasSelectedRef = useRef(false)
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  )
+
+  // Transfer store signal to local state (store is consumed immediately)
+  useEffect(() => {
+    if (!blockFocusTarget) return
+    setPendingFocusId(blockFocusTarget)
+    setBlockFocusTarget(null)
+  }, [blockFocusTarget, setBlockFocusTarget])
+
+  // Wait for accordion animation (~200ms), then scroll + focus before resetting
+  useEffect(() => {
+    if (!pendingFocusId) return
+    const id = pendingFocusId
+
+    const scrollTimer = setTimeout(() => {
+      const el = itemRefs.current.get(id)
+      if (el) {
+        const viewport = el.closest('[data-radix-scroll-area-viewport]') as HTMLElement | null
+        // Execute only when scrolling is required
+        if (viewport && viewport.scrollHeight > viewport.clientHeight) {
+          el.scrollIntoView({ block: 'start', behavior: 'smooth' })
+        }
+      }
+    }, 250)
+
+    // Reset pendingFocusId after focus processing (250ms)
+    const resetTimer = setTimeout(() => {
+      setPendingFocusId(null)
+    }, 300)
+
+    return () => {
+      clearTimeout(scrollTimer)
+      clearTimeout(resetTimer)
+    }
+  }, [pendingFocusId])
+
+  const projectName = scene?.project?.name ?? ''
+  const speakersByProject = useSpeakersStore((s) => s.speakersByProject)
+  const addSpeaker = useSpeakersStore((s) => s.addSpeaker)
+  const removeSpeaker = useSpeakersStore((s) => s.removeSpeaker)
+  const renameSpeaker = useSpeakersStore((s) => s.renameSpeaker)
+  const reorderSpeakers = useSpeakersStore((s) => s.reorderSpeakers)
+  const speakers = speakersByProject[projectName] ?? []
 
   if (!page) {
     return (
@@ -104,6 +187,50 @@ export function TextBlocksPanel() {
       defaultFont: prefs.defaultFont,
       readingOrder: editor.readingOrder === 'custom' ? undefined : editor.readingOrder,
     })
+  }
+  
+  // ── Common execution function for manual reordering ───
+  async function executeReorder(fromIndex: number, toIndex: number): Promise<void> {
+    if (fromIndex === toIndex || !page) return
+    if (readingOrder !== 'custom') setReadingOrder('custom')
+
+    const allNodeIds = Object.keys(page.nodes)
+    const textIds = textNodes.map((n) => n.id)
+    const textIdSet = new Set(textIds)
+
+    const newTextOrder = [...textIds]
+    const [moved] = newTextOrder.splice(fromIndex, 1)
+    newTextOrder.splice(toIndex, 0, moved)
+
+    let textCursor = 0
+    const newFullOrder = allNodeIds.map((id) =>
+      textIdSet.has(id) ? newTextOrder[textCursor++] : id,
+    )
+
+    await applyOp(ops.reorderNodes(page.id, newFullOrder, allNodeIds))
+  }
+
+  // ── Drag and Drop: DndContext onDragEnd callback ───
+  async function handleDrag({ active, over }: DragEndEvent) {
+    const wasSelected = dragWasSelectedRef.current
+    setActiveId(null)
+    dragWasSelectedRef.current = false
+
+    if (!over || active.id === over.id) {
+      // Cancel or in-place — restore if it was originally open
+      if (wasSelected) select(active.id as string, false)
+      return
+    }
+
+    const fromIndex = textNodes.findIndex((n) => n.id === active.id)
+    const toIndex = textNodes.findIndex((n) => n.id === over.id)
+    await executeReorder(fromIndex, toIndex)
+    if (wasSelected) select(active.id as string, false)
+  }
+
+  // ── Reordering via direct index input ───
+  function handleReorderByIndex(sourceIndex: number, targetIndex: number) {
+    void executeReorder(sourceIndex, targetIndex)
   }
 
   return (
@@ -153,6 +280,19 @@ export function TextBlocksPanel() {
               </SelectItem>
             </SelectContent>
           </Select>
+          <SpeakerManagerModal
+            speakers={speakers}
+            onAdd={(name) => addSpeaker(projectName, name)}
+            onRemove={(name) => {
+              removeSpeaker(projectName, name)
+              if (scene) void renameSpeakerInScene(scene, name, null)
+            }}
+            onRename={(oldName, newName) => {
+              renameSpeaker(projectName, oldName, newName)
+              if (scene) void renameSpeakerInScene(scene, oldName, newName)
+            }}
+            onReorder={(newOrder) => reorderSpeakers(projectName, newOrder)}
+          />
         </div>
       </div>
       <ScrollArea
@@ -167,37 +307,85 @@ export function TextBlocksPanel() {
               {t('textBlocks.none')}
             </p>
           ) : (
-            <Accordion
-              data-testid='textblocks-accordion'
-              type='single'
-              collapsible
-              value={accordionValue}
-              onValueChange={(value) => {
-                if (!value) {
-                  clearSelection()
-                  return
-                }
-                const idx = Number(value)
-                const node = textNodes[idx]
-                if (node) select(node.id, false)
+            <DndContext
+              sensors={sensors}
+              onDragStart={({ active }) => {
+                setActiveId(active.id as string)
+                dragWasSelectedRef.current = selectedIds.has(active.id as string)
+                if (dragWasSelectedRef.current) clearSelection()
               }}
-              className='flex flex-col gap-1'
+              onDragEnd={handleDrag}
+              onDragCancel={() => {
+                const wasSelected = dragWasSelectedRef.current
+                if (wasSelected && activeId) select(activeId, false)
+                setActiveId(null)
+                dragWasSelectedRef.current = false
+              }}
             >
-              {textNodes.map((node, index) => (
-                <BlockCard
-                  key={node.id}
-                  node={node}
-                  index={index}
-                  selected={selectedIds.has(node.id)}
-                  onToggleSelect={() => select(node.id, true)}
-                  onPatch={(patch) => void patchText(node.id, patch)}
-                  onDelete={() => void removeNode(node.id)}
-                  onGenerate={() => void generate(node.id)}
-                  processing={isProcessing}
-                  llmReady={llmReady}
-                />
-              ))}
-            </Accordion>
+              <SortableContext
+                items={textNodes.map((n) => n.id)}
+                strategy={verticalListSortingStrategy}
+              >
+                <Accordion
+                  data-testid='textblocks-accordion'
+                  type='single'
+                  collapsible
+                  value={accordionValue}
+                  onValueChange={(value) => {
+                    if (!value) {
+                      clearSelection()
+                      return
+                    }
+                    const idx = Number(value)
+                    const node = textNodes[idx]
+                    if (node) select(node.id, false)
+                  }}
+                  className='flex flex-col gap-1'
+                >
+                  {textNodes.map((node, index) => (
+                    <BlockCard
+                      key={node.id}
+                      node={node}
+                      index={index}
+                      selected={selectedIds.has(node.id)}
+                      speakers={speakers}
+                      onToggleSelect={() => select(node.id, true)}
+                      onPatch={(patch) => void patchText(node.id, patch)}
+                      onDelete={() => void removeNode(node.id)}
+                      onGenerate={() => void generate(node.id)}
+                      processing={isProcessing}
+                      llmReady={llmReady}
+                      focusOcr={pendingFocusId === node.id}
+                      onRef={(el) => {
+                        if (el) itemRefs.current.set(node.id, el)
+                        else itemRefs.current.delete(node.id)
+                      }}
+                      totalCount={textNodes.length}
+                      onMoveToIndex={(newIdx) => handleReorderByIndex(index, newIdx)}
+                    />
+                  ))}
+                </Accordion>
+              </SortableContext>
+              <DragOverlay dropAnimation={null}>
+                {activeId && (() => {
+                  const node = textNodes.find((n) => n.id === activeId)
+                  const idx = textNodes.findIndex((n) => n.id === activeId)
+                  if (!node) return null
+                  const preview = node.data.translation?.trim() || node.data.text?.trim()
+                  return (
+                    <div className='flex cursor-grabbing items-center gap-1.5 rounded-md bg-card px-2 py-1.5 text-xs shadow-lg ring-2 ring-primary'>
+                      <GripVertical className='size-3.5 shrink-0 text-muted-foreground' />
+                      <span className='shrink-0 rounded-md bg-primary px-1.5 py-0.5 text-center text-[10px] font-medium text-white'>
+                        {idx + 1}
+                      </span>
+                      {preview && (
+                        <p className='line-clamp-1 min-w-0 flex-1 text-muted-foreground'>{preview}</p>
+                      )}
+                    </div>
+                  )
+                })()}
+              </DragOverlay>
+            </DndContext>
           )}
         </div>
       </ScrollArea>
@@ -209,37 +397,70 @@ type BlockCardProps = {
   node: TextNodeEntry
   index: number
   selected: boolean
+  speakers: string[]
   onToggleSelect: () => void
   onPatch: (patch: TextDataPatch) => void
   onDelete: () => void
   onGenerate: () => void
   processing: boolean
   llmReady: boolean
+  onRef?: (el: HTMLElement | null) => void
+  focusOcr?: boolean
+  totalCount: number
+  onMoveToIndex: (newZeroBasedIndex: number) => void
 }
 
 function BlockCard({
   node,
   index,
   selected,
+  speakers,
   onToggleSelect,
   onPatch,
   onDelete,
   onGenerate,
   processing,
   llmReady,
+  onRef,
+  focusOcr,
+  totalCount,
+  onMoveToIndex,
 }: BlockCardProps) {
   const { t } = useTranslation()
   const data = node.data
   const hasOcr = !!data.text?.trim()
+  const ocrContainerRef = useRef<HTMLDivElement>(null)
+  const [speakerDropdownOpen, setSpeakerDropdownOpen] = useState(false)
+
+  const [isEditingIndex, setIsEditingIndex] = useState(false)
   const hasTranslation = !!data.translation?.trim()
   const preview = data.translation?.trim() || data.text?.trim()
 
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: node.id,
+  })
+  const sortableStyle = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  }
+
+  useEffect(() => {
+    if (!focusOcr) return
+    const timer = setTimeout(() => {
+      ocrContainerRef.current?.querySelector('textarea')?.focus()
+    }, 250)
+    return () => clearTimeout(timer)
+  }, [focusOcr])
+
   return (
-    <motion.div
+    <div
+      ref={(el) => {
+        setNodeRef(el)
+        onRef?.(el)
+      }}
       data-testid={`textblock-card-${index}`}
-      initial={{ opacity: 0, y: 8 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.2, delay: index * 0.03 }}
+      style={sortableStyle}
+      className={`relative${isDragging ? ' opacity-30' : ''}`}
     >
       <AccordionItem
         value={index.toString()}
@@ -248,6 +469,11 @@ function BlockCard({
       >
         <AccordionTrigger
           onClick={(e) => {
+            if (isEditingIndex) {
+              e.preventDefault()
+              e.stopPropagation()
+              return
+            }
             if (e.shiftKey || e.ctrlKey || e.metaKey) {
               e.preventDefault()
               e.stopPropagation()
@@ -257,13 +483,60 @@ function BlockCard({
           className='flex w-full cursor-pointer items-center gap-1.5 px-2 py-1.5 text-left transition outline-none hover:no-underline data-[state=open]:bg-accent [&>svg]:hidden'
         >
           <span
-            className={`shrink-0 rounded-md px-1.5 py-0.5 text-center text-[10px] font-medium text-white tabular-nums ${
-              selected ? 'bg-primary' : 'bg-muted-foreground/60'
-            }`}
-            style={{ minWidth: '1.5rem' }}
+            {...attributes}
+            {...listeners}
+            className='flex shrink-0 cursor-grab items-center text-muted-foreground/40 hover:text-muted-foreground active:cursor-grabbing'
+            onClick={(e) => e.stopPropagation()}
           >
-            {index + 1}
+            <GripVertical className='size-3.5' />
           </span>
+          {isEditingIndex ? (
+            <input
+              type='number'
+              min={1}
+              max={totalCount}
+              defaultValue={index + 1}
+              autoFocus
+              onFocus={(e) => e.currentTarget.select()}
+              onClick={(e) => e.stopPropagation()}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  const val = parseInt(e.currentTarget.value, 10)
+                  const clamped = isNaN(val)
+                    ? index + 1
+                    : Math.max(1, Math.min(val, totalCount))
+                  if (clamped !== index + 1) onMoveToIndex(clamped - 1)
+                  setIsEditingIndex(false)
+                  e.currentTarget.blur()
+                } else if (e.key === 'Escape') {
+                  setIsEditingIndex(false)
+                }
+              }}
+              onBlur={(e) => {
+                const val = parseInt(e.currentTarget.value, 10)
+                const clamped = isNaN(val)
+                  ? index + 1
+                  : Math.max(1, Math.min(val, totalCount))
+                if (clamped !== index + 1) onMoveToIndex(clamped - 1)
+                setIsEditingIndex(false)
+              }}
+              className='h-5 w-8 shrink-0 rounded-md bg-primary px-0.5 text-center text-[10px] font-medium text-white tabular-nums [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none'
+            />
+          ) : (
+            <span
+              className={`shrink-0 cursor-pointer rounded-md px-1.5 py-0.5 text-center text-[10px] font-medium text-white tabular-nums hover:ring-1 hover:ring-primary/60 ${
+                selected ? 'bg-primary' : 'bg-muted-foreground/60'
+              }`}
+              style={{ minWidth: '1.5rem' }}
+              title='Click to move to position'
+              onClick={(e) => {
+                e.stopPropagation()
+                setIsEditingIndex(true)
+              }}
+            >
+              {index + 1}
+            </span>
+          )}
           <div className='flex min-w-0 flex-1 items-center gap-1'>
             <span
               className={`shrink-0 rounded-sm px-1 py-0.5 text-[9px] font-medium uppercase ${
@@ -286,23 +559,11 @@ function BlockCard({
         </AccordionTrigger>
         <AccordionContent className='px-2 pt-1.5 pb-2 shadow-[inset_0_1px_0_0_var(--color-border)]'>
           <div className='space-y-1.5'>
-            <div className='flex flex-col gap-0.5'>
-              <span className='text-[10px] text-muted-foreground uppercase'>
-                {t('textBlocks.ocrLabel')}
-              </span>
-              <DraftTextarea
-                data-testid={`textblock-ocr-${index}`}
-                value={data.text ?? ''}
-                placeholder={t('textBlocks.addOcrPlaceholder')}
-                rows={2}
-                onValueChange={(value) => onPatch({ text: value })}
-                className='min-h-0 resize-none px-1.5 py-1 text-xs'
-              />
-            </div>
+            {/* Speaker */}
             <div className='flex flex-col gap-0.5'>
               <div className='flex items-center justify-between'>
                 <span className='text-[10px] text-muted-foreground uppercase'>
-                  {t('textBlocks.translationLabel')}
+                  {t('textBlocks.speakerLabel')}
                 </span>
                 <div className='flex items-center gap-0.5'>
                   <Tooltip>
@@ -347,6 +608,73 @@ function BlockCard({
                   </Tooltip>
                 </div>
               </div>
+              <div className='relative flex items-center'>
+                <DraftInput
+                  value={data.speaker ?? ''}
+                  placeholder={t('textBlocks.speakerInputPlaceholder')}
+                  onValueChange={(value) => onPatch({ speaker: value.trim() || null })}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') e.currentTarget.blur()
+                  }}
+                  className={`h-6 w-full px-1.5 text-xs ${speakers.length > 0 ? 'pr-6' : ''}`}
+                />
+                {speakers.length > 0 && (
+                  <Popover open={speakerDropdownOpen} onOpenChange={setSpeakerDropdownOpen}>
+                    <PopoverTrigger asChild>
+                      <button
+                        type='button'
+                        className='absolute right-0 flex h-6 w-6 items-center justify-center text-muted-foreground hover:text-foreground'
+                        onMouseDown={(e) => e.preventDefault()}
+                      >
+                        <svg width='10' height='6' viewBox='0 0 10 6' fill='currentColor'>
+                          <path d='M0 0L5 6L10 0H0Z' />
+                        </svg>
+                      </button>
+                    </PopoverTrigger>
+                    <PopoverContent className='w-40 p-1' align='end' side='bottom'>
+                      <button
+                        className='w-full rounded px-2 py-1 text-left text-xs text-muted-foreground hover:bg-accent'
+                        onClick={() => {
+                          onPatch({ speaker: null })
+                          setSpeakerDropdownOpen(false)
+                        }}
+                      >
+                        {t('textBlocks.speakerNone')}
+                      </button>
+                      {speakers.map((name) => (
+                        <button
+                          key={name}
+                          className='w-full rounded px-2 py-1 text-left text-xs hover:bg-accent'
+                          onClick={() => {
+                            onPatch({ speaker: name })
+                            setSpeakerDropdownOpen(false)
+                          }}
+                        >
+                          {name}
+                        </button>
+                      ))}
+                    </PopoverContent>
+                  </Popover>
+                )}
+              </div>
+            </div>
+            <div ref={ocrContainerRef} className='flex flex-col gap-0.5'>
+              <span className='text-[10px] text-muted-foreground uppercase'>
+                {t('textBlocks.ocrLabel')}
+              </span>
+              <DraftTextarea
+                data-testid={`textblock-ocr-${index}`}
+                value={data.text ?? ''}
+                placeholder={t('textBlocks.addOcrPlaceholder')}
+                rows={2}
+                onValueChange={(value) => onPatch({ text: value })}
+                className='min-h-0 resize-none px-1.5 py-1 text-xs'
+              />
+            </div>
+            <div className='flex flex-col gap-0.5'>
+              <span className='text-[10px] text-muted-foreground uppercase'>
+                {t('textBlocks.translationLabel')}
+              </span>
               <DraftTextarea
                 data-testid={`textblock-translation-${index}`}
                 value={data.translation ?? ''}
@@ -359,6 +687,191 @@ function BlockCard({
           </div>
         </AccordionContent>
       </AccordionItem>
-    </motion.div>
+    </div>
+  )
+}
+
+type DraftSpeaker = {
+  id: string       // dnd key and internal identifier
+  original: string // Original name on modal open. Empty for new items
+  current: string  // Name currently being edited
+}
+
+function SpeakerManagerModal({
+  speakers,
+  onAdd,
+  onRemove,
+  onRename,
+  onReorder,
+}: {
+  speakers: string[]
+  onAdd: (name: string) => void
+  onRemove: (name: string) => void
+  onRename: (oldName: string, newName: string) => void
+  onReorder: (newOrder: string[]) => void
+}) {
+  const { t } = useTranslation()
+  const [open, setOpen] = useState(false)
+  const [draft, setDraft] = useState<DraftSpeaker[]>([])
+  const [newInput, setNewInput] = useState('')
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  )
+
+  function handleOpenChange(next: boolean) {
+    if (next) {
+      setDraft(speakers.map((name) => ({ id: name, original: name, current: name })))
+      setNewInput('')
+    }
+    setOpen(next)
+  }
+
+  function handleDragEnd({ active, over }: DragEndEvent) {
+    if (!over || active.id === over.id) return
+    const oldIdx = draft.findIndex((d) => d.id === active.id)
+    const newIdx = draft.findIndex((d) => d.id === over.id)
+    if (oldIdx < 0 || newIdx < 0) return
+    const next = [...draft]
+    const [moved] = next.splice(oldIdx, 1)
+    next.splice(newIdx, 0, moved)
+    setDraft(next)
+  }
+
+  function handleAdd() {
+    const trimmed = newInput.trim()
+    if (!trimmed) return
+    if (draft.some((d) => d.current === trimmed)) return
+    const id = `__new__${Date.now()}`
+    setDraft((prev) => [...prev, { id, original: '', current: trimmed }])
+    setNewInput('')
+  }
+
+  function handleRemove(id: string) {
+    setDraft((prev) => prev.filter((d) => d.id !== id))
+  }
+
+  function handleCurrentChange(id: string, value: string) {
+    setDraft((prev) =>
+      prev.map((d) => (d.id === id ? { ...d, current: value } : d)),
+    )
+  }
+
+  function handleConfirm() {
+    const draftOriginals = new Set(draft.map((d) => d.original).filter(Boolean))
+
+    // Deleted items
+    for (const name of speakers) {
+      if (!draftOriginals.has(name)) onRemove(name)
+    }
+    // Renamed items
+    for (const item of draft) {
+      if (item.original && item.current !== item.original) onRename(item.original, item.current)
+    }
+    // Newly added items
+    for (const item of draft) {
+      if (!item.original) onAdd(item.current)
+    }
+    // Synchronize order
+    onReorder(draft.map((d) => d.current))
+
+    setOpen(false)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        <Button variant='ghost' size='icon-xs' className='size-5'>
+          <UserIcon className='size-3' />
+        </Button>
+      </DialogTrigger>
+      <DialogContent className='w-80'>
+        <DialogHeader>
+          <DialogTitle className='text-sm'>{t('textBlocks.speakerList')}</DialogTitle>
+        </DialogHeader>
+
+        <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
+          <SortableContext items={draft.map((d) => d.id)} strategy={verticalListSortingStrategy}>
+            <div className='max-h-64 space-y-0.5 overflow-y-auto py-1'>
+              {draft.length === 0 && (
+                <p className='px-1 text-xs text-muted-foreground'>{t('textBlocks.speakerEmpty')}</p>
+              )}
+              {draft.map((item) => (
+                <SpeakerDraftRow
+                  key={item.id}
+                  item={item}
+                  onCurrentChange={(value) => handleCurrentChange(item.id, value)}
+                  onRemove={() => handleRemove(item.id)}
+                />
+              ))}
+            </div>
+          </SortableContext>
+        </DndContext>
+
+        <div className='flex gap-1'>
+          <Input
+            value={newInput}
+            onChange={(e) => setNewInput(e.target.value)}
+            onKeyDown={(e) => { if (e.key === 'Enter') handleAdd() }}
+            placeholder={t('textBlocks.speakerAddPlaceholder')}
+            className='h-6 flex-1 px-1.5 text-xs'
+          />
+          <Button size='icon-xs' className='size-6 shrink-0' onClick={handleAdd}>
+            <PlusIcon className='size-3' />
+          </Button>
+        </div>
+
+        <DialogFooter>
+          <Button size='sm' className='h-7 text-xs' onClick={handleConfirm}>
+            {t('common.confirm')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function SpeakerDraftRow({
+  item,
+  onCurrentChange,
+  onRemove,
+}: {
+  item: DraftSpeaker
+  onCurrentChange: (value: string) => void
+  onRemove: () => void
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: item.id,
+  })
+  const style = { transform: CSS.Transform.toString(transform), transition }
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={`flex items-center gap-1 rounded px-1 py-0.5${isDragging ? ' opacity-30' : ''}`}
+    >
+      <span
+        {...attributes}
+        {...listeners}
+        className='flex shrink-0 cursor-grab items-center text-muted-foreground/40 hover:text-muted-foreground active:cursor-grabbing'
+      >
+        <GripVertical className='size-3' />
+      </span>
+      <Input
+        value={item.current}
+        onChange={(e) => onCurrentChange(e.target.value)}
+        className='h-6 flex-1 px-1.5 text-xs'
+      />
+      <Button
+        variant='ghost'
+        size='icon-xs'
+        className='size-4 shrink-0 text-muted-foreground hover:text-destructive'
+        onClick={onRemove}
+      >
+        <XIcon className='size-2.5' />
+      </Button>
+    </div>
   )
 }

--- a/ui/components/ui/draft-input.tsx
+++ b/ui/components/ui/draft-input.tsx
@@ -3,17 +3,17 @@
 import * as React from 'react'
 import { useEffect, useRef, useState } from 'react'
 
-import { Textarea } from '@/components/ui/textarea'
+import { Input } from '@/components/ui/input'
 
-export type DraftTextareaProps = Omit<
-  React.ComponentProps<typeof Textarea>,
+export type DraftInputProps = Omit<
+  React.ComponentProps<typeof Input>,
   'value' | 'onChange'
 > & {
   value: string
   onValueChange: (value: string) => void
 }
 
-export function DraftTextarea({
+export function DraftInput({
   value,
   onValueChange,
   onFocus,
@@ -22,13 +22,12 @@ export function DraftTextarea({
   onCompositionEnd,
   onKeyDown,
   ...props
-}: DraftTextareaProps) {
+}: DraftInputProps) {
   const [draftValue, setDraftValue] = useState(value)
   const draftValueRef = useRef(value)
   const isFocusedRef = useRef(false)
   const isComposingRef = useRef(false)
   const pendingCommitRef = useRef<string | null>(null)
-  const lastExternalValueRef = useRef(value)
 
   const commitValue = (nextValue: string) => {
     pendingCommitRef.current = null
@@ -40,19 +39,12 @@ export function DraftTextarea({
   }, [draftValue])
 
   useEffect(() => {
-    lastExternalValueRef.current = value
-
-    // While the user is focused or composing, preserve their draft.
-    // Stale server refetches must not override what the user is actively typing.
-    if (isFocusedRef.current || isComposingRef.current) {
-      return
-    }
-
+    if (isFocusedRef.current || isComposingRef.current) return
     setDraftValue(value)
   }, [value])
 
   return (
-    <Textarea
+    <Input
       {...props}
       value={draftValue}
       onKeyDown={(event) => {

--- a/ui/hooks/useKeyboardShortcuts.ts
+++ b/ui/hooks/useKeyboardShortcuts.ts
@@ -1,17 +1,40 @@
 'use client'
 
-import { useEffect, useMemo } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 
+import { fitCanvasToViewport, zoomAroundViewportCenter, } from '@/components/canvas/canvasViewport'
 import { redoOp, selectAllTextNodesOnCurrentPage, undoOp } from '@/lib/io/scene'
 import { getPlatform, formatShortcut, isModifierKey } from '@/lib/shortcutUtils'
 import { useEditorUiStore } from '@/lib/stores/editorUiStore'
 import { usePreferencesStore } from '@/lib/stores/preferencesStore'
+import { useScene } from '@/hooks/useScene'
+import { useSelectionStore } from '@/lib/stores/selectionStore'
+import { useTextNodes } from '@/hooks/useCurrentPage'
 
 export function useKeyboardShortcuts() {
   const setMode = useEditorUiStore((state) => state.setMode)
+  const setBlockFocusTarget = useEditorUiStore((state) => state.setBlockFocusTarget)
   const setBrushConfig = usePreferencesStore((state) => state.setBrushConfig)
   const shortcuts = usePreferencesStore((state) => state.shortcuts)
+  const zoomStep = usePreferencesStore((state) => state.zoomStep)
+  const blockNavWrapAround = usePreferencesStore((state) => state.blockNavWrapAround)
   const isMac = useMemo(() => getPlatform() === 'mac', [])
+
+  const { scene } = useScene()
+  const pageId = useSelectionStore((s) => s.pageId)
+  const setPage = useSelectionStore((s) => s.setPage)
+  const textNodes = useTextNodes()
+
+  const pagesRef = useRef<{ id: string }[]>([])
+  const pageIdRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    pagesRef.current = scene?.pages ? Object.values(scene.pages) : []
+  }, [scene])
+
+  useEffect(() => {
+    pageIdRef.current = pageId ?? null
+  }, [pageId])
 
   // Optimized tool mapping - built once and updated only when shortcuts change
   const TOOL_MAP = useMemo(
@@ -65,11 +88,85 @@ export function useKeyboardShortcuts() {
         return
       }
 
+      // Block navigation — works even when focused on a textarea (processed before inTextField check)
+      if (shortcut === shortcuts.nextBlock || shortcut === shortcuts.prevBlock) {
+        if (textNodes.length === 0) return
+        event.preventDefault()
+        // If currently focusing a text field, blur it first
+        if (inTextField && event.target instanceof HTMLElement) {
+          event.target.blur()
+        }
+        const isNext = shortcut === shortcuts.nextBlock
+        const currentNodeIds = useSelectionStore.getState().nodeIds
+        const selectedIdx = textNodes.findIndex((n) => currentNodeIds.has(n.id))
+        let targetIdx: number
+        if (isNext) {
+          if (selectedIdx === -1) {
+            targetIdx = 0
+          } else if (selectedIdx === textNodes.length - 1) {
+            if (!blockNavWrapAround) return
+            targetIdx = 0
+          } else {
+            targetIdx = selectedIdx + 1
+          }
+        } else {
+          if (selectedIdx === -1) {
+            targetIdx = textNodes.length - 1
+          } else if (selectedIdx === 0) {
+            if (!blockNavWrapAround) return
+            targetIdx = textNodes.length - 1
+          } else {
+            targetIdx = selectedIdx - 1
+          }
+        }
+        const target = textNodes[targetIdx]
+        if (!target) return
+        useSelectionStore.getState().select(target.id, false)
+        setBlockFocusTarget(target.id)
+        return
+      }
+
       // Every other shortcut is tool-level and should not fire while typing.
       if (inTextField) return
 
       // Early exit for modifier-only events
-      if (isModifierKey(event.key)) {
+      if (isModifierKey(event.key)) return
+
+      // Page navigation
+      if (shortcut === shortcuts.prevPage || shortcut === shortcuts.nextPage) {
+        const pages = pagesRef.current
+        const currentId = pageIdRef.current
+        if (pages.length < 2) return
+        const currentIndex = pages.findIndex((p) => p.id === currentId)
+        if (currentIndex < 0) return
+        const isPrev = shortcut === shortcuts.prevPage
+        const nextIndex = isPrev ? currentIndex - 1 : currentIndex + 1
+        if (nextIndex < 0 || nextIndex >= pages.length) return
+        event.preventDefault()
+        setPage(pages[nextIndex].id)
+        return
+      }
+
+      // Reset viewport (move to center)
+      if (shortcut === shortcuts.resetView) {
+        event.preventDefault()
+        fitCanvasToViewport()
+        return
+      }
+
+      // Zoom in
+      if (shortcut === shortcuts.zoomIn) {
+        event.preventDefault()
+        const current = useEditorUiStore.getState().scale
+        zoomAroundViewportCenter(current + zoomStep)
+        return
+      }
+
+      // Zoom out
+      if (shortcut === shortcuts.zoomOut) {
+        event.preventDefault()
+        const current = useEditorUiStore.getState().scale
+        zoomAroundViewportCenter(current - zoomStep)
         return
       }
 
@@ -93,5 +190,5 @@ export function useKeyboardShortcuts() {
     window.addEventListener('keydown', handleKeyDown)
     return () => window.removeEventListener('keydown', handleKeyDown)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isMac, setMode, TOOL_MAP, shortcuts])
+  }, [isMac, setMode, setPage, TOOL_MAP, shortcuts, zoomStep, blockNavWrapAround, textNodes, setBlockFocusTarget])
 }

--- a/ui/lib/api/schemas/textData.ts
+++ b/ui/lib/api/schemas/textData.ts
@@ -29,6 +29,8 @@ export interface TextData {
   spriteTransform?: null | Transform
   style?: null | TextStyle
   /** @nullable */
+  speaker?: string | null
+  /** @nullable */
   text?: string | null
   /** @nullable */
   translation?: string | null

--- a/ui/lib/api/schemas/textDataPatch.ts
+++ b/ui/lib/api/schemas/textDataPatch.ts
@@ -35,6 +35,8 @@ export interface TextDataPatch {
   spriteTransform?: null | Transform
   style?: null | TextStyle
   /** @nullable */
+  speaker?: string | null
+  /** @nullable */
   text?: string | null
   /** @nullable */
   translation?: string | null

--- a/ui/lib/io/speakerSync.ts
+++ b/ui/lib/io/speakerSync.ts
@@ -1,0 +1,23 @@
+import type { Scene } from '@/lib/api/schemas'
+import { applyOp } from '@/lib/io/scene'
+import { ops } from '@/lib/ops'
+
+/** Iterates through all pages in the scene and batch patches text nodes where speaker === oldName with newName (null allowed). */
+export async function renameSpeakerInScene(
+  scene: Scene,
+  oldName: string,
+  newName: string | null,
+): Promise<void> {
+  for (const page of Object.values(scene.pages)) {
+    for (const [nodeId, node] of Object.entries(page.nodes)) {
+      if (!('text' in node.kind)) continue
+      if (node.kind.text.speaker !== oldName) continue
+
+      await applyOp(
+        ops.updateNode(page.id, nodeId, {
+          data: { text: { speaker: newName } } as never,
+        }),
+      )
+    }
+  }
+}

--- a/ui/lib/io/textExport.ts
+++ b/ui/lib/io/textExport.ts
@@ -1,0 +1,108 @@
+import type { Scene } from '@/lib/api/schemas'
+
+// ── Types ───
+
+type TextKindData = {
+  text?: string | null
+  translation?: string | null
+  speaker?: string | null
+}
+
+export type ExportBlock = {
+  index: number
+  speaker: string | null
+  ocr: string | null
+  translation: string | null
+}
+
+export type ExportPage = {
+  pageId: string
+  pageName: string
+  pageIndex: number
+  blocks: ExportBlock[]
+}
+
+export type ExportData = {
+  project: string
+  exportedAt: string
+  scope: 'current' | 'selected' | 'all'
+  pages: ExportPage[]
+}
+
+// ── Data Collection ───
+
+function extractTextBlocks(page: Scene['pages'][string]): ExportBlock[] {
+  return Object.values(page.nodes)
+    .filter((node) => 'text' in node.kind)
+    .map((node, i) => {
+      const td = (node.kind as { text: TextKindData }).text
+      return {
+        index: i + 1,
+        speaker: td.speaker ?? null,
+        ocr: td.text ?? null,
+        translation: td.translation ?? null,
+      }
+    })
+    .filter((b) => b.ocr || b.translation)
+}
+
+export function buildExportData(
+  scene: Scene,
+  pageIds: string[],
+  scope: ExportData['scope'],
+): ExportData {
+  const pages: ExportPage[] = pageIds
+    .map((pid, i) => {
+      const page = scene.pages[pid]
+      if (!page) return null
+      return {
+        pageId: pid,
+        pageName: page.name,
+        pageIndex: i + 1,
+        blocks: extractTextBlocks(page),
+      }
+    })
+    .filter((p): p is ExportPage => p !== null)
+
+  return {
+    project: scene.project?.name ?? '',
+    exportedAt: new Date().toISOString(),
+    scope,
+    pages,
+  }
+}
+
+// ── Serialization ───
+
+export function toJson(data: ExportData): string {
+  return JSON.stringify(data, null, 2)
+}
+
+export type ExportTKeys =
+  | 'export.noText'
+  | 'export.speaker'
+  | 'export.original'
+  | 'export.translation'
+
+export type ExportTranslate = (key: ExportTKeys) => string
+
+export function toTxt(data: ExportData, t: ExportTranslate): string {
+  return data.pages
+    .map((page) => {
+      const header = page.pageName
+      const body =
+        page.blocks.length === 0
+          ? t('export.noText')
+          : page.blocks
+              .map((b) => {
+                const lines: string[] = [`[${b.index}]`]
+                if (b.speaker)     lines.push(`{${t('export.speaker')}: ${b.speaker}}`)
+                if (b.ocr)         lines.push(`{${t('export.original')}}\n${b.ocr}`)
+                if (b.translation) lines.push(`{${t('export.translation')}}\n${b.translation}`)
+                return lines.join('\n')
+              })
+              .join('\n\n')
+      return `${header}\n${'─'.repeat(32)}\n${body}`
+    })
+    .join('\n\n' + '═'.repeat(40) + '\n\n')
+}

--- a/ui/lib/stores/editorUiStore.ts
+++ b/ui/lib/stores/editorUiStore.ts
@@ -72,6 +72,10 @@ type EditorUiState = {
   // reading order
   readingOrder: 'rtl' | 'ltr' | 'custom'
   setReadingOrder: (order: 'rtl' | 'ltr' | 'custom') => void
+
+  // block Focus signal
+  blockFocusTarget: string | null
+  setBlockFocusTarget: (id: string | null) => void
 }
 
 const initialState = {
@@ -90,13 +94,14 @@ const initialState = {
   error: undefined as { id: number; message: string } | undefined,
   showNavigator: true,
   readingOrder: 'rtl' as const,
+  blockFocusTarget: null as string | null,
 }
 
 export const useEditorUiStore = create<EditorUiState>((set) => ({
   ...initialState,
 
   setScale: (scale) => {
-    const clamped = Math.max(10, Math.min(100, Math.round(scale)))
+    const clamped = Math.max(10, Math.min(400, Math.round(scale)))
     set({ scale: clamped })
   },
   setAutoFitEnabled: (enabled) => set({ autoFitEnabled: enabled }),
@@ -147,4 +152,6 @@ export const useEditorUiStore = create<EditorUiState>((set) => ({
   setShowNavigator: (show) => set({ showNavigator: show }),
 
   setReadingOrder: (readingOrder) => set({ readingOrder }),
+
+  setBlockFocusTarget: (id) => set({ blockFocusTarget: id }),
 }))

--- a/ui/lib/stores/preferencesStore.ts
+++ b/ui/lib/stores/preferencesStore.ts
@@ -31,10 +31,27 @@ type PreferencesState = {
     decreaseBrushSize: string
     undo: string
     redo: string
+    prevPage: string
+    nextPage: string
+    resetView: string
+    zoomIn: string
+    zoomOut: string
+    nextBlock: string
+    prevBlock: string
   }
+  zoomStep: number
+  setZoomStep: (value: number) => void
+  blockNavWrapAround: boolean
+  setBlockNavWrapAround: (value: boolean) => void
+  wheelZoomOnly: boolean
+  setWheelZoomOnly: (value: boolean) => void
   setShortcuts: (shortcuts: Partial<PreferencesState['shortcuts']>) => void
   resetShortcuts: () => void
   resetPreferences: () => void
+  wheelZoomSpeed: number
+  setWheelZoomSpeed: (value: number) => void
+  panningButton: 'right'
+  setPanningButton: (value: 'right') => void
 }
 
 const initialPreferences = {
@@ -53,10 +70,22 @@ const initialPreferences = {
     decreaseBrushSize: '[',
     undo: getPlatform() === 'mac' ? 'Cmd+Z' : 'Ctrl+Z',
     redo: getPlatform() === 'mac' ? 'Cmd+Shift+Z' : 'Ctrl+Shift+Z',
+    prevPage: 'O',
+    nextPage: 'P',
+    resetView: 'Home',
+    zoomIn: '=',
+    zoomOut: '-',
+    nextBlock: getPlatform() === 'mac' ? 'Cmd+Enter' : 'Ctrl+Enter',
+    prevBlock: getPlatform() === 'mac' ? 'Cmd+Shift+Enter' : 'Ctrl+Shift+Enter',
   },
   codexImagePrompt:
     'Translate all visible text to natural English, remove the original lettering, and redraw the page as a clean manga image while preserving the artwork, panel layout, speech bubbles, tone, and composition.',
   codexImageModel: 'gpt-5.5',
+  wheelZoomOnly: true,
+  wheelZoomSpeed: 3,
+  zoomStep: 10,
+  blockNavWrapAround: true,
+  panningButton: 'right' as const,
 }
 
 export const usePreferencesStore = create<PreferencesState>()(
@@ -93,11 +122,16 @@ export const usePreferencesStore = create<PreferencesState>()(
             ...initialPreferences.shortcuts,
           },
         })),
+      setWheelZoomOnly: (value) => set({ wheelZoomOnly: value }),
+      setWheelZoomSpeed: (value) => set({ wheelZoomSpeed: value }),
+      setZoomStep: (value) => set({ zoomStep: value }),
+      setBlockNavWrapAround: (value) => set({ blockNavWrapAround: value }),
+      setPanningButton: (value) => set({ panningButton: value }),
       resetPreferences: () => set({ ...initialPreferences }),
     }),
     {
       name: 'koharu-config',
-      version: 6,
+      version: 7,
       migrate: (persisted: any, version: number) => {
         if (version < 2 && persisted) {
           delete persisted.localLlm
@@ -129,6 +163,23 @@ export const usePreferencesStore = create<PreferencesState>()(
           persisted.codexImagePrompt ??= initialPreferences.codexImagePrompt
           persisted.codexImageModel ??= initialPreferences.codexImageModel
         }
+        if (version < 7 && persisted) {
+          const isMac = getPlatform() === 'mac'
+          persisted.wheelZoomOnly ??= true
+          persisted.wheelZoomSpeed ??= 3
+          persisted.panningButton ??= 'right'
+          persisted.zoomStep ??= 10
+          persisted.blockNavWrapAround ??= true
+          if (persisted.shortcuts) {
+            persisted.shortcuts.prevPage ??= 'O'
+            persisted.shortcuts.nextPage ??= 'P'
+            persisted.shortcuts.resetView ??= 'Home'
+            persisted.shortcuts.zoomIn    ??= '='
+            persisted.shortcuts.zoomOut   ??= '-'
+            persisted.shortcuts.nextBlock = isMac ? 'Cmd+Enter' : 'Ctrl+Enter'
+            persisted.shortcuts.prevBlock = isMac ? 'Cmd+Shift+Enter' : 'Ctrl+Shift+Enter'
+          }
+        }
         return persisted
       },
       partialize: (state) => ({
@@ -139,6 +190,11 @@ export const usePreferencesStore = create<PreferencesState>()(
         codexImagePrompt: state.codexImagePrompt,
         codexImageModel: state.codexImageModel,
         shortcuts: state.shortcuts,
+        wheelZoomOnly: state.wheelZoomOnly,
+        wheelZoomSpeed: state.wheelZoomSpeed,
+        zoomStep: state.zoomStep,
+        blockNavWrapAround: state.blockNavWrapAround,
+        panningButton: state.panningButton,
       }),
     },
   ),

--- a/ui/lib/stores/speakersStore.ts
+++ b/ui/lib/stores/speakersStore.ts
@@ -1,0 +1,73 @@
+'use client'
+
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+type SpeakersState = {
+  speakersByProject: Record<string, string[]>
+  addSpeaker: (projectId: string, name: string) => void
+  removeSpeaker: (projectId: string, name: string) => void
+  renameSpeaker: (projectId: string, oldName: string, newName: string) => void
+  reorderSpeakers: (projectId: string, newOrder: string[]) => void
+  getSpeakers: (projectId: string) => string[]
+}
+
+export const useSpeakersStore = create<SpeakersState>()(
+  persist(
+    (set, get) => ({
+      speakersByProject: {},
+
+      addSpeaker: (projectId, name) => {
+        const trimmed = name.trim()
+        if (!trimmed) return
+        const current = get().speakersByProject[projectId] ?? []
+        if (current.includes(trimmed)) return
+        set((state) => ({
+          speakersByProject: {
+            ...state.speakersByProject,
+            [projectId]: [...current, trimmed],
+          },
+        }))
+      },
+
+      removeSpeaker: (projectId, name) => {
+        const current = get().speakersByProject[projectId] ?? []
+        set((state) => ({
+          speakersByProject: {
+            ...state.speakersByProject,
+            [projectId]: current.filter((n) => n !== name),
+          },
+        }))
+      },
+
+      renameSpeaker: (projectId, oldName, newName) => {
+        const trimmed = newName.trim()
+        if (!trimmed || trimmed === oldName) return
+        const current = get().speakersByProject[projectId] ?? []
+        if (current.includes(trimmed)) return
+        set((state) => ({
+          speakersByProject: {
+            ...state.speakersByProject,
+            [projectId]: current.map((n) => (n === oldName ? trimmed : n)),
+          },
+        }))
+      },
+
+      reorderSpeakers: (projectId, newOrder) => {
+        set((state) => ({
+          speakersByProject: {
+            ...state.speakersByProject,
+            [projectId]: newOrder,
+          },
+        }))
+      },
+
+      getSpeakers: (projectId) => {
+        return get().speakersByProject[projectId] ?? []
+      },
+    }),
+    {
+      name: 'koharu-speakers',
+    },
+  ),
+)

--- a/ui/public/locales/en-US/translation.json
+++ b/ui/public/locales/en-US/translation.json
@@ -28,6 +28,7 @@
     "exportPsd": "Export PSD...",
     "exportAllInpainted": "Export All Inpainted...",
     "exportAllRendered": "Export All Rendered...",
+    "exportText": "Export Text...",
     "view": "View",
     "fitWindow": "Fit Window",
     "originalSize": "Original Size",
@@ -263,7 +264,14 @@
     "readingOrder": "Reading Order",
     "readingOrderRtl": "Right-to-Left (RTL)",
     "readingOrderLtr": "Left-to-Right (LTR)",
-    "readingOrderCustom": "Custom"
+    "readingOrderCustom": "Custom",
+    "speakerLabel": "Speaker",
+    "speakerList": "Speaker List",
+    "speakerAddPlaceholder": "Add speaker name",
+    "speakerEmpty": "No speakers registered.",
+    "speakerSelectPlaceholder": "Select speaker",
+    "speakerNone": "None",
+    "speakerInputPlaceholder": "Direct input"
   },
   "workspace": {
     "importPrompt": "Import a page to begin editing.",
@@ -285,6 +293,20 @@
     "brush": "Brush",
     "repairBrush": "Repair brush",
     "eraser": "Eraser"
+  },
+  "export": {
+    "dialogTitle": "Export",
+    "scope": "Scope",
+    "scopeCurrent": "Current page",
+    "scopeSelected": "Select pages",
+    "scopeAll": "All pages",
+    "format": "Format",
+    "filename": "Filename",
+    "save": "Save",
+    "noText": "(No text)",
+    "speaker": "Speaker",
+    "original": "Original",
+    "translation": "Translation"
   },
   "download": {
     "title": "Downloading"
@@ -428,7 +450,21 @@
     "shortcutReset": "Reset Keybinds",
     "shortcutResetDescription": "This will restore all shortcuts to their default values. Your saved changes will be lost.",
     "shortcutConflict": "Key combination already in use",
-    "shortcutInvalid": "This key cannot be used as a shortcut"
+    "shortcutInvalid": "This key cannot be used as a shortcut",
+    "shortcutPrevPage": "Previous Page",
+    "shortcutNextPage": "Next Page",
+    "shortcutResetView": "Reset View",
+    "settings.shortcutZoomIn": "Zoom In",
+    "settings.shortcutZoomOut": "Zoom Out",
+    "settings.shortcutNextBlock": "Next Text Block",
+    "settings.shortcutPrevBlock": "Previous Text Block",
+    "canvasControls": "Canvas Controls",
+    "wheelZoomOnly": "Require Ctrl / Cmd for Wheel Zoom",
+    "wheelZoomSpeed": "Zoom Speed",
+    "panningButton": "Panning Button",
+    "panningRight": "Right Click",
+    "settings.zoomStep": "Keyboard Zoom Step",
+    "settings.blockNavWrapAround": "Wrap Around Block Navigation"
   },
   "updater": {
     "available": {

--- a/ui/public/locales/es-ES/translation.json
+++ b/ui/public/locales/es-ES/translation.json
@@ -23,6 +23,7 @@
     "exportPsd": "Exportar PSD...",
     "exportAllInpainted": "Exportar todo lo rellenado...",
     "exportAllRendered": "Exportar todo lo renderizado...",
+    "exportText": "Exportar texto...",
     "view": "Ver",
     "fitWindow": "Ajustar a la ventana",
     "originalSize": "Tamaño original",
@@ -230,7 +231,14 @@
     "readingOrder": "Orden de lectura",
     "readingOrderRtl": "Derecha a izquierda (RTL)",
     "readingOrderLtr": "Izquierda a derecha (LTR)",
-    "readingOrderCustom": "Personalizado"
+    "readingOrderCustom": "Personalizado",
+    "speakerLabel": "Hablante",
+    "speakerList": "Lista de hablantes",
+    "speakerAddPlaceholder": "Añadir nombre de hablante",
+    "speakerEmpty": "No hay hablantes registrados.",
+    "speakerSelectPlaceholder": "Seleccionar hablante",
+    "speakerNone": "Ninguno",
+    "speakerInputPlaceholder": "Entrada directa"
   },
   "workspace": {
     "importPrompt": "Importa una página para comenzar a editar.",
@@ -252,6 +260,20 @@
     "brush": "Pincel",
     "repairBrush": "Pincel de reparación",
     "eraser": "Borrador"
+  },
+  "export": {
+    "dialogTitle": "Exportar",
+    "scope": "Ámbito",
+    "scopeCurrent": "Página actual",
+    "scopeSelected": "Seleccionar páginas",
+    "scopeAll": "Todas las páginas",
+    "format": "Formato",
+    "filename": "Nombre de archivo",
+    "save": "Guardar",
+    "noText": "(Sin texto)",
+    "speaker": "Hablante",
+    "original": "Original",
+    "translation": "Traducción"
   },
   "download": {
     "title": "Descargando"
@@ -391,7 +413,21 @@
     "shortcutReset": "Restablecer atajos",
     "shortcutResetDescription": "Esto restaurará todos los atajos a sus valores predeterminados. Los cambios guardados se perderán.",
     "shortcutConflict": "Combinación de teclas en uso",
-    "shortcutInvalid": "Esta tecla no se puede usar como atajo"
+    "shortcutInvalid": "Esta tecla no se puede usar como atajo",
+    "shortcutPrevPage": "Página anterior",
+    "shortcutNextPage": "Página siguiente",
+    "shortcutResetView": "Restablecer vista",
+    "settings.shortcutZoomIn": "Acercar",
+    "settings.shortcutZoomOut": "Alejar",
+    "settings.shortcutNextBlock": "Siguiente bloque de texto",
+    "settings.shortcutPrevBlock": "Bloque de texto anterior",
+    "canvasControls": "Controles del lienzo",
+    "wheelZoomOnly": "Requerir Ctrl / Cmd para zoom con rueda",
+    "wheelZoomSpeed": "Velocidad de zoom",
+    "panningButton": "Botón de desplazamiento",
+    "panningRight": "Clic derecho",
+    "settings.zoomStep": "Paso de zoom con teclado",
+    "settings.blockNavWrapAround": "Navegación circular entre bloques"
   },
   "updater": {
     "available": {

--- a/ui/public/locales/ja-JP/translation.json
+++ b/ui/public/locales/ja-JP/translation.json
@@ -23,6 +23,7 @@
     "exportPsd": "PSD を書き出し...",
     "exportAllInpainted": "インペイント画像をすべてエクスポート...",
     "exportAllRendered": "レンダリング画像をすべてエクスポート...",
+    "exportText": "テキストを書き出す...",
     "view": "表示",
     "fitWindow": "ウィンドウに合わせる",
     "originalSize": "原寸",
@@ -230,7 +231,14 @@
     "readingOrder": "読み順",
     "readingOrderRtl": "右から左 (RTL)",
     "readingOrderLtr": "左から右 (LTR)",
-    "readingOrderCustom": "カスタム"
+    "readingOrderCustom": "カスタム",
+    "speakerLabel": "話者",
+    "speakerList": "話者リスト",
+    "speakerAddPlaceholder": "話者名を追加",
+    "speakerEmpty": "話者が登録されていません。",
+    "speakerSelectPlaceholder": "話者を選択",
+    "speakerNone": "なし",
+    "speakerInputPlaceholder": "直接入力"
   },
   "workspace": {
     "importPrompt": "ページを読み込んで編集を開始してください。",
@@ -252,6 +260,20 @@
     "brush": "ブラシ",
     "repairBrush": "リペアブラシ",
     "eraser": "消しゴム"
+  },
+  "export": {
+    "dialogTitle": "エクスポート",
+    "scope": "範囲",
+    "scopeCurrent": "現在のページ",
+    "scopeSelected": "ページを選択",
+    "scopeAll": "すべてのページ",
+    "format": "フォーマット",
+    "filename": "ファイル名",
+    "save": "保存",
+    "noText": "(テキストなし)",
+    "speaker": "話者",
+    "original": "原文",
+    "translation": "翻訳"
   },
   "download": {
     "title": "ダウンロード中"
@@ -391,7 +413,21 @@
     "shortcutReset": "ショートカットのリセット",
     "shortcutResetDescription": "すべてのショートカットをデフォルト値に戻します。保存された変更は失われます。",
     "shortcutConflict": "そのキーの組み合わせは既に使用されています",
-    "shortcutInvalid": "このキーはショートカットとして使用できません"
+    "shortcutInvalid": "このキーはショートカットとして使用できません",
+    "shortcutPrevPage": "前のページ",
+    "shortcutNextPage": "次のページ",
+    "shortcutResetView": "表示をリセット",
+    "settings.shortcutZoomIn": "拡大",
+    "settings.shortcutZoomOut": "縮小",
+    "settings.shortcutNextBlock": "次のテキストブロック",
+    "settings.shortcutPrevBlock": "前のテキストブロック",
+    "canvasControls": "キャンバスコントロール",
+    "wheelZoomOnly": "ホイールズームにCtrl/Cmdを必要とする",
+    "wheelZoomSpeed": "ズーム速度",
+    "panningButton": "パンニングボタン",
+    "panningRight": "右クリック",
+    "settings.zoomStep": "キーボードズームステップ",
+    "settings.blockNavWrapAround": "ブロックナビゲーションの折り返し"
   },
   "updater": {
     "available": {

--- a/ui/public/locales/ko-KR/translation.json
+++ b/ui/public/locales/ko-KR/translation.json
@@ -28,6 +28,7 @@
     "exportPsd": "PSD 내보내기...",
     "exportAllInpainted": "모든 인페인트 이미지 내보내기...",
     "exportAllRendered": "모든 렌더링된 이미지 내보내기...",
+    "exportText": "텍스트 내보내기...",
     "view": "보기",
     "fitWindow": "창에 맞추기",
     "originalSize": "원본 크기",
@@ -252,7 +253,14 @@
     "readingOrder": "읽기 순서",
     "readingOrderRtl": "우에서 좌 (RTL)",
     "readingOrderLtr": "좌에서 우 (LTR)",
-    "readingOrderCustom": "사용자 정의"
+    "readingOrderCustom": "사용자 정의",
+    "speakerLabel": "화자",
+    "speakerList": "화자 목록",
+    "speakerAddPlaceholder": "화자 이름 추가",
+    "speakerEmpty": "등록된 화자가 없습니다.",
+    "speakerSelectPlaceholder": "화자 선택",
+    "speakerNone": "없음",
+    "speakerInputPlaceholder": "직접 입력"
   },
   "workspace": {
     "importPrompt": "편집을 시작하려면 페이지를 가져오세요.",
@@ -274,6 +282,20 @@
     "brush": "브러시",
     "repairBrush": "복구 브러시",
     "eraser": "지우개"
+  },
+  "export": {
+    "dialogTitle": "내보내기",
+    "scope": "범위",
+    "scopeCurrent": "현재 페이지",
+    "scopeSelected": "페이지 선택",
+    "scopeAll": "모든 페이지",
+    "format": "형식",
+    "filename": "파일명",
+    "save": "저장",
+    "noText": "(텍스트 없음)",
+    "speaker": "화자",
+    "original": "원문",
+    "translation": "번역"
   },
   "download": {
     "title": "다운로드 중"
@@ -417,7 +439,21 @@
     "shortcutReset": "단축키 초기화",
     "shortcutResetDescription": "모든 단축키를 기본값으로 복원합니다. 저장된 변경 사항은 삭제됩니다.",
     "shortcutConflict": "이미 사용 중인 키 조합입니다",
-    "shortcutInvalid": "이 키는 단축키로 사용할 수 없습니다"
+    "shortcutInvalid": "이 키는 단축키로 사용할 수 없습니다",
+    "shortcutPrevPage": "이전 페이지",
+    "shortcutNextPage": "다음 페이지",
+    "shortcutResetView": "뷰 초기화",
+    "shortcutZoomIn": "확대",
+    "shortcutZoomOut": "축소",
+    "shortcutNextBlock": "다음 텍스트 블록",
+    "shortcutPrevBlock": "이전 텍스트 블록",
+    "canvasControls": "캔버스 컨트롤",
+    "wheelZoomOnly": "휠 줌에 Ctrl / Cmd 필요",
+    "wheelZoomSpeed": "줌 속도",
+    "panningButton": "패닝 버튼",
+    "panningRight": "우클릭",
+    "zoomStep": "키보드 줌 배율",
+    "blockNavWrapAround": "블록 이동 순환"
   },
   "updater": {
     "available": {

--- a/ui/public/locales/pt-BR/translation.json
+++ b/ui/public/locales/pt-BR/translation.json
@@ -24,6 +24,7 @@
     "exportPsd": "Exportar PSD...",
     "exportAllInpainted": "Exportar todos os inpaintings...",
     "exportAllRendered": "Exportar todos os renderizados...",
+    "exportText": "Exportar texto...",
     "view": "Visualizar",
     "fitWindow": "Ajustar à janela",
     "originalSize": "Tamanho original",
@@ -231,7 +232,14 @@
     "readingOrder": "Ordem de leitura",
     "readingOrderRtl": "Direita para esquerda (RTL)",
     "readingOrderLtr": "Esquerda para direita (LTR)",
-    "readingOrderCustom": "Personalizado"
+    "readingOrderCustom": "Personalizado",
+    "speakerLabel": "Falante",
+    "speakerList": "Lista de falantes",
+    "speakerAddPlaceholder": "Adicionar nome do falante",
+    "speakerEmpty": "Nenhum falante registrado.",
+    "speakerSelectPlaceholder": "Selecionar falante",
+    "speakerNone": "Nenhum",
+    "speakerInputPlaceholder": "Entrada direta"
   },
   "workspace": {
     "importPrompt": "Importe uma página para começar a editar.",
@@ -253,6 +261,20 @@
     "brush": "Pincel",
     "repairBrush": "Pincel de reparo",
     "eraser": "Borracha"
+  },
+  "export": {
+    "dialogTitle": "Exportar",
+    "scope": "Escopo",
+    "scopeCurrent": "Página atual",
+    "scopeSelected": "Selecionar páginas",
+    "scopeAll": "Todas as páginas",
+    "format": "Formato",
+    "filename": "Nome do arquivo",
+    "save": "Salvar",
+    "noText": "(Sem texto)",
+    "speaker": "Falante",
+    "original": "Original",
+    "translation": "Tradução"
   },
   "download": {
     "title": "Baixando"
@@ -392,7 +414,21 @@
     "shortcutReset": "Redefinir Atalhos",
     "shortcutResetDescription": "Isso restaurará todos os atalhos para seus valores padrão. Suas alterações salvas serão perdidas.",
     "shortcutConflict": "Combinação de teclas já em uso",
-    "shortcutInvalid": "Esta tecla não pode ser usada como atalho"
+    "shortcutInvalid": "Esta tecla não pode ser usada como atalho",
+    "shortcutPrevPage": "Página anterior",
+    "shortcutNextPage": "Próxima página",
+    "shortcutResetView": "Redefinir visualização",
+    "settings.shortcutZoomIn": "Ampliar",
+    "settings.shortcutZoomOut": "Reduzir",
+    "settings.shortcutNextBlock": "Próximo bloco de texto",
+    "settings.shortcutPrevBlock": "Bloco de texto anterior",
+    "canvasControls": "Controles da tela",
+    "wheelZoomOnly": "Exigir Ctrl / Cmd para zoom com roda",
+    "wheelZoomSpeed": "Velocidade do zoom",
+    "panningButton": "Botão de panorâmica",
+    "panningRight": "Clique direito",
+    "settings.zoomStep": "Passo de zoom pelo teclado",
+    "settings.blockNavWrapAround": "Navegação circular entre blocos"
   },
   "updater": {
     "available": {

--- a/ui/public/locales/ru-RU/translation.json
+++ b/ui/public/locales/ru-RU/translation.json
@@ -23,6 +23,7 @@
     "exportPsd": "Экспортировать PSD...",
     "exportAllInpainted": "Экспортировать все изображения после инпейнтинга...",
     "exportAllRendered": "Экспортировать все отрендеренные изображения...",
+    "exportText": "Экспорт текста...",
     "view": "Вид",
     "fitWindow": "По размеру окна",
     "originalSize": "Исходный размер",
@@ -230,7 +231,14 @@
     "readingOrder": "Порядок чтения",
     "readingOrderRtl": "Справа налево (RTL)",
     "readingOrderLtr": "Слева направо (LTR)",
-    "readingOrderCustom": "Свой"
+    "readingOrderCustom": "Свой",
+    "speakerLabel": "Говорящий",
+    "speakerList": "Список говорящих",
+    "speakerAddPlaceholder": "Добавить имя говорящего",
+    "speakerEmpty": "Говорящие не зарегистрированы.",
+    "speakerSelectPlaceholder": "Выбрать говорящего",
+    "speakerNone": "Нет",
+    "speakerInputPlaceholder": "Прямой ввод"
   },
   "workspace": {
     "importPrompt": "Импортируйте страницу, чтобы начать редактирование.",
@@ -252,6 +260,20 @@
     "brush": "Кисть",
     "repairBrush": "Кисть восстановления",
     "eraser": "Ластик"
+  },
+  "export": {
+    "dialogTitle": "Экспорт",
+    "scope": "Область",
+    "scopeCurrent": "Текущая страница",
+    "scopeSelected": "Выбрать страницы",
+    "scopeAll": "Все страницы",
+    "format": "Формат",
+    "filename": "Имя файла",
+    "save": "Сохранить",
+    "noText": "(Нет текста)",
+    "speaker": "Говорящий",
+    "original": "Оригинал",
+    "translation": "Перевод"
   },
   "download": {
     "title": "Загрузка"
@@ -391,7 +413,21 @@
     "shortcutReset": "Сбросить сочетания",
     "shortcutResetDescription": "Это восстановит все сочетания клавиш до их значений по умолчанию. Сохраненные изменения будут потеряны.",
     "shortcutConflict": "Сочетание клавиш уже используется",
-    "shortcutInvalid": "Эту клавишу нельзя использовать как горячую"
+    "shortcutInvalid": "Эту клавишу нельзя использовать как горячую",
+    "shortcutPrevPage": "Предыдущая страница",
+    "shortcutNextPage": "Следующая страница",
+    "shortcutResetView": "Сбросить вид",
+    "settings.shortcutZoomIn": "Увеличить",
+    "settings.shortcutZoomOut": "Уменьшить",
+    "settings.shortcutNextBlock": "Следующий текстовый блок",
+    "settings.shortcutPrevBlock": "Предыдущий текстовый блок",
+    "canvasControls": "Управление холстом",
+    "wheelZoomOnly": "Требовать Ctrl / Cmd для масштабирования колёсиком",
+    "wheelZoomSpeed": "Скорость масштабирования",
+    "panningButton": "Кнопка панорамирования",
+    "panningRight": "Правая кнопка мыши",
+    "settings.zoomStep": "Шаг масштабирования клавиатурой",
+    "settings.blockNavWrapAround": "Циклическая навигация по блокам"
   },
   "updater": {
     "available": {

--- a/ui/public/locales/tr-TR/translation.json
+++ b/ui/public/locales/tr-TR/translation.json
@@ -23,6 +23,7 @@
     "exportPsd": "PSD Olarak Dışa Aktar...",
     "exportAllInpainted": "Tüm İnpaint Görsellerini Dışa Aktar...",
     "exportAllRendered": "Tüm Render Görsellerini Dışa Aktar...",
+    "exportText": "Metni dışa aktar...",
     "view": "Görünüm",
     "fitWindow": "Pencereye Sığdır",
     "originalSize": "Özgün Boyut",
@@ -230,7 +231,14 @@
     "readingOrder": "Okuma Sırası",
     "readingOrderRtl": "Sağdan Sola (RTL)",
     "readingOrderLtr": "Soldan Sağa (LTR)",
-    "readingOrderCustom": "Özel"
+    "readingOrderCustom": "Özel",
+    "speakerLabel": "Konuşmacı",
+    "speakerList": "Konuşmacı Listesi",
+    "speakerAddPlaceholder": "Konuşmacı adı ekle",
+    "speakerEmpty": "Kayıtlı konuşmacı yok.",
+    "speakerSelectPlaceholder": "Konuşmacı seç",
+    "speakerNone": "Yok",
+    "speakerInputPlaceholder": "Doğrudan giriş"
   },
   "workspace": {
     "importPrompt": "Düzenlemeye başlamak için bir sayfa içe aktarın.",
@@ -252,6 +260,20 @@
     "brush": "Fırça",
     "repairBrush": "Onarım fırçası",
     "eraser": "Silgi"
+  },
+  "export": {
+    "dialogTitle": "Dışa aktar",
+    "scope": "Kapsam",
+    "scopeCurrent": "Mevcut sayfa",
+    "scopeSelected": "Sayfa seç",
+    "scopeAll": "Tüm sayfalar",
+    "format": "Biçim",
+    "filename": "Dosya adı",
+    "save": "Kaydet",
+    "noText": "(Metin yok)",
+    "speaker": "Konuşmacı",
+    "original": "Orijinal",
+    "translation": "Çeviri"
   },
   "download": {
     "title": "İndiriliyor"
@@ -391,7 +413,21 @@
     "shortcutReset": "Kısayolları Sıfırla",
     "shortcutResetDescription": "Bu, tüm klavye kısayollarını varsayılan değerlerine döndürecektir. Kaydedilen değişiklikleriniz kaybolacaktır.",
     "shortcutConflict": "Tuş kombinasyonu zaten kullanılıyor",
-    "shortcutInvalid": "Bu tuş kısayol olarak kullanılamaz"
+    "shortcutInvalid": "Bu tuş kısayol olarak kullanılamaz",
+    "shortcutPrevPage": "Önceki Sayfa",
+    "shortcutNextPage": "Sonraki Sayfa",
+    "shortcutResetView": "Görünümü Sıfırla",
+    "settings.shortcutZoomIn": "Yakınlaştır",
+    "settings.shortcutZoomOut": "Uzaklaştır",
+    "settings.shortcutNextBlock": "Sonraki Metin Bloğu",
+    "settings.shortcutPrevBlock": "Önceki Metin Bloğu",
+    "canvasControls": "Tuval Kontrolleri",
+    "wheelZoomOnly": "Tekerlek Yakınlaştırma için Ctrl / Cmd Gerekli",
+    "wheelZoomSpeed": "Yakınlaştırma Hızı",
+    "panningButton": "Kaydırma Düğmesi",
+    "panningRight": "Sağ Tıklama",
+    "settings.zoomStep": "Klavye Yakınlaştırma Adımı",
+    "settings.blockNavWrapAround": "Döngüsel Blok Gezintisi"
   },
   "updater": {
     "available": {

--- a/ui/public/locales/zh-CN/translation.json
+++ b/ui/public/locales/zh-CN/translation.json
@@ -23,6 +23,7 @@
     "exportPsd": "导出 PSD...",
     "exportAllInpainted": "导出所有修复后的图像...",
     "exportAllRendered": "导出所有渲染后的图像...",
+    "exportText": "导出文本...",
     "view": "视图",
     "fitWindow": "适应窗口",
     "originalSize": "原始大小",
@@ -230,7 +231,14 @@
     "readingOrder": "阅读顺序",
     "readingOrderRtl": "从右至左 (RTL)",
     "readingOrderLtr": "从左至右 (LTR)",
-    "readingOrderCustom": "自定义"
+    "readingOrderCustom": "自定义",
+    "speakerLabel": "说话人",
+    "speakerList": "说话人列表",
+    "speakerAddPlaceholder": "添加说话人名称",
+    "speakerEmpty": "暂无已注册的说话人。",
+    "speakerSelectPlaceholder": "选择说话人",
+    "speakerNone": "无",
+    "speakerInputPlaceholder": "直接输入"
   },
   "workspace": {
     "importPrompt": "导入页面以开始编辑。",
@@ -252,6 +260,20 @@
     "brush": "画笔",
     "repairBrush": "修复笔",
     "eraser": "橡皮擦"
+  },
+  "export": {
+    "dialogTitle": "导出",
+    "scope": "范围",
+    "scopeCurrent": "当前页面",
+    "scopeSelected": "选择页面",
+    "scopeAll": "所有页面",
+    "format": "格式",
+    "filename": "文件名",
+    "save": "保存",
+    "noText": "(无文本)",
+    "speaker": "说话人",
+    "original": "原文",
+    "translation": "翻译"
   },
   "download": {
     "title": "下载中"
@@ -391,7 +413,21 @@
     "shortcutReset": "重置快捷键",
     "shortcutResetDescription": "这将恢复所有快捷键到默认值。您保存的更改将丢失。",
     "shortcutConflict": "此按键组合已在使用中",
-    "shortcutInvalid": "此按键不能用作快捷键"
+    "shortcutInvalid": "此按键不能用作快捷键",
+    "shortcutPrevPage": "上一页",
+    "shortcutNextPage": "下一页",
+    "shortcutResetView": "重置视图",
+    "settings.shortcutZoomIn": "放大",
+    "settings.shortcutZoomOut": "缩小",
+    "settings.shortcutNextBlock": "下一个文本块",
+    "settings.shortcutPrevBlock": "上一个文本块",
+    "canvasControls": "画布控制",
+    "wheelZoomOnly": "滚轮缩放需按住 Ctrl / Cmd",
+    "wheelZoomSpeed": "缩放速度",
+    "panningButton": "平移按键",
+    "panningRight": "右键",
+    "settings.zoomStep": "键盘缩放步长",
+    "settings.blockNavWrapAround": "文本块循环导航"
   },
   "updater": {
     "available": {

--- a/ui/public/locales/zh-TW/translation.json
+++ b/ui/public/locales/zh-TW/translation.json
@@ -23,6 +23,7 @@
     "exportPsd": "匯出 PSD...",
     "exportAllInpainted": "匯出所有修補後的影像...",
     "exportAllRendered": "匯出所有渲染後的影像...",
+    "exportText": "匯出文字...",
     "view": "檢視",
     "fitWindow": "符合視窗",
     "originalSize": "原始大小",
@@ -230,7 +231,14 @@
     "readingOrder": "閱讀順序",
     "readingOrderRtl": "從右至左 (RTL)",
     "readingOrderLtr": "從左至右 (LTR)",
-    "readingOrderCustom": "自定義"
+    "readingOrderCustom": "自定義",
+    "speakerLabel": "說話者",
+    "speakerList": "說話者列表",
+    "speakerAddPlaceholder": "新增說話者名稱",
+    "speakerEmpty": "尚無已登錄的說話者。",
+    "speakerSelectPlaceholder": "選擇說話者",
+    "speakerNone": "無",
+    "speakerInputPlaceholder": "直接輸入"
   },
   "workspace": {
     "importPrompt": "匯入頁面以開始編輯。",
@@ -252,6 +260,20 @@
     "brush": "筆刷",
     "repairBrush": "修復筆",
     "eraser": "橡皮擦"
+  },
+  "export": {
+    "dialogTitle": "匯出",
+    "scope": "範圍",
+    "scopeCurrent": "目前頁面",
+    "scopeSelected": "選擇頁面",
+    "scopeAll": "所有頁面",
+    "format": "格式",
+    "filename": "檔案名稱",
+    "save": "儲存",
+    "noText": "(無文字)",
+    "speaker": "說話者",
+    "original": "原文",
+    "translation": "翻譯"
   },
   "download": {
     "title": "下載中"
@@ -391,7 +413,21 @@
     "shortcutReset": "重置快捷鍵",
     "shortcutResetDescription": "這將恢復所有快捷鍵到默認值。您保存的更改將丟失。",
     "shortcutConflict": "按鍵組合已被使用",
-    "shortcutInvalid": "此按鍵不能用作快捷鍵"
+    "shortcutInvalid": "此按鍵不能用作快捷鍵",
+    "shortcutPrevPage": "上一頁",
+    "shortcutNextPage": "下一頁",
+    "shortcutResetView": "重置檢視",
+    "settings.shortcutZoomIn": "放大",
+    "settings.shortcutZoomOut": "縮小",
+    "settings.shortcutNextBlock": "下一個文字區塊",
+    "settings.shortcutPrevBlock": "上一個文字區塊",
+    "canvasControls": "畫布控制",
+    "wheelZoomOnly": "滾輪縮放需按住 Ctrl / Cmd",
+    "wheelZoomSpeed": "縮放速度",
+    "panningButton": "平移按鈕",
+    "panningRight": "右鍵",
+    "settings.zoomStep": "鍵盤縮放步進",
+    "settings.blockNavWrapAround": "文字區塊循環導覽"
   },
   "updater": {
     "available": {

--- a/ui/tests/hooks/useKeyboardShortcuts.test.tsx
+++ b/ui/tests/hooks/useKeyboardShortcuts.test.tsx
@@ -8,6 +8,8 @@ import type { Node, Page, SceneSnapshot } from '@/lib/api/schemas'
 import { queryClient } from '@/lib/queryClient'
 import { useSelectionStore } from '@/lib/stores/selectionStore'
 
+import { QueryClientProvider } from '@tanstack/react-query'
+
 function textNode(id: string): Node {
   return {
     id,
@@ -40,7 +42,13 @@ describe('useKeyboardShortcuts — Ctrl+A', () => {
   it('Ctrl+A selects every text node on the active page', () => {
     queryClient.setQueryData(getGetSceneJsonQueryKey(), seedScene())
     useSelectionStore.getState().setPage('p-1')
-    renderHook(() => useKeyboardShortcuts())
+    renderHook(() => useKeyboardShortcuts(), {
+      wrapper: ({ children }) => (
+        <QueryClientProvider client={queryClient}>
+          {children}
+        </QueryClientProvider>
+      ),
+    })
 
     fireEvent.keyDown(window, { key: 'a', ctrlKey: true })
 
@@ -50,7 +58,13 @@ describe('useKeyboardShortcuts — Ctrl+A', () => {
   it('Ctrl+A is a no-op while typing inside a textarea', () => {
     queryClient.setQueryData(getGetSceneJsonQueryKey(), seedScene())
     useSelectionStore.getState().setPage('p-1')
-    renderHook(() => useKeyboardShortcuts())
+    renderHook(() => useKeyboardShortcuts(), {
+      wrapper: ({ children }) => (
+        <QueryClientProvider client={queryClient}>
+         {children}
+        </QueryClientProvider>
+      ),
+    })
 
     const textarea = document.createElement('textarea')
     document.body.appendChild(textarea)


### PR DESCRIPTION
## Description
This PR introduces several UX improvements for text block management and editor navigation.

### Changes
[Text Block Panel]
- Add speaker field and project-level speaker name management modal
- Support block reordering via drag-and-drop and manual input
- Add text block export functionality (current, selected, or all pages)
- Move delete and translate buttons to the Speaker section header

[Compatibility]
- Add v1 schema migration for scene.bin files created before the speaker
field was introduced; legacy projects now open without error instead of 
failing with "Found an Option discriminant that wasn't 0 or 1"

[Navigation]
- Add keyboard shortcuts for page navigation and centering image
- Improve mouse-pointer-centric zoom, horizontal scrolling, and zoom speed control (up to 400%)
- Add right-click drag panning and +/- zoom shortcuts
- Add auto-scroll and center alignment when a text block is selected
- Add shortcut to select next text block (selects first block on page if none selected)
- Add ESC shortcut to dismiss text input focus

[Text Box UI]
- Visualize 8-directional resize handles and update text box design
- Adjust text box number badge position (top center)
 - Change edge midpoint handle positions

### AI Disclosure
- **Code Generation:** I used **Claude** to assist with generating and refactoring parts of the code logic.
-**Translation:** I used **Claude** to help with Language translation.
-**Validation::** I have manually tested the features to ensure they work as intended.