### PR TITLE
feat: add the ability to import font from local file

### DIFF
--- a/koharu-app/src/renderer.rs
+++ b/koharu-app/src/renderer.rs
@@ -19,6 +19,7 @@ use koharu_core::{
     TextStrokeStyle, TextStyle, Transform,
 };
 
+use camino::{Utf8Path, Utf8PathBuf};
 use koharu_renderer::{
     TextAlign as RendererTextAlign, TextShaderEffect as RendererEffect,
     font::{FaceInfo, Font, FontBook},
@@ -84,13 +85,16 @@ pub struct Renderer {
     renderer: TinySkiaRenderer,
     symbol_fallbacks: Vec<Font>,
     pub google_fonts: Arc<GoogleFontService>,
+    custom_fonts_dir: Utf8PathBuf,
 }
 
 impl Renderer {
     pub fn new() -> Result<Self> {
         let mut fontbook = FontBook::new();
-        let symbol_fallbacks = load_symbol_fallbacks(&mut fontbook);
         let app_data_root = koharu_runtime::default_app_data_root();
+        let custom_fonts_dir = app_data_root.join("fonts").join("custom");
+        load_custom_fonts(&mut fontbook, &custom_fonts_dir)?;
+        let symbol_fallbacks = load_symbol_fallbacks(&mut fontbook);
         let google_fonts = Arc::new(
             GoogleFontService::new(&app_data_root)
                 .context("failed to initialize Google Fonts service")?,
@@ -100,6 +104,7 @@ impl Renderer {
             renderer: TinySkiaRenderer::new()?,
             symbol_fallbacks,
             google_fonts,
+            custom_fonts_dir,
         })
     }
 
@@ -150,6 +155,42 @@ impl Renderer {
         }
         fonts.sort();
         Ok(fonts)
+    }
+
+    /// Persist a user font into the app data directory and load it into the renderer.
+    pub fn import_font_bytes(&self, filename: &str, bytes: Vec<u8>) -> Result<Vec<FontFaceInfo>> {
+        validate_font_filename(filename)?;
+        std::fs::create_dir_all(self.custom_fonts_dir.as_std_path())
+            .context("failed to create custom fonts dir")?;
+        let path = self.custom_fonts_dir.join(sanitize_font_filename(filename));
+        std::fs::write(path.as_std_path(), &bytes).context("failed to write imported font")?;
+
+        let faces = {
+            let mut fontbook = self
+                .fontbook
+                .lock()
+                .map_err(|_| anyhow::anyhow!("failed to lock fontbook"))?;
+            fontbook.load_faces_from_bytes(bytes)?
+        };
+
+        Ok(faces
+            .into_iter()
+            .filter(|face| !face.post_script_name.is_empty())
+            .map(|face| {
+                let family_name = face
+                    .families
+                    .first()
+                    .map(|(family, _)| family.clone())
+                    .unwrap_or_else(|| face.post_script_name.clone());
+                FontFaceInfo {
+                    family_name,
+                    post_script_name: face.post_script_name,
+                    source: FontSource::System,
+                    category: None,
+                    cached: true,
+                }
+            })
+            .collect())
     }
 
     /// Render every block's translation, composite onto `inpainted`, return
@@ -801,6 +842,55 @@ fn apply_default_font_families(font_families: &mut Vec<String>, text: &str) {
     if font_families.is_empty() {
         *font_families = font_families_for_text(text);
     }
+}
+
+fn load_custom_fonts(fontbook: &mut FontBook, custom_fonts_dir: &Utf8Path) -> Result<()> {
+    if !custom_fonts_dir.exists() {
+        return Ok(());
+    }
+
+    for entry in std::fs::read_dir(custom_fonts_dir.as_std_path())
+        .with_context(|| format!("failed to read custom fonts dir `{custom_fonts_dir}`"))?
+    {
+        let entry = entry?;
+        if !entry.file_type()?.is_file() {
+            continue;
+        }
+        let path = entry.path();
+        let Some(filename) = path.file_name().and_then(|s| s.to_str()) else {
+            continue;
+        };
+        if validate_font_filename(filename).is_err() {
+            continue;
+        }
+        let bytes = std::fs::read(&path)
+            .with_context(|| format!("failed to read custom font `{}`", path.display()))?;
+        if let Err(err) = fontbook.load_faces_from_bytes(bytes) {
+            tracing::warn!(path = %path.display(), "failed to load custom font: {err:#}");
+        }
+    }
+    Ok(())
+}
+
+fn validate_font_filename(filename: &str) -> Result<()> {
+    let lower = filename.to_ascii_lowercase();
+    if [".ttf", ".otf", ".ttc", ".otc"]
+        .iter()
+        .any(|ext| lower.ends_with(ext))
+    {
+        return Ok(());
+    }
+    anyhow::bail!("unsupported font file type: {filename}")
+}
+
+fn sanitize_font_filename(filename: &str) -> String {
+    filename
+        .chars()
+        .map(|c| match c {
+            'A'..='Z' | 'a'..='z' | '0'..='9' | '.' | '-' | '_' => c,
+            _ => '_',
+        })
+        .collect()
 }
 
 fn load_symbol_fallbacks(fontbook: &mut FontBook) -> Vec<Font> {

--- a/koharu-renderer/src/font.rs
+++ b/koharu-renderer/src/font.rs
@@ -75,7 +75,7 @@ pub struct FontBook {
     database: Database,
     cache: HashMap<ID, Font>,
     /// Maps data hash to font ID to avoid duplicate loading.
-    data_cache: HashMap<[u8; 32], ID>,
+    data_cache: HashMap<[u8; 32], Vec<ID>>,
 }
 
 impl FontBook {
@@ -114,7 +114,12 @@ impl FontBook {
     pub fn load_from_bytes(&mut self, data: Vec<u8>) -> anyhow::Result<Font> {
         let hash: [u8; 32] = blake3::hash(&data).into();
 
-        if let Some(&id) = self.data_cache.get(&hash) {
+        if let Some(id) = self
+            .data_cache
+            .get(&hash)
+            .and_then(|ids| ids.first())
+            .copied()
+        {
             return self.load_font(id);
         }
 
@@ -126,8 +131,41 @@ impl FontBook {
             .next()
             .context("font data contained no valid faces")?;
 
-        self.data_cache.insert(hash, id);
+        self.data_cache.insert(hash, vec![id]);
         self.load_font(id)
+    }
+
+    /// Loads a font source and returns all contained faces.
+    pub fn load_faces_from_bytes(&mut self, data: Vec<u8>) -> anyhow::Result<Vec<FaceInfo>> {
+        let hash: [u8; 32] = blake3::hash(&data).into();
+
+        if let Some(ids) = self.data_cache.get(&hash) {
+            return ids
+                .iter()
+                .map(|id| {
+                    self.database
+                        .face(*id)
+                        .cloned()
+                        .with_context(|| format!("missing font face for id {:?}", id))
+                })
+                .collect();
+        }
+
+        let data: Arc<dyn AsRef<[u8]> + Send + Sync> = Arc::new(data);
+        let source = fontdb::Source::Binary(data);
+        let ids = self.database.load_font_source(source);
+        if ids.is_empty() {
+            anyhow::bail!("font data contained no valid faces");
+        }
+
+        self.data_cache.insert(hash, ids.to_vec());
+        let mut faces = Vec::with_capacity(ids.len());
+        for id in ids {
+            if let Some(face) = self.database.face(id).cloned() {
+                faces.push(face);
+            }
+        }
+        Ok(faces)
     }
 
     pub fn load_font(&mut self, id: ID) -> anyhow::Result<Font> {

--- a/koharu-rpc/src/routes/fonts.rs
+++ b/koharu-rpc/src/routes/fonts.rs
@@ -6,10 +6,11 @@
 //! - `GET /google-fonts/{family}/{file}` — serve the cached TTF/WOFF file.
 
 use axum::body::Body;
-use axum::extract::{Path, State};
+use axum::extract::{Multipart, Path, State};
 use axum::http::{HeaderValue, StatusCode, header::CONTENT_TYPE};
 use axum::response::{Json, Response};
 use koharu_core::{FontFaceInfo, GoogleFontCatalog};
+use serde::{Deserialize, Serialize};
 use utoipa_axum::{router::OpenApiRouter, routes};
 
 use crate::AppState;
@@ -18,6 +19,7 @@ use crate::error::{ApiError, ApiResult};
 pub fn router() -> OpenApiRouter<AppState> {
     OpenApiRouter::default()
         .routes(routes!(list_fonts))
+        .routes(routes!(import_fonts))
         .routes(routes!(get_google_fonts_catalog))
         .routes(routes!(fetch_google_font))
         .routes(routes!(get_google_font_file))
@@ -27,6 +29,52 @@ pub fn router() -> OpenApiRouter<AppState> {
 async fn list_fonts(State(app): State<AppState>) -> ApiResult<Json<Vec<FontFaceInfo>>> {
     let fonts = app.renderer.available_fonts().map_err(ApiError::internal)?;
     Ok(Json(fonts))
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ImportFontsResponse {
+    pub fonts: Vec<FontFaceInfo>,
+}
+
+#[utoipa::path(
+    post,
+    path = "/fonts/import",
+    request_body(content_type = "multipart/form-data"),
+    responses((status = 200, body = ImportFontsResponse))
+)]
+async fn import_fonts(
+    State(app): State<AppState>,
+    mut multipart: Multipart,
+) -> ApiResult<Json<ImportFontsResponse>> {
+    let mut fonts = Vec::new();
+    while let Some(field) = multipart
+        .next_field()
+        .await
+        .map_err(|e| ApiError::bad_request(format!("multipart: {e}")))?
+    {
+        let filename = field
+            .file_name()
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| "font.ttf".to_string());
+        let bytes = field
+            .bytes()
+            .await
+            .map_err(|e| ApiError::bad_request(format!("read file: {e}")))?
+            .to_vec();
+
+        let imported = app
+            .renderer
+            .import_font_bytes(&filename, bytes)
+            .map_err(ApiError::internal)?;
+        fonts.extend(imported);
+    }
+
+    if fonts.is_empty() {
+        return Err(ApiError::bad_request("no font files uploaded"));
+    }
+
+    Ok(Json(ImportFontsResponse { fonts }))
 }
 
 #[utoipa::path(

--- a/ui/components/panels/RenderControlsPanel.tsx
+++ b/ui/components/panels/RenderControlsPanel.tsx
@@ -9,6 +9,7 @@ import {
   MinusIcon,
   PlusIcon,
   SquareIcon,
+  UploadIcon,
 } from 'lucide-react'
 import { type ComponentType, useMemo, useRef, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -50,7 +51,8 @@ import {
   STYLE_KEYWORDS,
   uniqueFontFaces,
 } from '@/lib/font-utils'
-import { applyOp, invalidateScene, queueAutoRender } from '@/lib/io/scene'
+import { openFontFiles } from '@/lib/io/openFiles'
+import { applyOp, importFontFiles, invalidateScene, queueAutoRender } from '@/lib/io/scene'
 import { ops } from '@/lib/ops'
 import { useEditorUiStore } from '@/lib/stores/editorUiStore'
 import { usePreferencesStore } from '@/lib/stores/preferencesStore'
@@ -342,6 +344,12 @@ export function RenderControlsPanel() {
     })
   }
 
+  const importFonts = async () => {
+    const picked = await openFontFiles()
+    if (picked.kind !== 'files' || picked.files.length === 0) return
+    await importFontFiles(picked.files)
+  }
+
   const updateStrokeWidth = (value: number) => {
     applyStrokeSetting({ ...currentStroke, widthPx: clampStrokeWidth(value) })
   }
@@ -402,10 +410,29 @@ export function RenderControlsPanel() {
 
       {/* Font + Color */}
       <div className='flex flex-col gap-0.5' ref={sectionRef}>
-        <div className='flex items-baseline justify-between'>
-          <span className='text-[10px] font-medium text-muted-foreground uppercase'>
-            {t('render.fontLabel')}
-          </span>
+        <div className='flex items-center justify-between'>
+          <div className='flex items-center gap-1'>
+            <span className='text-[10px] font-medium text-muted-foreground uppercase'>
+              {t('render.fontLabel')}
+            </span>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  type='button'
+                  variant='ghost'
+                  size='icon-xs'
+                  aria-label={t('render.importFont')}
+                  className='size-5 text-muted-foreground'
+                  onClick={() => void importFonts()}
+                >
+                  <UploadIcon className='size-3' />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side='bottom' sideOffset={4}>
+                {t('render.importFont')}
+              </TooltipContent>
+            </Tooltip>
+          </div>
           <span className='text-[10px] font-medium text-muted-foreground uppercase'>
             {t('render.fontColorLabel')}
           </span>

--- a/ui/lib/io/openFiles.ts
+++ b/ui/lib/io/openFiles.ts
@@ -16,6 +16,8 @@ import { isTauri } from '@/lib/backend'
 const IMAGE_EXTENSIONS = ['png', 'jpg', 'jpeg', 'webp'] as const
 const IMAGE_MIME = ['image/png', 'image/jpeg', 'image/webp']
 const IMAGE_RE = /\.(png|jpe?g|webp)$/i
+const FONT_EXTENSIONS = ['ttf', 'otf', 'ttc', 'otc'] as const
+const FONT_MIME = ['font/ttf', 'font/otf', 'application/font-sfnt', 'application/octet-stream']
 
 /**
  * Platform-tagged picker result. On Tauri we hand paths straight to the
@@ -47,6 +49,35 @@ export async function openImageFiles(): Promise<ImagePickerResult> {
       mimeTypes: IMAGE_MIME,
       extensions: IMAGE_EXTENSIONS.map((e) => `.${e}`),
       description: 'Images',
+    })
+    return { kind: 'files', files: Array.isArray(result) ? result : [result] }
+  } catch (e) {
+    if (isAbort(e)) return { kind: 'files', files: [] }
+    throw e
+  }
+}
+
+/** Pick one or more local font files. Empty result = user cancelled. */
+export async function openFontFiles(): Promise<ImagePickerResult> {
+  if (isTauri()) {
+    const { open } = await import('@tauri-apps/plugin-dialog')
+    const picked = await open({
+      multiple: true,
+      filters: [{ name: 'Fonts', extensions: [...FONT_EXTENSIONS] }],
+    })
+    if (!picked) return { kind: 'paths', paths: [] }
+    const paths = Array.isArray(picked) ? picked : [picked]
+    const files = await readTauriFiles(paths)
+    return { kind: 'files', files }
+  }
+
+  const { fileOpen } = await import('browser-fs-access')
+  try {
+    const result = await fileOpen({
+      multiple: true,
+      mimeTypes: FONT_MIME,
+      extensions: FONT_EXTENSIONS.map((e) => `.${e}`),
+      description: 'Fonts',
     })
     return { kind: 'files', files: Array.isArray(result) ? result : [result] }
   } catch (e) {
@@ -133,6 +164,8 @@ function mimeFromName(name: string): string {
   if (lower.endsWith('.jpg') || lower.endsWith('.jpeg')) return 'image/jpeg'
   if (lower.endsWith('.webp')) return 'image/webp'
   if (lower.endsWith('.khr')) return 'application/zip'
+  if (lower.endsWith('.ttf') || lower.endsWith('.ttc')) return 'font/ttf'
+  if (lower.endsWith('.otf') || lower.endsWith('.otc')) return 'font/otf'
   return 'application/octet-stream'
 }
 

--- a/ui/lib/io/scene.ts
+++ b/ui/lib/io/scene.ts
@@ -11,6 +11,7 @@ import {
   getGetConfigQueryKey,
   getGetCurrentLlmQueryKey,
   getGetSceneJsonQueryKey,
+  getListFontsQueryKey,
   importProject,
   patchConfig,
   putCurrentProject,
@@ -19,7 +20,7 @@ import {
   startPipeline,
   undo,
 } from '@/lib/api/default/default'
-import { ApiError } from '@/lib/api/fetch'
+import { ApiError, fetchApi } from '@/lib/api/fetch'
 import type {
   ConfigPatch,
   CreateProjectRequest,
@@ -51,6 +52,8 @@ export const invalidateScene = () =>
 const invalidateConfig = () => queryClient.invalidateQueries({ queryKey: getGetConfigQueryKey() })
 
 const invalidateLlm = () => queryClient.invalidateQueries({ queryKey: getGetCurrentLlmQueryKey() })
+
+const invalidateFonts = () => queryClient.invalidateQueries({ queryKey: getListFontsQueryKey() })
 
 // Ops ------------------------------------------------------------------------
 
@@ -190,6 +193,17 @@ export async function uploadKhrArchive(file: File): Promise<ProjectSummary> {
   })
   await invalidateScene()
   return summary
+}
+
+export async function importFontFiles(files: File[]): Promise<void> {
+  if (files.length === 0) return
+  const form = new FormData()
+  for (const file of files) form.append('file', file, file.name)
+  await fetchApi('/api/v1/fonts/import', {
+    method: 'POST',
+    body: form,
+  })
+  await invalidateFonts()
 }
 
 // Export ---------------------------------------------------------------------

--- a/ui/public/locales/en-US/translation.json
+++ b/ui/public/locales/en-US/translation.json
@@ -229,6 +229,7 @@
     "fontColorLabel": "Font color",
     "fontSizeLabel": "Size",
     "fontStylePlaceholder": "Style",
+    "importFont": "Import font",
     "fontScopeGlobal": "Global",
     "fontScopeBlock": "Per block",
     "fontScopeBlockIndex": "Block {{index}}",

--- a/ui/public/locales/es-ES/translation.json
+++ b/ui/public/locales/es-ES/translation.json
@@ -191,6 +191,7 @@
     "fontColorLabel": "Color de fuente",
     "fontSizeLabel": "Tamaño",
     "fontStylePlaceholder": "Estilo",
+    "importFont": "Importar fuente",
     "fontScopeGlobal": "Global",
     "fontScopeBlock": "Por bloque",
     "fontScopeBlockIndex": "Bloque {{index}}",

--- a/ui/public/locales/ja-JP/translation.json
+++ b/ui/public/locales/ja-JP/translation.json
@@ -191,6 +191,7 @@
     "fontColorLabel": "フォントカラー",
     "fontSizeLabel": "サイズ",
     "fontStylePlaceholder": "スタイル",
+    "importFont": "フォントをインポート",
     "fontScopeGlobal": "全体",
     "fontScopeBlock": "ブロックごと",
     "fontScopeBlockIndex": "ブロック {{index}}",

--- a/ui/public/locales/ko-KR/translation.json
+++ b/ui/public/locales/ko-KR/translation.json
@@ -218,6 +218,7 @@
     "fontColorLabel": "글꼴 색상",
     "fontSizeLabel": "크기",
     "fontStylePlaceholder": "스타일",
+    "importFont": "폰트 가져오기",
     "fontScopeGlobal": "전역",
     "fontScopeBlock": "블록별",
     "fontScopeBlockIndex": "블록 {{index}}",

--- a/ui/public/locales/pt-BR/translation.json
+++ b/ui/public/locales/pt-BR/translation.json
@@ -197,6 +197,7 @@
     "fontColorLabel": "Cor da fonte",
     "fontSizeLabel": "Tamanho",
     "fontStylePlaceholder": "Estilo",
+    "importFont": "Importar fonte",
     "fontScopeGlobal": "Global",
     "fontScopeBlock": "Por bloco",
     "fontScopeBlockIndex": "Bloco {{index}}",

--- a/ui/public/locales/ru-RU/translation.json
+++ b/ui/public/locales/ru-RU/translation.json
@@ -191,6 +191,7 @@
     "fontColorLabel": "Цвет шрифта",
     "fontSizeLabel": "Размер",
     "fontStylePlaceholder": "Стиль",
+    "importFont": "Импортировать шрифт",
     "fontScopeGlobal": "Глобально",
     "fontScopeBlock": "Для блока",
     "fontScopeBlockIndex": "Блок {{index}}",

--- a/ui/public/locales/tr-TR/translation.json
+++ b/ui/public/locales/tr-TR/translation.json
@@ -196,6 +196,7 @@
     "fontColorLabel": "Yazı rengi",
     "fontSizeLabel": "Boyut",
     "fontStylePlaceholder": "Stil",
+    "importFont": "Yazı tipi içe aktar",
     "fontScopeGlobal": "Genel",
     "fontScopeBlock": "Blok bazında",
     "fontScopeBlockIndex": "Blok {{index}}",

--- a/ui/public/locales/zh-CN/translation.json
+++ b/ui/public/locales/zh-CN/translation.json
@@ -191,6 +191,7 @@
     "fontColorLabel": "字体颜色",
     "fontSizeLabel": "大小",
     "fontStylePlaceholder": "样式",
+    "importFont": "导入字体",
     "fontScopeGlobal": "全局",
     "fontScopeBlock": "按文本块",
     "fontScopeBlockIndex": "文本块 {{index}}",

--- a/ui/public/locales/zh-TW/translation.json
+++ b/ui/public/locales/zh-TW/translation.json
@@ -191,6 +191,7 @@
     "fontColorLabel": "字體顏色",
     "fontSizeLabel": "大小",
     "fontStylePlaceholder": "樣式",
+    "importFont": "匯入字體",
     "fontScopeGlobal": "全域",
     "fontScopeBlock": "依文字區塊",
     "fontScopeBlockIndex": "文字區塊 {{index}}",


### PR DESCRIPTION
## Summary

Adds support for importing local font files into Koharu.

- Adds an import button beside the font controls
- Supports `.ttf`, `.otf`, `.ttc`, and `.otc`
- Copies imported fonts into Koharu’s app data directory
- Loads imported fonts into the renderer font book on startup
- Makes imported fonts available through the existing font selector

Imported fonts are treated as system fonts after they are loaded into the font book. I was trying to add a new FontSource but 1.I don't think defining a new source help with anything (except for use it to filtered font in the font select screen I guess?) and 2. it was a hassle since it need some changes to the API call

The scene continues to store the selected font by its normal PostScript name in `TextStyle.fontFamilies`, same as other fonts. Imported font files are only needed so the renderer can resolve that PostScript name later.

Font byte caching now stores all loaded face IDs for a font source instead of only one ID. This keeps duplicate imports consistent for font collection files like `.ttc` and `.otc`, where one file can contain multiple faces.

## Testing

I have built the project locally and tested the feature out manually.

## AI Usage

I used Codex to draft the implementation and help with language translations.
