### PR TITLE
fix: recover from an out-of-range detection threshold

### DIFF
--- a/crates/koharu-pipeline/src/stages/detection.rs
+++ b/crates/koharu-pipeline/src/stages/detection.rs
@@ -5,7 +5,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use anyhow::{Context as _, Result, anyhow, bail, ensure};
+use anyhow::{Context as _, Result, anyhow, bail};
 use async_trait::async_trait;
 use image::{DynamicImage, GrayImage, ImageFormat, Luma, RgbImage};
 use imageproc::{
@@ -61,26 +61,32 @@ pub(super) struct Processor {
 }
 
 impl Processor {
-    pub(super) fn new(config: DetectionModel, device: koharu_ml::Device) -> Result<Self> {
-        let DetectionModel::KoharuLayoutRFDetrSeg2XL(settings) = &config;
+    pub(super) fn new(mut config: DetectionModel, device: koharu_ml::Device) -> Self {
+        let DetectionModel::KoharuLayoutRFDetrSeg2XL(settings) = &mut config;
         for (name, value) in [
-            ("text", settings.text_threshold),
-            ("bubble", settings.bubble_threshold),
-            ("panel", settings.panel_threshold),
+            ("text", &mut settings.text_threshold),
+            ("bubble", &mut settings.bubble_threshold),
+            ("panel", &mut settings.panel_threshold),
         ] {
-            if let Some(value) = value {
-                ensure!(
-                    value.is_finite() && (0.0..=1.0).contains(&value),
-                    "{name} confidence threshold must be finite and between zero and one"
+            // A stored threshold is only a preference; refusing to start over one
+            // leaves the application unusable until the file is edited by hand.
+            if let Some(threshold) = *value
+                && !(threshold.is_finite() && (0.0..=1.0).contains(&threshold))
+            {
+                tracing::warn!(
+                    label = name,
+                    threshold = %threshold,
+                    "confidence threshold is not between zero and one; using the model default"
                 );
+                *value = None;
             }
         }
 
-        Ok(Self {
+        Self {
             config,
             device,
             model: ModelCell::new(),
-        })
+        }
     }
 }
 
@@ -1836,11 +1842,29 @@ mod tests {
     };
 
     use super::{
-        DIALOGUE_MASK_CONTAINMENT_THRESHOLD, DetectedRegion, DetectedText, ImageSize, MaskPixel,
-        PageRegions, RegionOutput, TextReuse, color_palette, generation, infer_typography,
-        layout_order, link_dialogue_regions, mask_containment, mask_for, mask_geometry,
-        non_maximum_suppression, normalize_text_color, write_region,
+        DIALOGUE_MASK_CONTAINMENT_THRESHOLD, DetectedRegion, DetectedText, DetectionModel,
+        ImageSize, KoharuLayoutRFDetrSeg2XLConfig, MaskPixel, PageRegions, Processor, RegionOutput,
+        TextReuse, color_palette, generation, infer_typography, layout_order,
+        link_dialogue_regions, mask_containment, mask_for, mask_geometry, non_maximum_suppression,
+        normalize_text_color, write_region,
     };
+
+    #[test]
+    fn out_of_range_thresholds_fall_back_to_the_model_defaults() {
+        let processor = Processor::new(
+            DetectionModel::KoharuLayoutRFDetrSeg2XL(KoharuLayoutRFDetrSeg2XLConfig {
+                text_threshold: Some(15.0),
+                bubble_threshold: Some(f32::NAN),
+                panel_threshold: Some(0.55),
+            }),
+            koharu_ml::Device::cpu(),
+        );
+
+        let DetectionModel::KoharuLayoutRFDetrSeg2XL(settings) = &processor.config;
+        assert_eq!(settings.text_threshold, None);
+        assert_eq!(settings.bubble_threshold, None);
+        assert_eq!(settings.panel_threshold, Some(0.55));
+    }
 
     #[tokio::test]
     async fn joined_text_uses_balloon_flow_semantics() {

--- a/crates/koharu-pipeline/src/stages/mod.rs
+++ b/crates/koharu-pipeline/src/stages/mod.rs
@@ -80,7 +80,7 @@ impl Stages {
         device: &koharu_ml::Device,
     ) -> Result<Self> {
         Ok(Self {
-            detection: detection::Processor::new(config.detection()?, device.clone())?,
+            detection: detection::Processor::new(config.detection()?, device.clone()),
             ocr: ocr::Processor::new(config.ocr.clone(), device.clone()),
             translation: translation::Processor::new(config.translation.clone(), translator),
             inpainting: inpainting::Processor::new(config.inpainting()?, device.clone())?,

--- a/packages/koharu/components/preferences/PreferenceFields.tsx
+++ b/packages/koharu/components/preferences/PreferenceFields.tsx
@@ -99,6 +99,20 @@ export function TextField({
   )
 }
 
+/**
+ * `min` and `max` on a number input are validation hints the browser never
+ * enforces on typed text, so bounds are applied here before the value reaches
+ * the stored configuration.
+ */
+function parseBounded(raw: string, min?: number, max?: number) {
+  if (raw === '') return null
+  const value = Number(raw)
+  if (!Number.isFinite(value)) return null
+  if (min !== undefined && value < min) return min
+  if (max !== undefined && value > max) return max
+  return value
+}
+
 export function NumberField({
   label,
   value,
@@ -128,9 +142,7 @@ export function NumberField({
         step={step}
         placeholder={t('model.default')}
         className='h-8 text-[12px] text-foreground'
-        onChange={(event) =>
-          onChange(event.currentTarget.value === '' ? null : Number(event.currentTarget.value))
-        }
+        onChange={(event) => onChange(parseBounded(event.currentTarget.value, min, max))}
       />
     </label>
   )

--- a/packages/koharu/tests/components/editor-components.test.tsx
+++ b/packages/koharu/tests/components/editor-components.test.tsx
@@ -774,6 +774,33 @@ describe('greenfield editor', () => {
     expect(screen.getByLabelText('Target language')).toHaveTextContent('English')
   })
 
+  it('clamps a threshold typed past its bounds before saving it', async () => {
+    installProject()
+    useKoharuStore.setState({ settingsOpen: true })
+    const save = vi.spyOn(commands, 'savePreferences').mockResolvedValue(preferences)
+    render(
+      <ThemeProvider attribute='class'>
+        <SettingsPage />
+      </ThemeProvider>,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Pipeline' }))
+    fireEvent.change(screen.getByRole('spinbutton', { name: 'Text threshold' }), {
+      target: { value: '15' },
+    })
+    await waitFor(() =>
+      expect(save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          processor: expect.objectContaining({
+            'koharu-layout-rfdetr-seg-2xl': expect.objectContaining({ text_threshold: 1 }),
+          }),
+        }),
+        preferences.providers,
+        preferences.typesetting,
+      ),
+    )
+  })
+
   it('saves a newer OpenRouter selection after an in-flight provider save', async () => {
     installProject()
     const user = userEvent.setup()


### PR DESCRIPTION
Fixes #911.

A detection threshold stored outside `0.0..=1.0` currently makes Koharu unopenable: `detection::Processor::new` rejects it, the error propagates out of `initialize`, and `crates/koharu-app/src/app.rs:135` turns it into a fatal startup dialog. Recovering means hand-editing `~/.koharu/config.toml`.

### Changes

**`crates/koharu-pipeline/src/stages/detection.rs`** — an out-of-range or non-finite threshold is reset to `None` with a `tracing::warn!`, so `Model::load` uses `recommended_thresholds()` for that label. A stored threshold is a preference; it should not be able to lock the user out of the UI that edits it. This sanitizes in memory only and does not rewrite the configuration file, so the invalid value stays on disk (now harmless) until preferences are next saved.

With the only fallible path gone, `Processor::new` returns `Self` rather than `Result<Self>`, matching the sibling `ocr` and `translation` processors; `stages/mod.rs` drops the corresponding `?`.

**`packages/koharu/components/preferences/PreferenceFields.tsx`** — `NumberField` clamps to its declared `min`/`max` and rejects non-finite input before the value reaches the stored configuration. The HTML `min`/`max` attributes are constraint-validation hints and do not restrict typed text, which is how `15` reached the config file in the first place. An empty field still means `null`, i.e. the model default.

### Tests

- `out_of_range_thresholds_fall_back_to_the_model_defaults` covers `15.0`, `NaN`, and a valid `0.55` that must survive: `cargo test -p koharu-pipeline --lib out_of_range`.
- `clamps a threshold typed past its bounds before saving it` types `15` into Text threshold and asserts `text_threshold: 1` reaches `savePreferences`. Verified to fail without the `PreferenceFields.tsx` change.
- Full `tests/components/editor-components.test.tsx` (25 tests), `cargo fmt -p koharu-pipeline -- --check`, and `oxlint` all pass. `oxfmt --check` flags 60 files repo-wide, none of them touched here.

---

*AI disclosure, per CONTRIBUTING.md: I hit this crash in normal use; this fix was written with Claude Code. Every test listed above was run locally on Windows 11 against 0.66.9.*
