### PR TITLE
Linux Wayland: native wl_subsurface desktop surface path

### DIFF
--- a/crates/koharu/build.rs
+++ b/crates/koharu/build.rs
@@ -1,4 +1,13 @@
 fn main() {
+    // Alias for the long `target_os` list needing the Wayland subsurface path.
+    println!("cargo::rustc-check-cfg=cfg(wayland_platform)");
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    if matches!(
+        target_os.as_str(),
+        "linux" | "dragonfly" | "freebsd" | "netbsd" | "openbsd"
+    ) {
+        println!("cargo::rustc-cfg=wayland_platform");
+    }
     std::env::var_os("DEP_KOHARU_TORCH_SHIM")
         .expect("koharu-torch-sys did not provide its runtime shim");
 }

--- a/packages/koharu/components/editor/CanvasWorkspace.tsx
+++ b/packages/koharu/components/editor/CanvasWorkspace.tsx
@@ -495,9 +495,14 @@ export function CanvasWorkspace() {
             event.preventDefault()
             const point = clientPhysicalPoint(event.clientX, event.clientY)
             const current = useKoharuStore.getState().camera
+            const zoomModifier =
+              event.ctrlKey ||
+              event.metaKey ||
+              event.getModifierState('Control') ||
+              event.getModifierState('Meta')
             let zoom = current.zoom
             let translation = current.translation
-            if (event.ctrlKey) {
+            if (zoomModifier) {
               zoom = clamp(current.zoom * Math.exp(-event.deltaY * 0.0015), 0.02, 16)
               const pageX = (point.x - current.translation[0]) / current.zoom
               const pageY = (point.y - current.translation[1]) / current.zoom

--- a/packages/koharu/components/editor/CanvasWorkspace.tsx
+++ b/packages/koharu/components/editor/CanvasWorkspace.tsx
@@ -411,6 +411,12 @@ export function CanvasWorkspace() {
               const additive = event.shiftKey || event.ctrlKey || event.metaKey
               if (!target) {
                 if (!additive) selectLayers([])
+                gesture.current = {
+                  kind: 'pan',
+                  pointer: event.pointerId,
+                  start: physical,
+                  translation: camera.translation,
+                }
                 return
               }
               const next = additive

--- a/packages/koharu/tests/components/workspace.test.tsx
+++ b/packages/koharu/tests/components/workspace.test.tsx
@@ -107,6 +107,19 @@ describe('canvas interaction adapter', () => {
     expect(setCanvasView).toHaveBeenCalledWith(1, [0, -10])
   })
 
+  it('uses Ctrl+wheel to zoom the canvas view', async () => {
+    installProject()
+    const setCanvasView = vi.spyOn(commands, 'setCanvasView').mockResolvedValue(null)
+    const surface = renderWorkspace()
+
+    fireEvent.wheel(surface, { clientX: 120, clientY: 120, deltaY: 100, ctrlKey: true })
+
+    runAnimationFrame()
+    await waitFor(() => expect(setCanvasView).toHaveBeenCalledOnce())
+    const [zoom] = setCanvasView.mock.calls[0]
+    expect(zoom).toBeLessThan(1)
+  })
+
   it('interprets a brush gesture in React and sends paint data to Rust', async () => {
     installProject()
     useKoharuStore.setState({ tool: 'draw', brush: { diameter: 48, color: '#FFFFFF' } })


### PR DESCRIPTION
# Linux Wayland surface fix

## Summary
This PR replaces the Linux X11 backdrop approach with a native Wayland `wl_subsurface` path and stabilizes startup/resize handling for the desktop WGPU surface.

## What changed
- Added Wayland surface layer implementation in [crates/koharu/src/desktop/wayland_overlay.rs](crates/koharu/src/desktop/wayland_overlay.rs).
- Added platform-specific surface creation and backend selection in [crates/koharu/src/desktop/surface.rs](crates/koharu/src/desktop/surface.rs).
- Switched desktop presenter to use the new surface creation path in [crates/koharu/src/desktop/gpu.rs](crates/koharu/src/desktop/gpu.rs).
- Added startup attach retry flow and resize hooks in [crates/koharu/src/desktop/mod.rs](crates/koharu/src/desktop/mod.rs) and [crates/koharu/src/app.rs](crates/koharu/src/app.rs).
- Added Linux/BSD target deps and cfg alias in [crates/koharu/Cargo.toml](crates/koharu/Cargo.toml) and [crates/koharu/build.rs](crates/koharu/build.rs).

## Why
- Avoids Wayland protocol conflicts from sharing WebKitGTK's surface.
- Handles delayed window realization during startup.
- Keeps platform-specific surface logic separate from rendering logic.

## Validation
- `cargo check -p koharu` passes.
- Existing generated binding warnings in `koharu-llama-sys` are unchanged.

## Review focus
- Startup and first paint on GNOME Wayland.
- Resize behavior on start screen and loaded workspace.
- Non-Wayland Linux/BSD fallback behavior.
