### PR TITLE
fix(editor): apply correct scaling to text stroke when zooming

### DIFF
--- a/crates/koharu-renderer/src/text_renderer.rs
+++ b/crates/koharu-renderer/src/text_renderer.rs
@@ -433,7 +433,8 @@ fn draw_layout(
                     normalized_coords: font.normalized_coords().to_vec(),
                     transform: transform.as_coeffs(),
                     glyph_transform,
-                    hint: options.hint_glyphs && !matches!(style, PreparedGlyphStyle::Stroke { .. }),
+                    hint: options.hint_glyphs
+                        && !matches!(style, PreparedGlyphStyle::Stroke { .. }),
                     embolden: if font.synthetic_bold() {
                         [1.0, 1.0]
                     } else {

--- a/crates/koharu-renderer/src/text_renderer.rs
+++ b/crates/koharu-renderer/src/text_renderer.rs
@@ -433,7 +433,7 @@ fn draw_layout(
                     normalized_coords: font.normalized_coords().to_vec(),
                     transform: transform.as_coeffs(),
                     glyph_transform,
-                    hint: options.hint_glyphs,
+                    hint: options.hint_glyphs && !matches!(style, PreparedGlyphStyle::Stroke { .. }),
                     embolden: if font.synthetic_bold() {
                         [1.0, 1.0]
                     } else {


### PR DESCRIPTION
> Note: This fix was developed with the assistance of AI tools.

When zooming the canvas, translated text correctly resizes, but the colored text outline stays a fixed pixel width. 
At low zoom this makes the border look huge relative to the shrunk text; at high zoom it looks unnaturally thin.

**Fix:** Disable Vello hinting specifically for the stroke pass, so it applies the actual zoom transform to the whole stroked shape (letters + border together), keeping them proportional at every zoom level.

Verified with `cargo check -p koharu`

The exported PNG image is correct.

### Issue example:

**Zoom 74%**

<img width="835" height="603" alt="Code_18-08-2026_21-56-09" src="https://github.com/user-attachments/assets/dd3b1251-c2e1-458b-bf6a-caf56864ab1e" />

**Zoom 333%** (same parameters)

<img width="837" height="602" alt="Code_18-08-2026_21-56-26" src="https://github.com/user-attachments/assets/12edeca9-25e1-4f44-a84b-050a885d7056" />