### PR TITLE
Fix scaling on sprites

### DIFF
--- a/ui/components/canvas/TextBlockLayer.tsx
+++ b/ui/components/canvas/TextBlockLayer.tsx
@@ -251,6 +251,8 @@ function BlockSprite({ node, scale }: { node: TextNodeEntry; scale: number }) {
   const spriteT = node.data.spriteTransform
   const x = (spriteT?.x ?? node.transform.x) * scale
   const y = (spriteT?.y ?? node.transform.y) * scale
+  const w = (spriteT?.width ?? node.transform.width) * scale
+  const h = (spriteT?.height ?? node.transform.height) * scale
   return (
     <img
       alt=''
@@ -260,8 +262,10 @@ function BlockSprite({ node, scale }: { node: TextNodeEntry; scale: number }) {
       style={{
         top: 0,
         left: 0,
+        width: w,
+        height: h,
         transformOrigin: 'top left',
-        transform: `translate(${x}px, ${y}px) scale(${scale})`,
+        transform: `translate(${x}px, ${y}px)`,
       }}
     />
   )


### PR DESCRIPTION
For some reason, the browser decides to downscale the sprite's bounding box before even applying the transform. This causes the scale and translate values to be incorrect. Fix this by forcing width and height to the correct values.

Correct Render:
<img width="1282" height="962" alt="image" src="https://github.com/user-attachments/assets/5e4bebde-47bb-48e9-a694-c4fb6d91180c" />

Preview Before:
<img width="1282" height="962" alt="image" src="https://github.com/user-attachments/assets/027cb796-0176-4f4f-ace5-c18ad627c241" />
Preview After:
<img width="1282" height="962" alt="image" src="https://github.com/user-attachments/assets/734ac8f4-4ed5-45e8-bbdc-33ac17c8b0e8" />
