### PR TITLE
fix: Remove Aggressive sceneEpoch Triggering

### DIFF
--- a/ui/components/canvas/Workspace.tsx
+++ b/ui/components/canvas/Workspace.tsx
@@ -37,7 +37,6 @@ import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts'
 import { useMaskDrawing } from '@/hooks/useMaskDrawing'
 import { usePointerToDocument } from '@/hooks/usePointerToDocument'
 import { useRenderBrushDrawing } from '@/hooks/useRenderBrushDrawing'
-import { useScene } from '@/hooks/useScene'
 import type { Node, Transform } from '@/lib/api/schemas'
 import { applyOp } from '@/lib/io/scene'
 import { ops } from '@/lib/ops'
@@ -68,27 +67,14 @@ export function Workspace() {
   const autoFitEnabled = useEditorUiStore((s) => s.autoFitEnabled)
 
   const page = useCurrentPage()
-  const { epoch: sceneEpoch } = useScene()
   const clearSelection = useSelectionStore((s) => s.clear)
 
   // Derive role-keyed blob hashes off the active page.
-  const imageHash = useMemo(() => (page ? findImageBlob(page, 'source') : null), [page, sceneEpoch])
-  const segmentHash = useMemo(
-    () => (page ? findMaskBlob(page, 'segment') : null),
-    [page, sceneEpoch],
-  )
-  const inpaintedHash = useMemo(
-    () => (page ? findImageBlob(page, 'inpainted') : null),
-    [page, sceneEpoch],
-  )
-  const brushLayerHash = useMemo(
-    () => (page ? findMaskBlob(page, 'brushInpaint') : null),
-    [page, sceneEpoch],
-  )
-  const renderedHash = useMemo(
-    () => (page ? findImageBlob(page, 'rendered') : null),
-    [page, sceneEpoch],
-  )
+  const imageHash = useMemo(() => (page ? findImageBlob(page, 'source') : null), [page])
+  const segmentHash = useMemo(() => (page ? findMaskBlob(page, 'segment') : null), [page])
+  const inpaintedHash = useMemo(() => (page ? findImageBlob(page, 'inpainted') : null), [page])
+  const brushLayerHash = useMemo(() => (page ? findMaskBlob(page, 'brushInpaint') : null), [page])
+  const renderedHash = useMemo(() => (page ? findImageBlob(page, 'rendered') : null), [page])
 
   const imageData = useBlobData(imageHash ?? undefined)
   const segmentData = useBlobData(segmentHash ?? undefined)

--- a/ui/components/panels/TextBlocksPanel.tsx
+++ b/ui/components/panels/TextBlocksPanel.tsx
@@ -23,7 +23,6 @@ import {
 } from '@/components/ui/select'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useCurrentPage, useTextNodes, type TextNodeEntry } from '@/hooks/useCurrentPage'
-import { useScene } from '@/hooks/useScene'
 import { getConfig, startPipeline, useGetCurrentLlm } from '@/lib/api/default/default'
 import { fetchApi } from '@/lib/api/fetch'
 import type { TextDataPatch } from '@/lib/api/schemas'
@@ -37,7 +36,6 @@ import { useSelectionStore } from '@/lib/stores/selectionStore'
 export function TextBlocksPanel() {
   const { t } = useTranslation()
   const page = useCurrentPage()
-  const { epoch } = useScene()
   const textNodes = useTextNodes()
   useEffect(() => {
     if (process.env.NODE_ENV !== 'production') {

--- a/ui/hooks/useCurrentPage.ts
+++ b/ui/hooks/useCurrentPage.ts
@@ -98,8 +98,7 @@ export function useCurrentPage(): Page | null {
 /** Text nodes on the active page, in stacking order. */
 export function useTextNodes(): TextNodeEntry[] {
   const page = useCurrentPage()
-  const { epoch } = useScene()
-  return useMemo(() => (page ? textNodesOf(page) : []), [page, epoch])
+  return useMemo(() => (page ? textNodesOf(page) : []), [page])
 }
 
 /**
@@ -109,7 +108,6 @@ export function useTextNodes(): TextNodeEntry[] {
 export function useSelectedTextNode(): TextNodeEntry | null {
   const page = useCurrentPage()
   const nodeIds = useSelectionStore((s) => s.nodeIds)
-  const { epoch } = useScene()
   return useMemo(() => {
     if (!page) return null
     for (const id of nodeIds) {
@@ -123,14 +121,13 @@ export function useSelectedTextNode(): TextNodeEntry | null {
       }
     }
     return null
-  }, [page, nodeIds, epoch])
+  }, [page, nodeIds])
 }
 
 /** All selected text nodes in stacking order (for batch edits). */
 export function useSelectedTextNodes(): TextNodeEntry[] {
   const page = useCurrentPage()
   const nodeIds = useSelectionStore((s) => s.nodeIds)
-  const { epoch } = useScene()
   return useMemo(() => {
     if (!page) return []
     const out: TextNodeEntry[] = []
@@ -143,5 +140,5 @@ export function useSelectedTextNodes(): TextNodeEntry[] {
       })
     }
     return out
-  }, [page, nodeIds, epoch])
+  }, [page, nodeIds])
 }

--- a/ui/hooks/useScene.ts
+++ b/ui/hooks/useScene.ts
@@ -18,7 +18,7 @@ export function useScene(): { scene: Scene | null; epoch: number } {
       retry: false,
       staleTime: Infinity,
       gcTime: Infinity,
-      structuralSharing: false,
+      structuralSharing: true,
     },
   })
   // React Query preserves `data` across a failed refetch, so closing a


### PR DESCRIPTION
## Summary
This PR removes `sceneEpoch` from numerous component and hook dependency arrays to optimize performance. This should reduce CPU overhead by avoiding redundant array iterations during use, as well as the affected components maintaining stable references unless their underlying blob hashes change.