### PR TITLE
Quality: RegionExt::clamp returns spurious 1×1 crop when region is entirely outside image bounds

### DIFF
--- a/koharu-app/src/utils.rs
+++ b/koharu-app/src/utils.rs
@@ -14,6 +14,9 @@ impl RegionExt for Region {
         if width == 0 || height == 0 {
             return None;
         }
+        if self.x >= width || self.y >= height {
+            return None;
+        }
         let x0 = self.x.min(width.saturating_sub(1));
         let y0 = self.y.min(height.saturating_sub(1));
         let x1 = self.x.saturating_add(self.width).min(width).max(x0);


### PR DESCRIPTION
## ✨ Code Quality

### Problem
When a Region is completely outside the image (e.g., self.x=100 on a 50-wide image), the clamp method incorrectly returns Some((49, y0, 1, h)) — a 1-pixel strip at the boundary — instead of None. This happens because x0 is capped at width-1 (49), then x1 is computed as max(..., x0)=50, yielding w=1. The caller has no way to know the region was entirely out-of-bounds and will silently crop a wrong sliver of the image.


**Severity**: `high`
**File**: `koharu-app/src/utils.rs`

### Solution
Add an early-exit check for fully out-of-bounds regions before the min/max calculations:


### Changes
- `koharu-app/src/utils.rs` (modified)

### Testing
- [x] Existing tests pass
- [x] Manual review completed
- [x] No new warnings/errors introduced

---


---

<details>
<summary>🤖 About this PR</summary>

This pull request was generated by [ContribAI](https://github.com/tang-vu/ContribAI), an AI agent
that helps improve open source projects. The change was:

1. **Discovered** by automated code analysis
2. **Generated** by AI with context-aware code generation
3. **Self-reviewed** by AI quality checks

If you have questions or feedback about this PR, please comment below.
We appreciate your time reviewing this contribution!

</details>


Closes #825