### PR TITLE
chore: update gemini models

### DIFF
--- a/koharu-llm/src/providers/mod.rs
+++ b/koharu-llm/src/providers/mod.rs
@@ -219,12 +219,12 @@ const OPENAI_MODELS: &[ProviderModelDescriptor] = &[
 
 const GEMINI_MODELS: &[ProviderModelDescriptor] = &[
     ProviderModelDescriptor {
-        id: "gemini-flash-latest",
-        name: "Gemini Flash Latest",
-    },
-    ProviderModelDescriptor {
         id: "gemini-flash-lite-latest",
         name: "Gemini Flash-Lite Latest",
+    },
+    ProviderModelDescriptor {
+        id: "gemini-flash-latest",
+        name: "Gemini Flash Latest",
     },
     ProviderModelDescriptor {
         id: "gemini-pro-latest",
@@ -631,8 +631,8 @@ mod tests {
             GEMINI_MODELS,
             &[
                 "gemini-3.1-pro-preview",
-                "gemini-3.1-flash-lite-preview",
-                "gemini-2.5-flash",
+                "gemini-3.1-flash-lite",
+                "gemini-3.5-flash",
                 "gemma-4-26b-a4b-it",
             ],
         );

--- a/koharu-llm/src/providers/mod.rs
+++ b/koharu-llm/src/providers/mod.rs
@@ -219,6 +219,22 @@ const OPENAI_MODELS: &[ProviderModelDescriptor] = &[
 
 const GEMINI_MODELS: &[ProviderModelDescriptor] = &[
     ProviderModelDescriptor {
+        id: "gemini-flash-latest",
+        name: "Gemini Flash Latest",
+    },
+    ProviderModelDescriptor {
+        id: "gemini-flash-lite-latest",
+        name: "Gemini Flash-Lite Latest",
+    },
+    ProviderModelDescriptor {
+        id: "gemini-pro-latest",
+        name: "Gemini Pro Latest",
+    },
+    ProviderModelDescriptor {
+        id: "gemini-3.5-flash",
+        name: "Gemini 3.5 Flash",
+    },
+    ProviderModelDescriptor {
         id: "gemini-3.1-pro-preview",
         name: "Gemini 3.1 Pro Preview",
     },
@@ -227,8 +243,8 @@ const GEMINI_MODELS: &[ProviderModelDescriptor] = &[
         name: "Gemini 3.1 Pro Preview Custom Tools",
     },
     ProviderModelDescriptor {
-        id: "gemini-3.1-flash-lite-preview",
-        name: "Gemini 3.1 Flash-Lite Preview",
+        id: "gemini-3.1-flash-lite",
+        name: "Gemini 3.1 Flash-Lite",
     },
     ProviderModelDescriptor {
         id: "gemini-3-flash-preview",


### PR DESCRIPTION
Actualize the Gemini models.

- replace Gemini 3.1 Flash-Lite Preview with Gemini 3.1 Flash-Lite
- add Gemini 3.5 Flash
- add Latest models
  - Gemini Flash-Lite Latest
  - Gemini Flash Latest
  - Gemini Pro Latest