### PR TITLE
feat: add per-block OCR action

### DIFF
--- a/koharu-app/src/pipeline/engines/manga_ocr.rs
+++ b/koharu-app/src/pipeline/engines/manga_ocr.rs
@@ -10,14 +10,16 @@ use koharu_ml::manga_ocr::MangaOcr;
 
 use crate::pipeline::artifacts::Artifact;
 use crate::pipeline::engine::{Engine, EngineCtx, EngineInfo};
-use crate::pipeline::engines::support::{load_source_image, text_node_to_region, text_nodes};
+use crate::pipeline::engines::support::{
+    load_source_image, scoped_text_nodes, text_node_to_region,
+};
 
 pub struct Model(MangaOcr);
 
 #[async_trait]
 impl Engine for Model {
     async fn run(&self, ctx: EngineCtx<'_>) -> Result<Vec<Op>> {
-        let texts = text_nodes(ctx.scene, ctx.page);
+        let texts = scoped_text_nodes(ctx.scene, ctx.page, ctx.options.text_node_ids.as_deref());
         if texts.is_empty() {
             return Ok(Vec::new());
         }

--- a/koharu-app/src/pipeline/engines/mit48px_ocr.rs
+++ b/koharu-app/src/pipeline/engines/mit48px_ocr.rs
@@ -9,14 +9,16 @@ use koharu_ml::types::TextRegion;
 
 use crate::pipeline::artifacts::Artifact;
 use crate::pipeline::engine::{Engine, EngineCtx, EngineInfo};
-use crate::pipeline::engines::support::{load_source_image, text_node_to_region, text_nodes};
+use crate::pipeline::engines::support::{
+    load_source_image, scoped_text_nodes, text_node_to_region,
+};
 
 pub struct Model(Mit48pxOcr);
 
 #[async_trait]
 impl Engine for Model {
     async fn run(&self, ctx: EngineCtx<'_>) -> Result<Vec<Op>> {
-        let texts = text_nodes(ctx.scene, ctx.page);
+        let texts = scoped_text_nodes(ctx.scene, ctx.page, ctx.options.text_node_ids.as_deref());
         if texts.is_empty() {
             return Ok(Vec::new());
         }

--- a/koharu-app/src/pipeline/engines/paddle_ocr.rs
+++ b/koharu-app/src/pipeline/engines/paddle_ocr.rs
@@ -15,7 +15,9 @@ use koharu_ml::comic_text_detector::crop_text_block_bbox;
 use crate::app::shared_llama_backend;
 use crate::pipeline::artifacts::Artifact;
 use crate::pipeline::engine::{Engine, EngineCtx, EngineInfo};
-use crate::pipeline::engines::support::{load_source_image, text_node_to_region, text_nodes};
+use crate::pipeline::engines::support::{
+    load_source_image, scoped_text_nodes, text_node_to_region,
+};
 
 const MAX_NEW_TOKENS: usize = 256;
 
@@ -24,7 +26,7 @@ pub struct Model(Mutex<PaddleOcrVl>);
 #[async_trait]
 impl Engine for Model {
     async fn run(&self, ctx: EngineCtx<'_>) -> Result<Vec<Op>> {
-        let texts = text_nodes(ctx.scene, ctx.page);
+        let texts = scoped_text_nodes(ctx.scene, ctx.page, ctx.options.text_node_ids.as_deref());
         if texts.is_empty() {
             return Ok(Vec::new());
         }

--- a/koharu-app/src/pipeline/engines/support.rs
+++ b/koharu-app/src/pipeline/engines/support.rs
@@ -71,6 +71,18 @@ pub fn text_nodes(scene: &Scene, page: PageId) -> Vec<(NodeId, &Transform, &Text
         .collect()
 }
 
+/// Collect text nodes, optionally restricted to a requested set of node ids.
+pub fn scoped_text_nodes<'a>(
+    scene: &'a Scene,
+    page: PageId,
+    allowed_ids: Option<&[NodeId]>,
+) -> Vec<(NodeId, &'a Transform, &'a TextData)> {
+    text_nodes(scene, page)
+        .into_iter()
+        .filter(|(id, _, _)| allowed_ids.is_none_or(|ids| ids.contains(id)))
+        .collect()
+}
+
 /// Convert a scene `(Transform, TextData)` pair into a `koharu-ml` `TextRegion`
 /// for passing back through detector helpers that need geometry + language
 /// hints (e.g. CTD's `refine_segmentation_mask`, OCR's `extract_text_block_regions`).
@@ -463,6 +475,34 @@ pub fn sort_manga_reading_order<T>(blocks: &mut [([f32; 4], T)], order: ReadingO
 mod tests {
     use super::*;
     use koharu_core::ReadingOrder;
+
+    #[test]
+    fn scoped_text_nodes_filters_requested_ids() {
+        let mut page = koharu_core::Page::new("page", 100, 100);
+        let first = NodeId::new();
+        let second = NodeId::new();
+        for id in [first, second] {
+            page.nodes.insert(
+                id,
+                Node {
+                    id,
+                    transform: Transform::default(),
+                    visible: true,
+                    kind: NodeKind::Text(TextData::default()),
+                },
+            );
+        }
+        let page_id = page.id;
+        let mut scene = Scene::default();
+        scene.pages.insert(page_id, page);
+
+        let nodes = scoped_text_nodes(&scene, page_id, Some(&[second]));
+
+        assert_eq!(
+            nodes.iter().map(|(id, _, _)| *id).collect::<Vec<_>>(),
+            vec![second]
+        );
+    }
 
     #[test]
     fn test_reading_order_sort() {

--- a/ui/components/panels/TextBlocksPanel.tsx
+++ b/ui/components/panels/TextBlocksPanel.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Languages, LoaderCircleIcon, Trash2Icon } from 'lucide-react'
+import { Languages, LoaderCircleIcon, ScanTextIcon, Trash2Icon } from 'lucide-react'
 import { motion } from 'motion/react'
 import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -104,6 +104,17 @@ export function TextBlocksPanel() {
     })
   }
 
+  const runOcr = async (nodeId: string) => {
+    if (!page) return
+    const cfg = await getConfig()
+    const ocr = cfg.pipeline?.ocr || 'paddle-ocr-vl-1.5'
+    await startPipeline({
+      steps: [ocr],
+      pages: [page.id],
+      textNodeIds: [nodeId],
+    })
+  }
+
   return (
     <div className='flex min-h-0 flex-1 flex-col' data-testid='panels-textblocks'>
       <div className='flex items-center justify-between border-b border-border px-2 py-1.5 text-xs font-semibold tracking-wide text-muted-foreground uppercase'>
@@ -190,6 +201,7 @@ export function TextBlocksPanel() {
                   onToggleSelect={() => select(node.id, true)}
                   onPatch={(patch) => void patchText(node.id, patch)}
                   onDelete={() => void removeNode(node.id)}
+                  onOcr={() => void runOcr(node.id)}
                   onGenerate={() => void generate(node.id)}
                   processing={isProcessing}
                   llmReady={llmReady}
@@ -210,6 +222,7 @@ type BlockCardProps = {
   onToggleSelect: () => void
   onPatch: (patch: TextDataPatch) => void
   onDelete: () => void
+  onOcr: () => void
   onGenerate: () => void
   processing: boolean
   llmReady: boolean
@@ -222,6 +235,7 @@ function BlockCard({
   onToggleSelect,
   onPatch,
   onDelete,
+  onOcr,
   onGenerate,
   processing,
   llmReady,
@@ -303,6 +317,28 @@ function BlockCard({
                   {t('textBlocks.translationLabel')}
                 </span>
                 <div className='flex items-center gap-0.5'>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        data-testid={`textblock-ocr-run-${index}`}
+                        aria-label={t('textBlocks.ocrTooltip')}
+                        variant='ghost'
+                        size='icon-xs'
+                        disabled={processing}
+                        onClick={onOcr}
+                        className='size-5'
+                      >
+                        {processing ? (
+                          <LoaderCircleIcon className='size-3 animate-spin' />
+                        ) : (
+                          <ScanTextIcon className='size-3' />
+                        )}
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent side='left' sideOffset={4}>
+                      {t('textBlocks.ocrTooltip')}
+                    </TooltipContent>
+                  </Tooltip>
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <Button

--- a/ui/public/locales/en-US/translation.json
+++ b/ui/public/locales/en-US/translation.json
@@ -263,7 +263,8 @@
     "readingOrder": "Reading Order",
     "readingOrderRtl": "Right-to-Left (RTL)",
     "readingOrderLtr": "Left-to-Right (LTR)",
-    "readingOrderCustom": "Custom"
+    "readingOrderCustom": "Custom",
+    "ocrTooltip": "Run OCR for this block"
   },
   "workspace": {
     "importPrompt": "Import a page to begin editing.",

--- a/ui/public/locales/es-ES/translation.json
+++ b/ui/public/locales/es-ES/translation.json
@@ -230,7 +230,8 @@
     "readingOrder": "Orden de lectura",
     "readingOrderRtl": "Derecha a izquierda (RTL)",
     "readingOrderLtr": "Izquierda a derecha (LTR)",
-    "readingOrderCustom": "Personalizado"
+    "readingOrderCustom": "Personalizado",
+    "ocrTooltip": "Ejecutar OCR para este bloque"
   },
   "workspace": {
     "importPrompt": "Importa una página para comenzar a editar.",

--- a/ui/public/locales/ja-JP/translation.json
+++ b/ui/public/locales/ja-JP/translation.json
@@ -230,7 +230,8 @@
     "readingOrder": "読み順",
     "readingOrderRtl": "右から左 (RTL)",
     "readingOrderLtr": "左から右 (LTR)",
-    "readingOrderCustom": "カスタム"
+    "readingOrderCustom": "カスタム",
+    "ocrTooltip": "このブロックでOCRを実行"
   },
   "workspace": {
     "importPrompt": "ページを読み込んで編集を開始してください。",

--- a/ui/public/locales/ko-KR/translation.json
+++ b/ui/public/locales/ko-KR/translation.json
@@ -252,7 +252,8 @@
     "readingOrder": "읽기 순서",
     "readingOrderRtl": "우에서 좌 (RTL)",
     "readingOrderLtr": "좌에서 우 (LTR)",
-    "readingOrderCustom": "사용자 정의"
+    "readingOrderCustom": "사용자 정의",
+    "ocrTooltip": "이 블록에 OCR 실행"
   },
   "workspace": {
     "importPrompt": "편집을 시작하려면 페이지를 가져오세요.",

--- a/ui/public/locales/pt-BR/translation.json
+++ b/ui/public/locales/pt-BR/translation.json
@@ -231,7 +231,8 @@
     "readingOrder": "Ordem de leitura",
     "readingOrderRtl": "Direita para esquerda (RTL)",
     "readingOrderLtr": "Esquerda para direita (LTR)",
-    "readingOrderCustom": "Personalizado"
+    "readingOrderCustom": "Personalizado",
+    "ocrTooltip": "Executar OCR neste bloco"
   },
   "workspace": {
     "importPrompt": "Importe uma página para começar a editar.",

--- a/ui/public/locales/ru-RU/translation.json
+++ b/ui/public/locales/ru-RU/translation.json
@@ -230,7 +230,8 @@
     "readingOrder": "Порядок чтения",
     "readingOrderRtl": "Справа налево (RTL)",
     "readingOrderLtr": "Слева направо (LTR)",
-    "readingOrderCustom": "Свой"
+    "readingOrderCustom": "Свой",
+    "ocrTooltip": "Запустить OCR для этого блока"
   },
   "workspace": {
     "importPrompt": "Импортируйте страницу, чтобы начать редактирование.",

--- a/ui/public/locales/tr-TR/translation.json
+++ b/ui/public/locales/tr-TR/translation.json
@@ -230,7 +230,8 @@
     "readingOrder": "Okuma Sırası",
     "readingOrderRtl": "Sağdan Sola (RTL)",
     "readingOrderLtr": "Soldan Sağa (LTR)",
-    "readingOrderCustom": "Özel"
+    "readingOrderCustom": "Özel",
+    "ocrTooltip": "Bu blok için OCR çalıştır"
   },
   "workspace": {
     "importPrompt": "Düzenlemeye başlamak için bir sayfa içe aktarın.",

--- a/ui/public/locales/zh-CN/translation.json
+++ b/ui/public/locales/zh-CN/translation.json
@@ -230,7 +230,8 @@
     "readingOrder": "阅读顺序",
     "readingOrderRtl": "从右至左 (RTL)",
     "readingOrderLtr": "从左至右 (LTR)",
-    "readingOrderCustom": "自定义"
+    "readingOrderCustom": "自定义",
+    "ocrTooltip": "对该文本块运行 OCR"
   },
   "workspace": {
     "importPrompt": "导入页面以开始编辑。",

--- a/ui/public/locales/zh-TW/translation.json
+++ b/ui/public/locales/zh-TW/translation.json
@@ -230,7 +230,8 @@
     "readingOrder": "閱讀順序",
     "readingOrderRtl": "從右至左 (RTL)",
     "readingOrderLtr": "從左至右 (LTR)",
-    "readingOrderCustom": "自定義"
+    "readingOrderCustom": "自定義",
+    "ocrTooltip": "對此文字區塊執行 OCR"
   },
   "workspace": {
     "importPrompt": "匯入頁面以開始編輯。",


### PR DESCRIPTION
## Summary

Adds a per-block OCR action in the Text Blocks panel.

- Adds an OCR button next to the existing per-block translation action
- Sends `textNodeIds` when starting OCR from an individual block
- Updates PaddleOCR-VL, Manga OCR, and MIT 48px OCR engines to use `textNodeIds`
- Keeps existing full-page OCR behavior when no block scope is provided

## User-visible changes

Users can now run OCR for a single text block from the Text Blocks panel instead of rerunning OCR for every block on the page. Similar to how they can translate single text block. 

<img width="273" height="152" alt="image" src="https://github.com/user-attachments/assets/57cca140-6a64-4fff-8f4e-3608d74ce189" />

Existing page-level OCR behavior should be unchanged.

## AI Disclosure
Code Generation: I used Codex to draft the implementation.
- Translation: Also used Codex to help with Language translation (except English).
- Validation: I have built the project locally and test it manually.