### PR TITLE
docs: add AI Router compatible API setup

### DIFF
--- a/docs/en-US/how-to/use-openai-compatible-api.md
+++ b/docs/en-US/how-to/use-openai-compatible-api.md
@@ -89,6 +89,23 @@ Official references:
 - [OpenRouter authentication](https://openrouter.ai/docs/api/reference/authentication)
 - [OpenRouter models](https://openrouter.ai/models)
 
+## AI Router
+
+Use AI Router as an independent hosted OpenAI-compatible API gateway.
+
+1. Create an account and API key on [AI Router](https://ai-router.dev/).
+2. In Koharu, open **Settings > API Keys** and expand `OpenAI Compatible`.
+3. Set `Base URL` to `https://api.ai-router.dev/v1`.
+4. Paste your AI Router API key into `API Key` and save.
+5. Wait for the provider's status dot to turn green.
+6. Pick one of the discovered models from Koharu's LLM picker.
+
+Important details:
+
+- AI Router is an independent service and is not operated by OpenAI
+- Koharu discovers available models through authenticated `GET /v1/models`; the list reflects the API response for your account
+- translation requests use standard bearer authentication and the OpenAI-style `POST /v1/chat/completions` path
+
 ## Other compatible endpoints
 
 For other self-hosted or routed APIs, use the same checklist:

--- a/docs/ja-JP/how-to/use-openai-compatible-api.md
+++ b/docs/ja-JP/how-to/use-openai-compatible-api.md
@@ -89,6 +89,23 @@ curl http://127.0.0.1:1234/v1/models
 - [OpenRouter authentication](https://openrouter.ai/docs/api/reference/authentication)
 - [OpenRouter models](https://openrouter.ai/models)
 
+## AI Router
+
+AI Router は、独立運営のホスト型 OpenAI 互換 API ゲートウェイです。
+
+1. [AI Router 日本語サイト](https://ai-router.dev/ja/) でアカウントを作成し、API キーを発行します。
+2. Koharu で **Settings > API Keys** を開き、`OpenAI Compatible` を展開します。
+3. `Base URL` に `https://api.ai-router.dev/v1` を設定します。
+4. AI Router の API キーを `API Key` に貼り付けて保存します。
+5. プロバイダのステータスドットが緑になるまで待ちます。
+6. Koharu の LLM ピッカーから、検出されたモデルを選びます。
+
+重要な点:
+
+- AI Router は独立したサービスであり、OpenAI が運営するサービスではありません
+- Koharu は認証付きの `GET /v1/models` で利用可能なモデルを検出します。表示される一覧は、利用中のアカウントに対する API レスポンスに基づきます
+- 翻訳リクエストには標準の bearer 認証と OpenAI 形式の `POST /v1/chat/completions` パスを使います
+
 ## その他の互換エンドポイント
 
 他のセルフホスト API やルーティング型 API を使う場合も、確認項目は同じです。

--- a/docs/pt-BR/how-to/use-openai-compatible-api.md
+++ b/docs/pt-BR/how-to/use-openai-compatible-api.md
@@ -89,6 +89,23 @@ Referências oficiais:
 - [Autenticação do OpenRouter](https://openrouter.ai/docs/api/reference/authentication)
 - [Modelos do OpenRouter](https://openrouter.ai/models)
 
+## AI Router
+
+Use o AI Router como um gateway de API hospedado e independente compatível com OpenAI.
+
+1. Crie uma conta e uma API key no [AI Router em português](https://ai-router.dev/pt/).
+2. No Koharu, abra **Settings > API Keys** e expanda `OpenAI Compatible`.
+3. Defina `Base URL` como `https://api.ai-router.dev/v1`.
+4. Cole sua API key do AI Router em `API Key` e salve.
+5. Aguarde o status dot do provedor ficar verde.
+6. Escolha um dos modelos descobertos no seletor de LLM do Koharu.
+
+Detalhes importantes:
+
+- o AI Router é um serviço independente e não é operado pela OpenAI
+- o Koharu descobre os modelos disponíveis com um `GET /v1/models` autenticado; a lista reflete a resposta da API para sua conta
+- as solicitações de tradução usam autenticação bearer padrão e o endpoint `POST /v1/chat/completions` no formato OpenAI
+
 ## Outros endpoints compatíveis
 
 Para outras APIs self-hosted ou roteadas, use o mesmo checklist:

--- a/docs/zh-CN/how-to/use-openai-compatible-api.md
+++ b/docs/zh-CN/how-to/use-openai-compatible-api.md
@@ -89,6 +89,23 @@ OpenRouter 是一个托管的多模型 OpenAI 兼容 API。
 - [OpenRouter 鉴权](https://openrouter.ai/docs/api/reference/authentication)
 - [OpenRouter 模型列表](https://openrouter.ai/models)
 
+## AI Router
+
+AI Router 是一个独立运营的托管式 OpenAI 兼容 API 网关。
+
+1. 在 [AI Router 中文站](https://ai-router.dev/cn/) 注册并创建 API key。
+2. 在 Koharu 中打开 **Settings > API Keys**，展开 `OpenAI Compatible`。
+3. 将 `Base URL` 设为 `https://api.ai-router.dev/v1`。
+4. 把 AI Router API key 粘贴到 `API Key` 并保存。
+5. 等待该提供方的状态指示点变绿。
+6. 在 Koharu 的 LLM 选择器中选择一个已发现的模型。
+
+重要细节：
+
+- AI Router 是独立服务，并非由 OpenAI 运营
+- Koharu 通过带鉴权的 `GET /v1/models` 发现可用模型；列表以当前账号收到的 API 响应为准
+- 翻译请求使用标准 Bearer 鉴权和 OpenAI 风格的 `POST /v1/chat/completions` 路径
+
 ## 其他兼容端点
 
 对于其他自托管或路由型 API，可以使用同样的检查表：


### PR DESCRIPTION
## Summary

- Add AI Router as a concrete hosted endpoint example in the existing OpenAI-compatible API guide.
- Keep the setup under Koharu's generic `OpenAI Compatible` provider; this adds no built-in provider or runtime behavior.
- Update the English, Simplified Chinese, Japanese, and Brazilian Portuguese pages with matching localized product links.
- Limit the guidance to the API base URL, bearer authentication, model discovery, and Chat Completions contract.

## Validation

- `zensical build -f docs/zensical.toml --clean`
- `zensical build -f docs/zensical.ja-JP.toml`
- `zensical build -f docs/zensical.zh-CN.toml`
- `zensical build -f docs/zensical.pt-BR.toml`
- `git diff --check`
- Confirmed all four localized product pages return HTTP 200.
- Confirmed unauthenticated `GET /v1/models` and `POST /v1/chat/completions` return HTTP 401, matching the documented authentication requirement.

## Disclosure

AI Router is operated by the submitter. It is independent from Koharu and OpenAI, and this documentation change does not imply endorsement. AI assistance was used to compare the existing language structure and review wording; every changed line was reviewed and all validation above was run by the submitter.