### PR TITLE
feat: added a "delete selected textblocks" button and keyboard shortcut

### DIFF
--- a/ui/components/MenuBar.tsx
+++ b/ui/components/MenuBar.tsx
@@ -24,7 +24,7 @@ import { useScene } from '@/hooks/useScene'
 import { getConfig, startPipeline } from '@/lib/api/default/default'
 import { isTauri, openExternalUrl } from '@/lib/backend'
 import { exportCurrentProjectAs, importPages } from '@/lib/io/pagesIo'
-import { closeProject, redoOp, selectAllTextNodesOnCurrentPage, undoOp } from '@/lib/io/scene'
+import { clearSelectionOnCurrentPage, closeProject, redoOp, selectAllTextNodesOnCurrentPage, undoOp } from '@/lib/io/scene'
 import { formatShortcutForDisplay, getPlatform } from '@/lib/shortcutUtils'
 import { useEditorUiStore } from '@/lib/stores/editorUiStore'
 import { usePreferencesStore } from '@/lib/stores/preferencesStore'
@@ -286,6 +286,14 @@ export function MenuBar() {
             >
               {t('menu.selectAll')}
               <MenubarShortcut>{isMac ? '⌘A' : 'Ctrl+A'}</MenubarShortcut>
+            </MenubarItem>
+            <MenubarItem
+              data-testid='menu-edit-clear-select'
+              className='text-[13px]'
+              disabled={!hasPage}
+              onSelect={() => clearSelectionOnCurrentPage()}
+            >
+              {t('menu.clearSelect')}
             </MenubarItem>
           </MenubarContent>
         </MenubarMenu>

--- a/ui/components/Navigator.tsx
+++ b/ui/components/Navigator.tsx
@@ -14,6 +14,7 @@ import { getGetPageThumbnailUrl } from '@/lib/api/default/default'
 import { applyOp } from '@/lib/io/scene'
 import { ops } from '@/lib/ops'
 import { useSelectionStore } from '@/lib/stores/selectionStore'
+import { useHotkeys } from 'react-hotkeys-hook'
 
 const THUMBNAIL_DPR =
   typeof window !== 'undefined' ? Math.min(Math.ceil(window.devicePixelRatio || 1), 3) : 2
@@ -125,13 +126,21 @@ export function Navigator() {
     (id: string) => {
       void handleDeletePages(new Set([id]))
     },
-    [handleDeletePages],
+    [handleDeletePages,],
   )
 
   const handleBatchDelete = useCallback(() => {
-    const { selectedPageIds } = useSelectionStore.getState()
     void handleDeletePages(selectedPageIds)
-  }, [handleDeletePages])
+  }, [handleDeletePages, selectedPageIds])
+
+  const delHotkeyRef = useHotkeys(
+    'delete',
+    () => {
+      handleBatchDelete()
+    },
+    { enabled: selectedPageIds.size !== 0 },
+    [handleDeletePages],
+  )
 
   const virtualizer = useVirtualizer({
     count: totalPages,
@@ -142,6 +151,8 @@ export function Navigator() {
 
   return (
     <div
+      tabIndex={-1}
+      ref={delHotkeyRef}
       data-testid='navigator-panel'
       data-total-pages={totalPages}
       className='flex h-full min-h-0 w-full flex-col bg-muted/50'
@@ -202,7 +213,6 @@ export function Navigator() {
                   onSelect={handleSelect}
                   canDelete={totalPages > 1}
                   onDelete={handleDeletePage}
-                  onBatchDelete={handleBatchDelete}
                 />
               </div>
             )
@@ -223,7 +233,6 @@ type PagePreviewProps = {
   onSelect: (id: string, e: React.MouseEvent | React.KeyboardEvent) => void
   canDelete: boolean
   onDelete: (id: string) => void
-  onBatchDelete: () => void
 }
 
 const PagePreview = memo(function PagePreview({
@@ -234,7 +243,6 @@ const PagePreview = memo(function PagePreview({
   onSelect,
   canDelete,
   onDelete,
-  onBatchDelete,
 }: PagePreviewProps) {
   const src = pageId ? `${getGetPageThumbnailUrl(pageId)}?size=${200 * THUMBNAIL_DPR}` : undefined
   const { t } = useTranslation()
@@ -248,9 +256,6 @@ const PagePreview = memo(function PagePreview({
         if (e.key === 'Enter' || e.key === ' ') {
           e.preventDefault()
           onSelect(pageId, e)
-        } else if (e.key === 'Delete') {
-          e.preventDefault()
-          onBatchDelete()
         }
       }}
       data-testid={`navigator-page-${index}`}

--- a/ui/components/canvas/TextBlockLayer.tsx
+++ b/ui/components/canvas/TextBlockLayer.tsx
@@ -36,25 +36,6 @@ export function TextBlockLayer({ showSprites, scale, style }: TextBlockLayerProp
     return false
   }, [selectedIds])
 
-  const removeNode = async (id: string) => {
-    if (!page) return
-    const node = page.nodes[id]
-    if (!node) return
-    const idx = Object.keys(page.nodes).indexOf(id)
-    await applyOp(ops.removeNode(page.id, id, node, idx < 0 ? 0 : idx))
-    if ('text' in node.kind) queueAutoRender(page.id)
-  }
-
-  const removeSelected = async () => {
-    if (!page) return
-    // Snapshot selection now: each op invalidates the page state by removing a
-    // node, so we can't iterate against a stale closure mid-loop.
-    const ids = Array.from(selectedIds).filter((id): id is string => !!id)
-    for (const id of ids) {
-      await removeNode(id)
-    }
-  }
-
   const updateTransform = async (id: string, t: Transform) => {
     if (!page) return
     const data: NodeDataPatch = {
@@ -65,15 +46,6 @@ export function TextBlockLayer({ showSprites, scale, style }: TextBlockLayerProp
     await applyOp(ops.updateNode(page.id, id, { transform: t, data }))
     queueAutoRender(page.id)
   }
-
-  useHotkeys(
-    'delete',
-    () => {
-      if (hasSelection && interactive) void removeSelected()
-    },
-    { enabled: hasSelection && interactive },
-    [selectedIds, interactive],
-  )
 
   return (
     <div
@@ -250,16 +222,14 @@ function TextBlockItem({
       }}
     >
       <div
-        className={`absolute inset-0 rounded-md ${
-          selected
-            ? 'border-[3px] border-primary bg-primary/15'
-            : 'border-2 border-rose-400/60 bg-rose-400/5'
-        }`}
+        className={`absolute inset-0 rounded-md ${selected
+          ? 'border-[3px] border-primary bg-primary/15'
+          : 'border-2 border-rose-400/60 bg-rose-400/5'
+          }`}
       />
       <div
-        className={`pointer-events-none absolute -top-1.5 -left-1.5 flex h-4 w-4 items-center justify-center rounded-full text-[9px] font-semibold text-white shadow ${
-          selected ? 'bg-primary' : 'bg-rose-400'
-        }`}
+        className={`pointer-events-none absolute -top-1.5 -left-1.5 flex h-4 w-4 items-center justify-center rounded-full text-[9px] font-semibold text-white shadow ${selected ? 'bg-primary' : 'bg-rose-400'
+          }`}
       >
         {index + 1}
       </div>

--- a/ui/components/panels/TextBlocksPanel.tsx
+++ b/ui/components/panels/TextBlocksPanel.tsx
@@ -24,9 +24,8 @@ import {
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useCurrentPage, useTextNodes, type TextNodeEntry } from '@/hooks/useCurrentPage'
 import { getConfig, startPipeline, useGetCurrentLlm } from '@/lib/api/default/default'
-import { fetchApi } from '@/lib/api/fetch'
 import type { TextDataPatch } from '@/lib/api/schemas'
-import { applyOp, invalidateScene, queueAutoRender, reorderPageTextNodes } from '@/lib/io/scene'
+import { applyOp, queueAutoRender, reorderPageTextNodes } from '@/lib/io/scene'
 import { ops } from '@/lib/ops'
 import { useEditorUiStore } from '@/lib/stores/editorUiStore'
 import { useJobsStore } from '@/lib/stores/jobsStore'
@@ -218,6 +217,7 @@ export function TextBlocksPanel() {
         <Tooltip>
           <TooltipTrigger asChild>
             <Button
+              data-testid="textblocks-delete-selected"
               aria-label={t('workspace.deleteSelected')}
               variant='ghost'
               size='icon-xs'
@@ -278,6 +278,7 @@ function BlockCard({
         className='overflow-hidden rounded-md bg-card/90 text-xs ring-1 ring-border data-[selected=true]:ring-primary'
       >
         <AccordionTrigger
+          data-testid={`textblock-trigger-${index}`}
           onClick={(e) => {
             if (e.shiftKey || e.ctrlKey || e.metaKey) {
               e.preventDefault()

--- a/ui/components/panels/TextBlocksPanel.tsx
+++ b/ui/components/panels/TextBlocksPanel.tsx
@@ -32,6 +32,7 @@ import { useEditorUiStore } from '@/lib/stores/editorUiStore'
 import { useJobsStore } from '@/lib/stores/jobsStore'
 import { usePreferencesStore } from '@/lib/stores/preferencesStore'
 import { useSelectionStore } from '@/lib/stores/selectionStore'
+import { cn } from '@/lib/utils'
 
 export function TextBlocksPanel() {
   const { t } = useTranslation()
@@ -81,6 +82,18 @@ export function TextBlocksPanel() {
     if (!node) return
     const idx = Object.keys(page.nodes).indexOf(nodeId)
     await applyOp(ops.removeNode(page.id, nodeId, node, idx < 0 ? 0 : idx))
+    clearSelection()
+    queueAutoRender(page.id)
+  }
+
+  const removeNodes = async (nodeIds: string[]) => {
+    const batch = nodeIds.flatMap((nodeId) => {
+      const node = page.nodes[nodeId]
+      if (!node) return []
+      const idx = Object.keys(page.nodes).indexOf(nodeId)
+      return [ops.removeNode(page.id, nodeId, node, idx < 0 ? 0 : idx)]
+    })
+    await applyOp(ops.batch("removeNodes", batch))
     clearSelection()
     queueAutoRender(page.id)
   }
@@ -199,6 +212,26 @@ export function TextBlocksPanel() {
           )}
         </div>
       </ScrollArea>
+      <div className={cn('flex items-center justify-between border-t border-border px-2 py-1.5 text-xs font-semibold tracking-wide text-muted-foreground uppercase',
+        selectedIds.size <= 1 && 'hidden'
+      )}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              aria-label={t('workspace.deleteSelected')}
+              variant='ghost'
+              size='icon-xs'
+              className='size-5 text-rose-600 hover:text-rose-600'
+              onClick={() => removeNodes([...selectedIds])}
+            >
+              <Trash2Icon className='size-4' />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side='left' sideOffset={4}>
+            {t('workspace.deleteSelected')}
+          </TooltipContent>
+        </Tooltip>
+      </div>
     </div>
   )
 }
@@ -255,25 +288,22 @@ function BlockCard({
           className='flex w-full cursor-pointer items-center gap-1.5 px-2 py-1.5 text-left transition outline-none hover:no-underline data-[state=open]:bg-accent [&>svg]:hidden'
         >
           <span
-            className={`shrink-0 rounded-md px-1.5 py-0.5 text-center text-[10px] font-medium text-white tabular-nums ${
-              selected ? 'bg-primary' : 'bg-muted-foreground/60'
-            }`}
+            className={`shrink-0 rounded-md px-1.5 py-0.5 text-center text-[10px] font-medium text-white tabular-nums ${selected ? 'bg-primary' : 'bg-muted-foreground/60'
+              }`}
             style={{ minWidth: '1.5rem' }}
           >
             {index + 1}
           </span>
           <div className='flex min-w-0 flex-1 items-center gap-1'>
             <span
-              className={`shrink-0 rounded-sm px-1 py-0.5 text-[9px] font-medium uppercase ${
-                hasOcr ? 'bg-rose-400/70 text-white' : 'bg-muted text-muted-foreground/50'
-              }`}
+              className={`shrink-0 rounded-sm px-1 py-0.5 text-[9px] font-medium uppercase ${hasOcr ? 'bg-rose-400/70 text-white' : 'bg-muted text-muted-foreground/50'
+                }`}
             >
               {t('textBlocks.ocrBadge')}
             </span>
             <span
-              className={`shrink-0 rounded-sm px-1 py-0.5 text-[9px] font-medium uppercase ${
-                hasTranslation ? 'bg-rose-400/70 text-white' : 'bg-muted text-muted-foreground/50'
-              }`}
+              className={`shrink-0 rounded-sm px-1 py-0.5 text-[9px] font-medium uppercase ${hasTranslation ? 'bg-rose-400/70 text-white' : 'bg-muted text-muted-foreground/50'
+                }`}
             >
               {t('textBlocks.translationBadge')}
             </span>

--- a/ui/components/panels/TextBlocksPanel.tsx
+++ b/ui/components/panels/TextBlocksPanel.tsx
@@ -32,6 +32,7 @@ import { useJobsStore } from '@/lib/stores/jobsStore'
 import { usePreferencesStore } from '@/lib/stores/preferencesStore'
 import { useSelectionStore } from '@/lib/stores/selectionStore'
 import { cn } from '@/lib/utils'
+import { useHotkeys } from 'react-hotkeys-hook'
 
 export function TextBlocksPanel() {
   const { t } = useTranslation()

--- a/ui/hooks/useKeyboardShortcuts.ts
+++ b/ui/hooks/useKeyboardShortcuts.ts
@@ -2,16 +2,23 @@
 
 import { useEffect, useMemo } from 'react'
 
-import { deleteSelectedTextNodesOnCurrentPage, redoOp, selectAllTextNodesOnCurrentPage, undoOp } from '@/lib/io/scene'
+import { applyOp, deleteSelectedTextNodesOnCurrentPage, queueAutoRender, redoOp, selectAllTextNodesOnCurrentPage, undoOp } from '@/lib/io/scene'
 import { getPlatform, formatShortcut, isModifierKey } from '@/lib/shortcutUtils'
 import { useEditorUiStore } from '@/lib/stores/editorUiStore'
 import { usePreferencesStore } from '@/lib/stores/preferencesStore'
+import { useCurrentPage } from './useCurrentPage'
+import { useSelectionStore } from '@/lib/stores/selectionStore'
+import { ops } from '@/lib/ops'
+import { useHotkeys } from 'react-hotkeys-hook'
 
 export function useKeyboardShortcuts() {
   const setMode = useEditorUiStore((state) => state.setMode)
   const setBrushConfig = usePreferencesStore((state) => state.setBrushConfig)
   const shortcuts = usePreferencesStore((state) => state.shortcuts)
   const isMac = useMemo(() => getPlatform() === 'mac', [])
+  const page = useCurrentPage()
+  const clearSelection = useSelectionStore((s) => s.clear)
+  const selectedIds = useSelectionStore((s) => s.nodeIds)
 
   // Optimized tool mapping - built once and updated only when shortcuts change
   const TOOL_MAP = useMemo(
@@ -65,12 +72,6 @@ export function useKeyboardShortcuts() {
         return
       }
 
-      if (event.key === 'Delete' && !inTextField) {
-        event.preventDefault()
-        deleteSelectedTextNodesOnCurrentPage()
-        return
-      }
-
       // Every other shortcut is tool-level and should not fire while typing.
       if (inTextField) return
 
@@ -100,4 +101,29 @@ export function useKeyboardShortcuts() {
     return () => window.removeEventListener('keydown', handleKeyDown)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isMac, setMode, TOOL_MAP, shortcuts])
+
+  const removeNodes = async (nodeIds: string[]) => {
+    if (!page) {
+      return;
+    }
+
+    const batch = nodeIds.flatMap((nodeId) => {
+      const node = page.nodes[nodeId]
+      if (!node) return []
+      const idx = Object.keys(page.nodes).indexOf(nodeId)
+      return [ops.removeNode(page.id, nodeId, node, idx < 0 ? 0 : idx)]
+    })
+    await applyOp(ops.batch("removeNodes", batch))
+    clearSelection()
+    queueAutoRender(page.id)
+  }
+
+  useHotkeys(
+    'delete',
+    () => {
+      if (selectedIds.size !== 0) void removeNodes([...selectedIds])
+    },
+    { enabled: selectedIds.size !== 0 },
+    [selectedIds],
+  )
 }

--- a/ui/hooks/useKeyboardShortcuts.ts
+++ b/ui/hooks/useKeyboardShortcuts.ts
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo } from 'react'
 
-import { redoOp, selectAllTextNodesOnCurrentPage, undoOp } from '@/lib/io/scene'
+import { deleteSelectedTextNodesOnCurrentPage, redoOp, selectAllTextNodesOnCurrentPage, undoOp } from '@/lib/io/scene'
 import { getPlatform, formatShortcut, isModifierKey } from '@/lib/shortcutUtils'
 import { useEditorUiStore } from '@/lib/stores/editorUiStore'
 import { usePreferencesStore } from '@/lib/stores/preferencesStore'
@@ -62,6 +62,12 @@ export function useKeyboardShortcuts() {
       if (mod && (event.key === 'a' || event.key === 'A') && !inTextField) {
         event.preventDefault()
         selectAllTextNodesOnCurrentPage()
+        return
+      }
+
+      if (event.key === 'Delete' && !inTextField) {
+        event.preventDefault()
+        deleteSelectedTextNodesOnCurrentPage()
         return
       }
 

--- a/ui/lib/io/scene.ts
+++ b/ui/lib/io/scene.ts
@@ -34,6 +34,7 @@ import { filenameFromContentDisposition } from '@/lib/io/saveBlob'
 import { queryClient } from '@/lib/queryClient'
 import { usePreferencesStore } from '@/lib/stores/preferencesStore'
 import { useSelectionStore } from '@/lib/stores/selectionStore'
+import { ops } from '../ops'
 
 /**
  * Imperative action helpers. Every mutation below is a thin wrapper that
@@ -145,6 +146,22 @@ export function selectAllTextNodesOnCurrentPage(): void {
 /** Deselect everything on the current page. No-op if nothing is selected. */
 export function clearSelectionOnCurrentPage(): void {
   useSelectionStore.getState().selectMany([])
+}
+
+export async function deleteSelectedTextNodesOnCurrentPage(): Promise<void> {
+  const pageId = useSelectionStore.getState().pageId
+  if (!pageId) return
+  const snap = queryClient.getQueryData<SceneSnapshot>(getGetSceneJsonQueryKey())
+  const page = snap?.scene?.pages?.[pageId]
+  if (!page) return
+  const nodeIds = useSelectionStore.getState().nodeIds
+  const batch = [...nodeIds.keys().flatMap((nodeId) => {
+    const node = page.nodes[nodeId]
+    if (!node) return []
+    const idx = Object.keys(page.nodes).indexOf(nodeId)
+    return [ops.removeNode(page.id, nodeId, node, idx < 0 ? 0 : idx)]
+  })]
+  await applyOp(ops.batch("removeNodes", batch))
 }
 
 // Project lifecycle ----------------------------------------------------------

--- a/ui/lib/io/scene.ts
+++ b/ui/lib/io/scene.ts
@@ -142,6 +142,11 @@ export function selectAllTextNodesOnCurrentPage(): void {
   useSelectionStore.getState().selectMany(ids)
 }
 
+/** Deselect everything on the current page. No-op if nothing is selected. */
+export function clearSelectionOnCurrentPage(): void {
+  useSelectionStore.getState().selectMany([])
+}
+
 // Project lifecycle ----------------------------------------------------------
 
 export async function createAndOpenProject(req: CreateProjectRequest): Promise<ProjectSummary> {

--- a/ui/public/locales/en-US/translation.json
+++ b/ui/public/locales/en-US/translation.json
@@ -24,6 +24,7 @@
     "undo": "Undo",
     "redo": "Redo",
     "selectAll": "Select All",
+    "clearSelect": "Clear Selection",
     "exportGroup": "Export",
     "export": "Export...",
     "exportPsd": "Export PSD...",
@@ -277,7 +278,8 @@
   },
   "workspace": {
     "importPrompt": "Import a page to begin editing.",
-    "deleteBlock": "Delete block"
+    "deleteBlock": "Delete block",
+    "deleteSelected": "Delete selected"
   },
   "statusBar": {
     "zoom": "Zoom",

--- a/ui/tests/components/TextBlocksPanel.test.tsx
+++ b/ui/tests/components/TextBlocksPanel.test.tsx
@@ -11,6 +11,8 @@ import { useSelectionStore } from '@/lib/stores/selectionStore'
 
 import { renderWithQuery } from '../helpers'
 import { server } from '../msw/server'
+import { queryClient } from '@/lib/queryClient'
+import { MenuBar } from '@/components/MenuBar'
 
 function sceneWithTextNodes() {
   return {
@@ -48,6 +50,7 @@ describe('TextBlocksPanel', () => {
     useSelectionStore.getState().setPage('p1')
     useSelectionStore.getState().select('t2', false)
     useJobsStore.getState().clear()
+    queryClient.clear()
     useEditorUiStore.setState({ selectedLanguage: 'en' })
     usePreferencesStore.setState({
       customSystemPrompt: 'translate naturally',
@@ -86,5 +89,51 @@ describe('TextBlocksPanel', () => {
       systemPrompt: 'translate naturally',
       defaultFont: 'Arial',
     })
+  })
+
+  it('deletes the corresponding text block when the delete button is clicked', async () => {
+    let lastOp: any = null
+
+    server.use(
+      http.get('/api/v1/scene.json', () => HttpResponse.json(sceneWithTextNodes())),
+      http.post('/api/v1/history/apply', async ({ request }) => {
+        lastOp = await request.json()
+        return HttpResponse.json({ epoch: 2 })
+      }),
+    )
+    renderWithQuery(<TextBlocksPanel />)
+
+    const block0 = await screen.findByTestId('textblock-trigger-0')
+    await userEvent.click(block0)
+    const button0 = await screen.findByTestId('textblock-delete-0')
+    await userEvent.click(button0)
+
+    expect(lastOp).toMatchObject({ removeNode: { id: 't1' } })
+
+    const block1 = await screen.findByTestId('textblock-trigger-1')
+    await userEvent.click(block1)
+    const button1 = await screen.findByTestId('textblock-delete-1')
+    await userEvent.click(button1)
+
+    expect(lastOp).toMatchObject({ removeNode: { id: 't2' } })
+  })
+
+  it('deletes all text blocks when the batch delete button is clicked', async () => {
+    let lastOp: any = null
+
+    server.use(
+      http.get('/api/v1/scene.json', () => HttpResponse.json(sceneWithTextNodes())),
+      http.post('/api/v1/history/apply', async ({ request }) => {
+        lastOp = await request.json()
+        return HttpResponse.json({ epoch: 2 })
+      }),
+    )
+    renderWithQuery(<div><MenuBar /><TextBlocksPanel /></div>)
+
+    await userEvent.click(await screen.findByTestId('menu-edit-trigger'))
+    await userEvent.click(await screen.findByTestId('menu-edit-select-all'))
+    await userEvent.click(await screen.findByTestId('textblocks-delete-selected'))
+
+    expect(lastOp).toMatchObject({ batch: { ops: [{ removeNode: { id: 't1' } }, { removeNode: { id: 't2' } }] } })
   })
 })

--- a/ui/tests/hooks/useKeyboardShortcuts.test.tsx
+++ b/ui/tests/hooks/useKeyboardShortcuts.test.tsx
@@ -7,6 +7,7 @@ import { getGetSceneJsonQueryKey } from '@/lib/api/default/default'
 import type { Node, Page, SceneSnapshot } from '@/lib/api/schemas'
 import { queryClient } from '@/lib/queryClient'
 import { useSelectionStore } from '@/lib/stores/selectionStore'
+import { QueryClientProvider } from '@tanstack/react-query'
 
 function textNode(id: string): Node {
   return {
@@ -40,7 +41,13 @@ describe('useKeyboardShortcuts — Ctrl+A', () => {
   it('Ctrl+A selects every text node on the active page', () => {
     queryClient.setQueryData(getGetSceneJsonQueryKey(), seedScene())
     useSelectionStore.getState().setPage('p-1')
-    renderHook(() => useKeyboardShortcuts())
+    renderHook(() => useKeyboardShortcuts(), {
+      wrapper: ({ children }) => (
+        <QueryClientProvider client={queryClient}>
+          {children}
+        </QueryClientProvider>
+      ),
+    })
 
     fireEvent.keyDown(window, { key: 'a', ctrlKey: true })
 
@@ -50,7 +57,13 @@ describe('useKeyboardShortcuts — Ctrl+A', () => {
   it('Ctrl+A is a no-op while typing inside a textarea', () => {
     queryClient.setQueryData(getGetSceneJsonQueryKey(), seedScene())
     useSelectionStore.getState().setPage('p-1')
-    renderHook(() => useKeyboardShortcuts())
+    renderHook(() => useKeyboardShortcuts(), {
+      wrapper: ({ children }) => (
+        <QueryClientProvider client={queryClient}>
+          {children}
+        </QueryClientProvider>
+      ),
+    })
 
     const textarea = document.createElement('textarea')
     document.body.appendChild(textarea)


### PR DESCRIPTION
This adds a few small tweaks to the textblock workflow. First, there is now a delete all button. Second, there is a deselect all button in the menu. Third, the delete key is mapped to delete all selected.

The delete button is put in a panel which is hidden until multiple selections are made. In the future, this panel can be used for other selection-specific buttons.

Note I didn't add a keyboard shortcut for clear selection. That shortcut should probably be escape, but I wasn't sure if it was desirable.

No AI assistance was used to write this MR.