### PR TITLE
fix: Allow deleting font size value completely.

### DIFF
--- a/ui/components/panels/RenderControlsPanel.tsx
+++ b/ui/components/panels/RenderControlsPanel.tsx
@@ -287,7 +287,7 @@ export function RenderControlsPanel() {
     const current = n.data.style
     const nextStyle: TextStyle = {
       fontFamilies: updates.fontFamilies ?? current?.fontFamilies ?? [],
-      fontSize: updates.fontSize ?? current?.fontSize ?? null,
+      fontSize: updates.fontSize !== undefined ? updates.fontSize : (current?.fontSize ?? null),
       color: updates.color ?? effectiveColorOf(current, n.data.fontPrediction),
       effect: updates.effect ?? current?.effect ?? null,
       stroke: updates.stroke ?? current?.stroke ?? null,
@@ -576,6 +576,9 @@ export function RenderControlsPanel() {
             value={currentFontSize !== undefined ? Math.round(currentFontSize) : ''}
             placeholder='auto'
             onChange={(event) => {
+              if (event.target.value === '') {
+                applyStyleToSelected({ fontSize: null })
+              }
               const parsed = Number.parseInt(event.target.value, 10)
               if (!Number.isFinite(parsed) || parsed < 1) return
               applyStyleToSelected({ fontSize: Math.min(300, parsed) })


### PR DESCRIPTION
When typing a font size, an intuitive way to do that is to delete the whole thing and type in the number you want. This allows you to do that, and has the convenient side effect of allowing you to reset the font size to auto.

Note: it would be ideal to do this with border stroke width too, but we don't have an empty default state for that field. A future MR should add a default state and similar logic to that field.

This patch was made with no AI assistance.