### PR TITLE
feat: workflow presets for bundled pipeline steps

### DIFF
--- a/ui/components/WorkflowPresetsDialog.tsx
+++ b/ui/components/WorkflowPresetsDialog.tsx
@@ -1,0 +1,190 @@
+'use client'
+
+import { PlusIcon, Trash2Icon } from 'lucide-react'
+import { type FormEvent, type KeyboardEvent, useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Separator } from '@/components/ui/separator'
+import {
+  WORKFLOW_STEP_KEYS,
+  type PipelineStepKey,
+  usePreferencesStore,
+} from '@/lib/stores/preferencesStore'
+
+type WorkflowPresetsDialogProps = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+const STEP_LABELS: Record<PipelineStepKey, string> = {
+  detect: 'Detect',
+  ocr: 'OCR',
+  translate: 'Translate',
+  inpaint: 'Inpaint',
+  render: 'Render',
+}
+
+const DEFAULT_SELECTED_STEPS: PipelineStepKey[] = ['detect', 'ocr']
+
+function formatSteps(steps: PipelineStepKey[]): string {
+  return steps.map((step) => STEP_LABELS[step]).join(' + ')
+}
+
+export function WorkflowPresetsDialog({ open, onOpenChange }: WorkflowPresetsDialogProps) {
+  const workflowPresets = usePreferencesStore((s) => s.workflowPresets)
+  const addWorkflowPreset = usePreferencesStore((s) => s.addWorkflowPreset)
+  const removeWorkflowPreset = usePreferencesStore((s) => s.removeWorkflowPreset)
+  const renameWorkflowPreset = usePreferencesStore((s) => s.renameWorkflowPreset)
+  const [name, setName] = useState('')
+  const [selectedSteps, setSelectedSteps] = useState<PipelineStepKey[]>(DEFAULT_SELECTED_STEPS)
+  const [renameDrafts, setRenameDrafts] = useState<Record<string, string>>({})
+
+  const canSave = name.trim().length > 0 && selectedSteps.length > 0
+
+  const toggleStep = (step: PipelineStepKey) => {
+    setSelectedSteps((steps) =>
+      steps.includes(step) ? steps.filter((candidate) => candidate !== step) : [...steps, step],
+    )
+  }
+
+  const clearRenameDraft = (id: string) => {
+    setRenameDrafts((drafts) => {
+      const next = { ...drafts }
+      delete next[id]
+      return next
+    })
+  }
+
+  const commitRename = (id: string) => {
+    const draft = renameDrafts[id]
+    if (draft === undefined) return
+    const nextName = draft.trim()
+    if (nextName) renameWorkflowPreset(id, nextName)
+    clearRenameDraft(id)
+  }
+
+  const handleRenameKeyDown = (event: KeyboardEvent<HTMLInputElement>, id: string) => {
+    if (event.key === 'Enter') {
+      event.preventDefault()
+      commitRename(id)
+      event.currentTarget.blur()
+    }
+    if (event.key === 'Escape') {
+      clearRenameDraft(id)
+      event.currentTarget.blur()
+    }
+  }
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (!canSave) return
+    addWorkflowPreset({ name, steps: selectedSteps })
+    setName('')
+    setSelectedSteps(DEFAULT_SELECTED_STEPS)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className='max-w-md gap-4'>
+        <div className='space-y-1'>
+          <DialogTitle>Workflow Presets</DialogTitle>
+          <DialogDescription className='sr-only'>
+            Create, rename, and delete workflow presets.
+          </DialogDescription>
+        </div>
+
+        <form className='space-y-3' onSubmit={handleSubmit}>
+          <div className='space-y-1.5'>
+            <Label htmlFor='workflow-preset-name'>Preset name</Label>
+            <Input
+              id='workflow-preset-name'
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              placeholder='Detect + OCR'
+              data-testid='workflow-preset-name'
+            />
+          </div>
+
+          <div className='grid grid-cols-2 gap-2'>
+            {WORKFLOW_STEP_KEYS.map((step) => (
+              <label
+                key={step}
+                className='flex h-9 items-center gap-2 rounded-md border border-input px-2 text-sm'
+              >
+                <input
+                  type='checkbox'
+                  className='size-4 accent-primary'
+                  checked={selectedSteps.includes(step)}
+                  onChange={() => toggleStep(step)}
+                  data-testid={`workflow-preset-step-${step}`}
+                />
+                <span>{STEP_LABELS[step]}</span>
+              </label>
+            ))}
+          </div>
+
+          <div className='flex justify-end'>
+            <Button
+              type='submit'
+              size='sm'
+              disabled={!canSave}
+              data-testid='workflow-preset-save'
+            >
+              <PlusIcon className='size-4' />
+              Save preset
+            </Button>
+          </div>
+        </form>
+
+        <Separator />
+
+        <div className='max-h-64 space-y-2 overflow-y-auto pr-1'>
+          {workflowPresets.map((preset) => (
+            <div
+              key={preset.id}
+              className='flex items-center gap-2 rounded-md border border-border px-2 py-2'
+              data-testid={`workflow-preset-row-${preset.id}`}
+            >
+              <div className='min-w-0 flex-1 space-y-1'>
+                <Input
+                  value={renameDrafts[preset.id] ?? preset.name}
+                  onChange={(event) =>
+                    setRenameDrafts((drafts) => ({
+                      ...drafts,
+                      [preset.id]: event.target.value,
+                    }))
+                  }
+                  onBlur={() => commitRename(preset.id)}
+                  onKeyDown={(event) => handleRenameKeyDown(event, preset.id)}
+                  aria-label={`Rename ${preset.name}`}
+                  className='h-7 px-2 text-xs md:text-xs'
+                  data-testid={`workflow-preset-name-${preset.id}`}
+                />
+                <div className='truncate px-1 text-[11px] text-muted-foreground'>
+                  {formatSteps(preset.steps)}
+                </div>
+              </div>
+              <Button
+                variant='ghost'
+                size='icon-xs'
+                onClick={() => removeWorkflowPreset(preset.id)}
+                aria-label={`Delete ${preset.name}`}
+                data-testid={`workflow-preset-delete-${preset.id}`}
+              >
+                <Trash2Icon className='size-4' />
+              </Button>
+            </div>
+          ))}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/ui/components/canvas/CanvasToolbar.tsx
+++ b/ui/components/canvas/CanvasToolbar.tsx
@@ -2,9 +2,11 @@
 
 import {
   LanguagesIcon,
+  ListChecksIcon,
   LoaderCircleIcon,
   ScanIcon,
   ScanTextIcon,
+  Settings2Icon,
   TypeIcon,
   Wand2Icon,
 } from 'lucide-react'
@@ -24,6 +26,7 @@ import {
 } from '@/components/ui/select'
 import { Separator } from '@/components/ui/separator'
 import { Textarea } from '@/components/ui/textarea'
+import { WorkflowPresetsDialog } from '@/components/WorkflowPresetsDialog'
 import {
   deleteCurrentLlm,
   getConfig,
@@ -32,10 +35,16 @@ import {
   useGetCatalog,
   useGetCurrentLlm,
 } from '@/lib/api/default/default'
-import type { LlmCatalog, LlmCatalogModel, LlmProviderCatalog, LlmTarget } from '@/lib/api/schemas'
+import type {
+  LlmCatalog,
+  LlmCatalogModel,
+  LlmProviderCatalog,
+  LlmTarget,
+  PipelineConfig,
+} from '@/lib/api/schemas'
 import { useEditorUiStore } from '@/lib/stores/editorUiStore'
 import { useJobsStore } from '@/lib/stores/jobsStore'
-import { usePreferencesStore } from '@/lib/stores/preferencesStore'
+import { type PipelineStepKey, usePreferencesStore } from '@/lib/stores/preferencesStore'
 import { useSelectionStore } from '@/lib/stores/selectionStore'
 
 // ---------------------------------------------------------------------------
@@ -63,6 +72,32 @@ const flattenCatalogModels = (catalog?: LlmCatalog): SelectableLlmModel[] => [
     .filter((p) => p.status === 'ready')
     .flatMap((p) => p.models.map((model) => ({ model, provider: p }))),
 ]
+
+type PipelinePick = (p: PipelineConfig) => Array<string | undefined>
+
+const workflowStepPickers: Record<PipelineStepKey, PipelinePick> = {
+  detect: (p) => [p.detector, p.segmenter, p.bubble_segmenter, p.font_detector],
+  ocr: (p) => [p.ocr],
+  translate: (p) => [p.translator],
+  inpaint: (p) => [p.inpainter],
+  render: (p) => [p.renderer],
+}
+
+export function composeWorkflowPresetSteps(
+  steps: PipelineStepKey[],
+  pipeline: PipelineConfig,
+): string[] {
+  const seen = new Set<string>()
+  const result: string[] = []
+  for (const key of steps) {
+    for (const step of workflowStepPickers[key](pipeline)) {
+      if (!step || seen.has(step)) continue
+      seen.add(step)
+      result.push(step)
+    }
+  }
+  return result
+}
 
 // ---------------------------------------------------------------------------
 // Component
@@ -100,6 +135,9 @@ function WorkflowButtons() {
   const hasPage = pageId !== null
   const isProcessing = useIsProcessing()
   const currentStep = useCurrentStep()
+  const workflowPresets = usePreferencesStore((s) => s.workflowPresets)
+  const [presetSelectKey, setPresetSelectKey] = useState(0)
+  const [presetsDialogOpen, setPresetsDialogOpen] = useState(false)
 
   /**
    * Run a pipeline step (or a small chain). `GET /config` is the single
@@ -113,9 +151,7 @@ function WorkflowButtons() {
    * backend driver skips any step whose artifact is already satisfied,
    * so re-running is idempotent.
    */
-  const runStep = async (
-    pick: (p: NonNullable<Awaited<ReturnType<typeof getConfig>>['pipeline']>) => string[],
-  ) => {
+  const runStep = async (pick: PipelinePick) => {
     if (!pageId) return
     const cfg = await getConfig()
     if (!cfg.pipeline) return
@@ -133,19 +169,18 @@ function WorkflowButtons() {
     })
   }
 
-  type PipelinePick = (
-    p: NonNullable<Awaited<ReturnType<typeof getConfig>>['pipeline']>,
-  ) => string[]
-  const detectChain: PipelinePick = (p) => [
-    p.detector!,
-    p.segmenter!,
-    p.bubble_segmenter!,
-    p.font_detector!,
-  ]
-  const ocrChain: PipelinePick = (p) => [p.ocr!]
-  const translateChain: PipelinePick = (p) => [p.translator!]
-  const inpaintChain: PipelinePick = (p) => [p.inpainter!]
-  const renderChain: PipelinePick = (p) => [p.renderer!]
+  const detectChain = workflowStepPickers.detect
+  const ocrChain = workflowStepPickers.ocr
+  const translateChain = workflowStepPickers.translate
+  const inpaintChain = workflowStepPickers.inpaint
+  const renderChain = workflowStepPickers.render
+
+  const handleRunWorkflowPreset = (id: string) => {
+    const preset = workflowPresets.find((candidate) => candidate.id === id)
+    setPresetSelectKey((key) => key + 1)
+    if (!preset) return
+    void runStep((pipeline) => composeWorkflowPresetSteps(preset.steps, pipeline))
+  }
 
   const isDetecting = currentStep === 'detect'
   const isOcr = currentStep === 'ocr'
@@ -229,6 +264,43 @@ function WorkflowButtons() {
         )}
         {t('llm.render')}
       </Button>
+      <Separator orientation='vertical' className='mx-0.5 h-4' />
+      <Select
+        key={presetSelectKey}
+        onValueChange={handleRunWorkflowPreset}
+        disabled={!hasPage || isProcessing || workflowPresets.length === 0}
+      >
+        <SelectTrigger
+          size='sm'
+          data-testid='toolbar-workflow-presets'
+          className='h-6 w-[130px] border-transparent bg-transparent shadow-none hover:bg-accent'
+        >
+          <ListChecksIcon className='size-4' />
+          <SelectValue placeholder='Presets' />
+        </SelectTrigger>
+        <SelectContent position='popper' align='start' className='min-w-44'>
+          {workflowPresets.map((preset) => (
+            <SelectItem
+              key={preset.id}
+              value={preset.id}
+              disabled={preset.steps.includes('translate') && !llmReady}
+              data-testid={`toolbar-workflow-preset-${preset.id}`}
+            >
+              {preset.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <Button
+        variant='ghost'
+        size='icon-xs'
+        onClick={() => setPresetsDialogOpen(true)}
+        data-testid='toolbar-workflow-presets-manage'
+        aria-label='Manage workflow presets'
+      >
+        <Settings2Icon className='size-4' />
+      </Button>
+      <WorkflowPresetsDialog open={presetsDialogOpen} onOpenChange={setPresetsDialogOpen} />
     </div>
   )
 }

--- a/ui/lib/stores/preferencesStore.ts
+++ b/ui/lib/stores/preferencesStore.ts
@@ -5,6 +5,16 @@ import { persist } from 'zustand/middleware'
 
 import { getPlatform } from '@/lib/shortcutUtils'
 
+export const WORKFLOW_STEP_KEYS = ['detect', 'ocr', 'translate', 'inpaint', 'render'] as const
+
+export type PipelineStepKey = (typeof WORKFLOW_STEP_KEYS)[number]
+
+export type WorkflowPreset = {
+  id: string
+  name: string
+  steps: PipelineStepKey[]
+}
+
 type PreferencesState = {
   brushConfig: {
     size: number
@@ -15,6 +25,10 @@ type PreferencesState = {
   setDefaultFont: (font?: string) => void
   favoriteFonts: string[]
   toggleFavoriteFont: (font: string) => void
+  workflowPresets: WorkflowPreset[]
+  addWorkflowPreset: (preset: Omit<WorkflowPreset, 'id'>) => void
+  removeWorkflowPreset: (id: string) => void
+  renameWorkflowPreset: (id: string, name: string) => void
   customSystemPrompt?: string
   setCustomSystemPrompt: (prompt?: string) => void
   codexImagePrompt?: string
@@ -37,12 +51,56 @@ type PreferencesState = {
   resetPreferences: () => void
 }
 
+const defaultWorkflowPresets: WorkflowPreset[] = [
+  {
+    id: 'default-detect-ocr-inpaint',
+    name: 'Detect + OCR + Inpaint',
+    steps: ['detect', 'ocr', 'inpaint'],
+  },
+  {
+    id: 'default-translate-render',
+    name: 'Translate + Render',
+    steps: ['translate', 'render'],
+  },
+]
+
+function getDefaultWorkflowPresets(): WorkflowPreset[] {
+  return defaultWorkflowPresets.map((preset) => ({
+    ...preset,
+    steps: [...preset.steps],
+  }))
+}
+
+function createWorkflowPresetId(): string {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID()
+  }
+  return `workflow-preset-${Date.now()}-${Math.random().toString(36).slice(2)}`
+}
+
+function isPipelineStepKey(step: unknown): step is PipelineStepKey {
+  return typeof step === 'string' && WORKFLOW_STEP_KEYS.includes(step as PipelineStepKey)
+}
+
+function normalizeWorkflowPreset(preset: unknown): WorkflowPreset | null {
+  if (!preset || typeof preset !== 'object') return null
+  const candidate = preset as Partial<WorkflowPreset>
+  const id = typeof candidate.id === 'string' && candidate.id.trim() ? candidate.id : null
+  const name = typeof candidate.name === 'string' ? candidate.name.trim() : ''
+  const steps = Array.isArray(candidate.steps)
+    ? Array.from(new Set(candidate.steps.filter(isPipelineStepKey)))
+    : []
+  if (!id || !name || steps.length === 0) return null
+  return { id, name, steps }
+}
+
 const initialPreferences = {
   brushConfig: {
     size: 36,
     color: '#ffffff',
   },
   favoriteFonts: [],
+  workflowPresets: getDefaultWorkflowPresets(),
   shortcuts: {
     select: 'V',
     block: 'M',
@@ -77,6 +135,36 @@ export const usePreferencesStore = create<PreferencesState>()(
             ? state.favoriteFonts.filter((f) => f !== font)
             : [...state.favoriteFonts, font],
         })),
+      addWorkflowPreset: (preset) =>
+        set((state) => {
+          const name = preset.name.trim()
+          const steps = Array.from(new Set(preset.steps))
+          if (!name || steps.length === 0) return {}
+          return {
+            workflowPresets: [
+              ...state.workflowPresets,
+              {
+                id: createWorkflowPresetId(),
+                name,
+                steps,
+              },
+            ],
+          }
+        }),
+      removeWorkflowPreset: (id) =>
+        set((state) => ({
+          workflowPresets: state.workflowPresets.filter((preset) => preset.id !== id),
+        })),
+      renameWorkflowPreset: (id, name) =>
+        set((state) => {
+          const nextName = name.trim()
+          if (!nextName) return {}
+          return {
+            workflowPresets: state.workflowPresets.map((preset) =>
+              preset.id === id ? { ...preset, name: nextName } : preset,
+            ),
+          }
+        }),
       setCustomSystemPrompt: (prompt) => set({ customSystemPrompt: prompt }),
       setCodexImagePrompt: (prompt) => set({ codexImagePrompt: prompt }),
       setCodexImageModel: (model) => set({ codexImageModel: model }),
@@ -97,7 +185,7 @@ export const usePreferencesStore = create<PreferencesState>()(
     }),
     {
       name: 'koharu-config',
-      version: 6,
+      version: 7,
       migrate: (persisted: any, version: number) => {
         if (version < 2 && persisted) {
           delete persisted.localLlm
@@ -129,12 +217,22 @@ export const usePreferencesStore = create<PreferencesState>()(
           persisted.codexImagePrompt ??= initialPreferences.codexImagePrompt
           persisted.codexImageModel ??= initialPreferences.codexImageModel
         }
+        if (version < 7 && persisted) {
+          const presets = Array.isArray(persisted.workflowPresets)
+            ? persisted.workflowPresets
+                .map(normalizeWorkflowPreset)
+                .filter((preset): preset is WorkflowPreset => preset !== null)
+            : []
+          persisted.workflowPresets =
+            presets.length > 0 ? presets : getDefaultWorkflowPresets()
+        }
         return persisted
       },
       partialize: (state) => ({
         brushConfig: state.brushConfig,
         defaultFont: state.defaultFont,
         favoriteFonts: state.favoriteFonts,
+        workflowPresets: state.workflowPresets,
         customSystemPrompt: state.customSystemPrompt,
         codexImagePrompt: state.codexImagePrompt,
         codexImageModel: state.codexImageModel,

--- a/ui/tests/stores/preferencesStore.test.ts
+++ b/ui/tests/stores/preferencesStore.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { composeWorkflowPresetSteps } from '@/components/canvas/CanvasToolbar'
+import type { PipelineConfig } from '@/lib/api/schemas'
+import { type WorkflowPreset, usePreferencesStore } from '@/lib/stores/preferencesStore'
+
+function persistedWorkflowPresets(): WorkflowPreset[] {
+  const stored = window.localStorage.getItem('koharu-config')
+  expect(stored).not.toBeNull()
+  return JSON.parse(stored!).state.workflowPresets
+}
+
+describe('preferencesStore workflow presets', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    usePreferencesStore.getState().resetPreferences()
+  })
+
+  it('seeds built-in workflow presets', () => {
+    expect(usePreferencesStore.getState().workflowPresets).toEqual([
+      {
+        id: 'default-detect-ocr-inpaint',
+        name: 'Detect + OCR + Inpaint',
+        steps: ['detect', 'ocr', 'inpaint'],
+      },
+      {
+        id: 'default-translate-render',
+        name: 'Translate + Render',
+        steps: ['translate', 'render'],
+      },
+    ])
+  })
+
+  it('adds and persists a named workflow preset', () => {
+    usePreferencesStore
+      .getState()
+      .addWorkflowPreset({ name: '  Review pass  ', steps: ['detect', 'ocr', 'ocr'] })
+
+    const preset = usePreferencesStore
+      .getState()
+      .workflowPresets.find((candidate) => candidate.name === 'Review pass')
+
+    expect(preset).toEqual({
+      id: expect.any(String),
+      name: 'Review pass',
+      steps: ['detect', 'ocr'],
+    })
+    expect(persistedWorkflowPresets()).toEqual(
+      expect.arrayContaining([
+        {
+          id: expect.any(String),
+          name: 'Review pass',
+          steps: ['detect', 'ocr'],
+        },
+      ]),
+    )
+  })
+
+  it('removes workflow presets from memory and persisted state', () => {
+    const preset = usePreferencesStore.getState().workflowPresets[0]
+
+    usePreferencesStore.getState().removeWorkflowPreset(preset.id)
+
+    expect(
+      usePreferencesStore
+        .getState()
+        .workflowPresets.some((candidate) => candidate.id === preset.id),
+    ).toBe(false)
+    expect(persistedWorkflowPresets().some((candidate) => candidate.id === preset.id)).toBe(false)
+  })
+
+  it('renames workflow presets', () => {
+    const preset = usePreferencesStore.getState().workflowPresets[0]
+
+    usePreferencesStore.getState().renameWorkflowPreset(preset.id, '  Clean Images  ')
+
+    expect(
+      usePreferencesStore.getState().workflowPresets.find((candidate) => candidate.id === preset.id),
+    ).toMatchObject({ name: 'Clean Images' })
+    expect(
+      persistedWorkflowPresets().find((candidate) => candidate.id === preset.id),
+    ).toMatchObject({ name: 'Clean Images' })
+  })
+
+  it('composes workflow preset steps in order and dedupes engine ids', () => {
+    const pipeline: PipelineConfig = {
+      detector: 'detector',
+      segmenter: 'shared-segmenter',
+      bubble_segmenter: 'bubble-segmenter',
+      font_detector: 'font-detector',
+      ocr: 'ocr',
+      inpainter: 'shared-segmenter',
+    }
+
+    expect(composeWorkflowPresetSteps(['detect', 'ocr', 'inpaint'], pipeline)).toEqual([
+      'detector',
+      'shared-segmenter',
+      'bubble-segmenter',
+      'font-detector',
+      'ocr',
+    ])
+  })
+
+  it('filters missing engine ids while composing workflow preset steps', () => {
+    expect(
+      composeWorkflowPresetSteps(['detect', 'translate', 'render'], {
+        detector: 'detector',
+        renderer: 'renderer',
+      }),
+    ).toEqual(['detector', 'renderer'])
+  })
+})


### PR DESCRIPTION
## Summary

Adds reusable workflow presets that bundle pipeline steps (for example Detect+OCR, or Translate+Render), so a partial pipeline runs in one click instead of relying on the rigid Run All.

## Why this matters

This maintainer-authored request (with community votes from RedRain77, Dear-moon, and TenviLi) asks for named step bundles, motivated by VRAM management (running the LLM and inpainting models in separate phases) and reviewability (getting clean inpainted images before translating) (#592). The backend already accepts an arbitrary ordered `steps: string[]` in `StartPipelineRequest`, and the toolbar's `runStep` helper already executes arbitrary chains, so this is a frontend-only addition that names and persists bundles.

A `workflowPresets` slice is added to the persisted zustand `preferencesStore` (mirroring the existing `favoriteFonts` pattern) with `addWorkflowPreset`/`removeWorkflowPreset`/`renameWorkflowPreset` actions and two built-in defaults. `CanvasToolbar.tsx` gets a presets dropdown that composes the corresponding chain pickers and calls the existing `runStep` with the deduped step list, reusing `getConfig()` engine-id resolution so no engine ids are hardcoded. A small dialog creates, names, and deletes presets. No Rust, RPC, or generated-schema changes.

## Changes

- `workflowPresets` slice + actions in `preferencesStore`, persisted, with seeded defaults.
- Presets dropdown in `CanvasToolbar` that runs the composed step chain.
- Create/name/delete dialog.

## Testing

- Store round-trips presets through persistence; add/remove/rename behave as expected.
- Selecting a preset runs the deduped step chain.

Refs #592
