### PR TITLE
chore(ui): cleaned up the styling of the text style buttons

### DIFF
--- a/ui/app/globals.css
+++ b/ui/app/globals.css
@@ -145,3 +145,4 @@
     @apply select-text;
   }
 }
+

--- a/ui/components/panels/RenderControlsPanel.tsx
+++ b/ui/components/panels/RenderControlsPanel.tsx
@@ -8,6 +8,7 @@ import {
   ItalicIcon,
   MinusIcon,
   PlusIcon,
+  SquareDashedIcon,
   SquareIcon,
 } from 'lucide-react'
 import { type ComponentType, useMemo, useRef, useEffect, useState } from 'react'
@@ -377,6 +378,14 @@ export function RenderControlsPanel() {
     ? 'border-primary/20 bg-primary/10 text-primary'
     : 'border-border/60 bg-muted text-muted-foreground'
 
+  const renderBorderIcon = () => {
+    if (currentStroke.enabled) {
+      return <SquareIcon className='size-3.5' strokeWidth={3} />
+    } else {
+      return <SquareDashedIcon className='size-3.5' />
+    }
+  }
+
   if (!page) {
     return (
       <div className='flex items-center justify-center py-6 text-xs text-muted-foreground'>
@@ -604,15 +613,11 @@ export function RenderControlsPanel() {
               <Tooltip key={item.key}>
                 <TooltipTrigger asChild>
                   <Button
-                    variant='outline'
+                    variant={active ? 'toggle_on' : 'toggle_off'}
                     size='icon-sm'
                     aria-label={item.label}
                     data-testid={`render-effect-toggle-${item.key}`}
-                    className={cn(
-                      'size-6 shrink-0',
-                      active &&
-                        'border-primary bg-primary text-primary-foreground hover:bg-primary/90',
-                    )}
+                    className={cn('size-6 shrink-0')}
                     onClick={() => {
                       const nextEffect: TextShaderEffect = {
                         ...currentEffect,
@@ -644,16 +649,12 @@ export function RenderControlsPanel() {
               <Tooltip key={item.value}>
                 <TooltipTrigger asChild>
                   <Button
-                    variant='outline'
+                    variant={active ? 'toggle_on' : 'toggle_off'}
                     size='icon-sm'
                     aria-label={item.label}
                     data-testid={`render-align-${item.value}`}
                     disabled={!hasNodes}
-                    className={cn(
-                      'size-6 shrink-0',
-                      active &&
-                        'border-primary bg-primary text-primary-foreground hover:bg-primary/90',
-                    )}
+                    className={cn('size-6 shrink-0')}
                     onClick={() => {
                       if (applyStyleToSelected({ textAlign: item.value })) return
                       applyStyleToAll({ textAlign: item.value })
@@ -680,19 +681,15 @@ export function RenderControlsPanel() {
           <Tooltip>
             <TooltipTrigger asChild>
               <Button
-                variant='outline'
+                variant={currentStroke.enabled ? 'toggle_on' : 'toggle_off'}
                 size='icon-sm'
                 data-testid='render-stroke-enable'
-                className={cn(
-                  'size-7 shrink-0',
-                  currentStroke.enabled &&
-                    'border-primary bg-primary text-primary-foreground hover:bg-primary/90',
-                )}
+                className={cn('size-7 shrink-0')}
                 onClick={() =>
                   applyStrokeSetting({ ...currentStroke, enabled: !currentStroke.enabled })
                 }
               >
-                <SquareIcon className='size-3.5' />
+                {renderBorderIcon()}
               </Button>
             </TooltipTrigger>
             <TooltipContent side='bottom' sideOffset={4}>

--- a/ui/components/ui/button.tsx
+++ b/ui/components/ui/button.tsx
@@ -14,6 +14,8 @@ const buttonVariants = cva(
           'bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40',
         outline:
           'border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50',
+        toggle_off: 'border bg-background text-muted-foreground shadow-xs hover:bg-accent hover:text-accent-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50 dark:hover:text-foreground',
+        toggle_on: 'border border-primary bg-primary text-primary-foreground hover:text-accent-foreground shadow-xs dark:border-input dark:bg-input/30 dark:hover:bg-input/50 dark:text-foreground',
         secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
         ghost: 'hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50',
         link: 'text-primary underline-offset-4 hover:underline',


### PR DESCRIPTION
Changed the icon when unselected to make it clear it is unselected. Adjusted colors so that in dark mode it is clearer that the button is selected and not deselected.

Currently I adjust the weight of the `SquareIcon` so that it looks less ugly in light mode. Ideally we would do this for all the icons when selected, and only in light mode. This is because the accent-foreground looks bad against accent at low font weights/stroke widths. Alternatively, we might play with the colors a bit more.

Note: the dark colors are a little bit ad-hoc right now. It might be worth reviewing the color scheme as a whole and creating a larger set of color tokens that better matches the semantic roles we have in play.

No AI was used in making this MR.