### PR TITLE
[Feature] : Toggle font color, weight and width between auto and manual

### DIFF
--- a/crates/koharu-renderer/src/config.rs
+++ b/crates/koharu-renderer/src/config.rs
@@ -5,12 +5,18 @@ use specta::Type;
 #[serde(default)]
 pub struct TypesettingConfig {
     pub font_families: Vec<String>,
+    pub force_border_width: Option<f32>,
+    pub force_font_color: Option<String>,
+    pub force_font_weight: Option<u16>,
 }
 
 impl Default for TypesettingConfig {
     fn default() -> Self {
         Self {
             font_families: vec!["CCWildWords".to_owned(), "Adobe 黑体 Std".to_owned()],
+            force_border_width: None,
+            force_font_color: None,
+            force_font_weight: None,
         }
     }
 }

--- a/crates/koharu-renderer/src/renderer.rs
+++ b/crates/koharu-renderer/src/renderer.rs
@@ -541,6 +541,9 @@ impl Renderer {
             height,
             source_role: &source_role,
             font_families: &typesetting.font_families,
+            force_border_width: typesetting.force_border_width,
+            force_font_color: typesetting.force_font_color.clone(),
+            force_font_weight: typesetting.force_font_weight,
             balloon_flows: flow_plan.placements,
             layers: Vec::new(),
             dependencies: BTreeSet::from([
@@ -615,6 +618,9 @@ struct Traversal<'a> {
     height: u32,
     source_role: &'a AssetRole,
     font_families: &'a [String],
+    force_border_width: Option<f32>,
+    force_font_color: Option<String>,
+    force_font_weight: Option<u16>,
     balloon_flows: HashMap<EntityId, ResolvedPlacement>,
     layers: Vec<LayerDraft>,
     dependencies: BTreeSet<RenderDependency>,
@@ -842,6 +848,39 @@ impl Traversal<'_> {
             dependencies.insert(RenderDependency::Font(family.clone()));
         }
         let is_bubble = balloon_contour.is_some();
+        let mut foreground_color = typography
+            .as_ref()
+            .and_then(|value| value.color)
+            .unwrap_or([0, 0, 0, 255]);
+        if let Some(ref hex) = self.force_font_color {
+            if hex.len() == 7 && hex.starts_with('#') {
+                if let (Ok(r), Ok(g), Ok(b)) = (
+                    u8::from_str_radix(&hex[1..3], 16),
+                    u8::from_str_radix(&hex[3..5], 16),
+                    u8::from_str_radix(&hex[5..7], 16),
+                ) {
+                    foreground_color = [r, g, b, 255];
+                }
+            }
+        }
+        let mut stroke = resolve_stroke(typography.as_ref());
+        if let Some(forced_width) = self.force_border_width {
+            if let Some(ref mut existing_stroke) = stroke {
+                existing_stroke.width_px = forced_width;
+            } else if forced_width > 0.0 {
+                stroke = Some(StrokeOptions {
+                    color: typography
+                        .as_ref()
+                        .and_then(|t| t.stroke_color)
+                        .unwrap_or([255, 255, 255, 255]),
+                    width_px: forced_width,
+                });
+            }
+        }
+        let mut resolved_weight = typography.as_ref().and_then(|value| value.font_weight);
+        if let Some(fw) = self.force_font_weight {
+            resolved_weight = Some(fw);
+        }
         let descriptor = TextNodeDescriptor {
             entity,
             text: text.clone(),
@@ -852,7 +891,7 @@ impl Traversal<'_> {
             flow_contour,
             preferred_font,
             font_families,
-            font_weight: typography.as_ref().and_then(|value| value.font_weight),
+            font_weight: resolved_weight,
             font_style: typography
                 .as_ref()
                 .and_then(|value| value.font_style)
@@ -862,17 +901,15 @@ impl Traversal<'_> {
             auto_fit: typography.as_ref().is_none_or(|value| value.auto_fit),
             alignment,
             writing_mode,
-            foreground_color: typography
-                .as_ref()
-                .and_then(|value| value.color)
-                .unwrap_or([0, 0, 0, 255]),
-            stroke: resolve_stroke(typography.as_ref()),
+            foreground_color,
+            stroke,
             line_height: 1.2,
             letter_spacing: 0.0,
             word_spacing: 0.0,
             text_inset: [4.0; 4],
             point_text: !is_bubble && layout.kind == TextLayoutKind::Point,
         };
+
         Ok(Some(LayerDraft {
             entity,
             geometry,

--- a/crates/koharu-renderer/src/renderer.rs
+++ b/crates/koharu-renderer/src/renderer.rs
@@ -852,16 +852,16 @@ impl Traversal<'_> {
             .as_ref()
             .and_then(|value| value.color)
             .unwrap_or([0, 0, 0, 255]);
-        if let Some(ref hex) = self.force_font_color {
-            if hex.len() == 7 && hex.starts_with('#') {
-                if let (Ok(r), Ok(g), Ok(b)) = (
-                    u8::from_str_radix(&hex[1..3], 16),
-                    u8::from_str_radix(&hex[3..5], 16),
-                    u8::from_str_radix(&hex[5..7], 16),
-                ) {
-                    foreground_color = [r, g, b, 255];
-                }
-            }
+        if let Some(ref hex) = self.force_font_color
+            && hex.len() == 7
+            && hex.starts_with('#')
+            && let (Ok(r), Ok(g), Ok(b)) = (
+                u8::from_str_radix(&hex[1..3], 16),
+                u8::from_str_radix(&hex[3..5], 16),
+                u8::from_str_radix(&hex[5..7], 16),
+            )
+        {
+            foreground_color = [r, g, b, 255];
         }
         let mut stroke = resolve_stroke(typography.as_ref());
         if let Some(forced_width) = self.force_border_width {

--- a/packages/koharu/components/editor/Inspector.tsx
+++ b/packages/koharu/components/editor/Inspector.tsx
@@ -143,6 +143,15 @@ function TypeInspector() {
   } | null>(null)
   const updateSequence = useRef(0)
 
+  const typesetting = useKoharuStore((state) => state.preferences?.typesetting)
+  const forcedFontColor = typesetting?.force_font_color
+  const forcedBorderWidth = typesetting?.force_border_width
+  const forcedFontWeight = typesetting?.force_font_weight
+
+  const isColorForced = !!forcedFontColor
+  const isBorderForced = forcedBorderWidth !== undefined && forcedBorderWidth !== null
+  const isWeightForced = forcedFontWeight !== undefined && forcedFontWeight !== null
+
   useEffect(() => setDraft(null), [current?.id])
 
   const apply = (update: (value: Typography) => Typography) => {
@@ -216,12 +225,12 @@ function TypeInspector() {
               }}
             />
           </InspectorField>
-          <InspectorField label={t('inspector.color')}>
+          <InspectorField label={t('inspector.color')} forced={isColorForced}>
             <ColorWell
               label={t('inspector.textColor')}
               size='sm'
-              disabled={disabled}
-              value={rgbaToHex(typography.color ?? defaultTypography.color!)}
+              disabled={disabled || isColorForced}
+              value={forcedFontColor ?? rgbaToHex(typography.color ?? defaultTypography.color!)}
               onChange={(color) => apply((value) => ({ ...value, color: hexToRgba(color) }))}
             />
           </InspectorField>
@@ -243,10 +252,10 @@ function TypeInspector() {
               }
             />
           </InspectorField>
-          <InspectorField label={t('inspector.weight')}>
+          <InspectorField label={t('inspector.weight')} forced={isWeightForced}>
             <Select
-              disabled={disabled}
-              value={String(weight)}
+              disabled={disabled || isWeightForced}
+              value={isWeightForced ? String(forcedFontWeight) : String(weight)}
               onValueChange={(font_weight) =>
                 apply((value) => ({
                   ...value,
@@ -398,13 +407,13 @@ function TypeInspector() {
               }}
             />
           </InspectorField>
-          <InspectorField label={t('inspector.width')}>
+          <InspectorField label={t('inspector.width')} forced={isBorderForced}>
             <NumberField
               id={borderWidthId}
               name='border-width'
               className='min-w-0'
-              disabled={disabled}
-              value={displayedStrokeWidth}
+              disabled={disabled || isBorderForced}
+              value={isBorderForced ? forcedBorderWidth : displayedStrokeWidth}
               min={0.5}
               max={32}
               step={0.5}
@@ -875,12 +884,30 @@ function LayerEditor({ layer, onDelete }: { layer: Layer; onDelete?: () => void 
   )
 }
 
-function InspectorField({ label, children }: { label: string; children: React.ReactNode }) {
+function InspectorField({
+  label,
+  forced,
+  children,
+}: {
+  label: string
+  forced?: boolean
+  children: React.ReactNode
+}) {
   return (
     <div className='grid min-w-0 gap-0.5'>
-      <span className='text-[8px] font-medium tracking-[0.06em] text-muted-foreground uppercase'>
-        {label}
-      </span>
+      <div className='flex items-center gap-1.5'>
+        <span className='truncate text-[8px] font-medium tracking-[0.06em] text-muted-foreground uppercase'>
+          {label}
+        </span>
+        {forced && (
+          <div
+            className='relative flex size-2.5 shrink-0 items-center justify-center overflow-hidden rounded-[1px] border border-muted-foreground/40 bg-transparent'
+            title='Overridden by global setting'
+          >
+            <div className='absolute h-[0.5px] w-[120%] -rotate-45 bg-muted-foreground/40' />
+          </div>
+        )}
+      </div>
       {children}
     </div>
   )

--- a/packages/koharu/components/preferences/TypesettingPreferences.tsx
+++ b/packages/koharu/components/preferences/TypesettingPreferences.tsx
@@ -5,7 +5,11 @@ import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { FontPicker } from '@/components/controls/FontPicker'
-import { PreferencePage } from '@/components/preferences/PreferenceFields'
+import {
+  PreferencePage,
+  PreferenceRow,
+  PreferenceSection,
+} from '@/components/preferences/PreferenceFields'
 import type { TypesettingConfig } from '@/lib/protocol'
 import { useFonts } from '@/lib/queries'
 import { Button } from '@koharu/ui/components/button'
@@ -133,6 +137,121 @@ export function TypesettingPreferences({
           </p>
         )}
       </section>
+
+      {/* Grouped Overrides Section */}
+      <PreferenceSection
+        title="Global Overrides"
+        description="Force specific typography settings across all text layers."
+      >
+        <PreferenceRow
+          title="Font Color"
+          description="Override the typography color with solid black."
+        >
+          <Button
+            type='button'
+            variant={value.force_font_color ? 'default' : 'outline'}
+            className='h-8 text-[11px]'
+            onClick={() =>
+              onChange({
+                ...value,
+                force_font_color: value.force_font_color === '#000000' ? undefined : '#000000',
+              })
+            }
+          >
+            {value.force_font_color ? 'Revert to Auto' : 'Force Black'}
+          </Button>
+        </PreferenceRow>
+
+        <PreferenceRow
+          title="Font Border Width"
+          description="Override the automatically detected stroke width."
+        >
+          <div className='flex items-center gap-2'>
+            {value.force_border_width !== undefined && value.force_border_width !== null && (
+              <div className='flex items-center gap-1.5'>
+                <input
+                  type='number'
+                  min='0'
+                  step='0.1'
+                  className='h-8 w-16 rounded-md border border-input bg-transparent px-2 py-1 text-right text-[11px] tabular-nums shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring'
+                  value={value.force_border_width}
+                  onChange={(e) => {
+                    const num = parseFloat(e.target.value)
+                    onChange({ ...value, force_border_width: isNaN(num) ? 0 : num })
+                  }}
+                />
+                <span className='select-none text-[11px] text-muted-foreground'>px</span>
+              </div>
+            )}
+            <Button
+              type='button'
+              variant={
+                value.force_border_width !== undefined && value.force_border_width !== null
+                  ? 'default'
+                  : 'outline'
+              }
+              className='h-8 text-[11px]'
+              onClick={() =>
+                onChange({
+                  ...value,
+                  force_border_width:
+                    value.force_border_width !== undefined && value.force_border_width !== null
+                      ? undefined
+                      : 0.5,
+                })
+              }
+            >
+              {value.force_border_width !== undefined && value.force_border_width !== null
+                ? 'Revert'
+                : 'Override'}
+            </Button>
+          </div>
+        </PreferenceRow>
+
+        <PreferenceRow
+          title="Font Weight"
+          description="Override the font thickness globally"
+        >
+          <div className='flex items-center gap-2'>
+            {value.force_font_weight !== undefined && value.force_font_weight !== null && (
+              <input
+                type='number'
+                min='100'
+                max='900'
+                step='100'
+                className='h-8 w-16 rounded-md border border-input bg-transparent px-2 py-1 text-right text-[11px] tabular-nums shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring'
+                value={value.force_font_weight}
+                onChange={(e) => {
+                  const num = parseInt(e.target.value, 10)
+                  onChange({ ...value, force_font_weight: isNaN(num) ? 400 : num })
+                }}
+              />
+            )}
+            <Button
+              type='button'
+              variant={
+                value.force_font_weight !== undefined && value.force_font_weight !== null
+                  ? 'default'
+                  : 'outline'
+              }
+              className='h-8 text-[11px]'
+              onClick={() =>
+                onChange({
+                  ...value,
+                  force_font_weight:
+                    value.force_font_weight !== undefined && value.force_font_weight !== null
+                      ? undefined
+                      : 400,
+                })
+              }
+            >
+              {value.force_font_weight !== undefined && value.force_font_weight !== null
+                ? 'Revert'
+                : 'Override'}
+            </Button>
+          </div>
+        </PreferenceRow>
+      </PreferenceSection>
     </PreferencePage>
   )
 }

--- a/packages/koharu/lib/protocol.ts
+++ b/packages/koharu/lib/protocol.ts
@@ -497,6 +497,9 @@ export type TranslationConfig = {
 
 export type TypesettingConfig = {
 	font_families?: string[],
+  force_border_width?: number | null;
+  force_font_color?: string | null;
+  force_font_weight?: number | null;
 };
 
 export type Typography = {


### PR DESCRIPTION
Added options to be able to override auto for font weight, width and font color.
Global font weight and width can now be set in typesetting preferences.
<img width="1138" height="799" alt="Screenshot 2026-08-14 192528" src="https://github.com/user-attachments/assets/3567cb09-ea89-44fd-a8a9-9ba90f1ad234" />
