### PR TITLE
fix(editor): replace text centered stroke with outward path

### DIFF
--- a/crates/koharu-rasterizer/src/frame.rs
+++ b/crates/koharu-rasterizer/src/frame.rs
@@ -4,15 +4,15 @@ use std::{collections::HashMap, sync::Arc};
 
 use vello::{
     FontEmbolden, Glyph, Scene,
-    kurbo::{Affine, BezPath, Diagonal2, Join, Rect, Stroke},
+    kurbo::{Affine, BezPath, Diagonal2, Join, Rect},
     peniko::{Blob, Color, Fill, FontData, Mix},
 };
 
 use crate::{
     Bounds, CompositionCommand, Error, FillRule, LayerId, LayerKind, PathElement, PreparedContent,
-    PreparedElementFrame, PreparedFrame, PreparedFrameBundle, PreparedFrameManifest,
-    PreparedGlyphStyle, PreparedPath, PreparedResource, PreparedResourceStore, PreparedScene,
-    PreparedSceneCommand, Presentation, RasterDraw, ResourceId, Result, Revision,
+    PreparedElementFrame, PreparedFrame, PreparedFrameBundle, PreparedFrameManifest, PreparedPath,
+    PreparedResource, PreparedResourceStore, PreparedScene, PreparedSceneCommand, Presentation,
+    RasterDraw, ResourceId, Result, Revision,
 };
 
 #[derive(Clone)]
@@ -474,25 +474,22 @@ fn compile_scene(
                     run = run.glyph_transform(Some(Affine::new(transform)));
                 }
                 if prepared.embolden != [0.0, 0.0] {
-                    run = run.font_embolden(FontEmbolden::new(Diagonal2::new(
-                        f64::from(prepared.embolden[0]),
-                        f64::from(prepared.embolden[1]),
-                    )));
+                    // Round joins avoid the long miter spikes a dilated outline can otherwise
+                    // produce at sharp glyph corners once the border width is large.
+                    run = run.font_embolden(
+                        FontEmbolden::new(Diagonal2::new(
+                            f64::from(prepared.embolden[0]),
+                            f64::from(prepared.embolden[1]),
+                        ))
+                        .with_join(Join::Round),
+                    );
                 }
                 let glyphs = prepared.glyphs.iter().map(|glyph| Glyph {
                     id: glyph.id,
                     x: glyph.x,
                     y: glyph.y,
                 });
-                match prepared.style {
-                    PreparedGlyphStyle::Fill { color } => {
-                        run.brush(rgba(color)).draw(Fill::NonZero, glyphs);
-                    }
-                    PreparedGlyphStyle::Stroke { color, width } => {
-                        let stroke = Stroke::new(f64::from(width)).with_join(Join::Round);
-                        run.brush(rgba(color)).draw(&stroke, glyphs);
-                    }
-                }
+                run.brush(rgba(prepared.color)).draw(Fill::NonZero, glyphs);
             }
             PreparedSceneCommand::FillPath(prepared) => {
                 let path = compile_path(prepared);

--- a/crates/koharu-rasterizer/src/lib.rs
+++ b/crates/koharu-rasterizer/src/lib.rs
@@ -18,8 +18,8 @@ pub use prepared::{
     Bounds, FillRule, LayerId, LayerKind, PREPARED_FRAME_MANIFEST_VERSION,
     PREPARED_RASTER_TILE_DIMENSION, PREPARED_RESOURCE_FORMAT_VERSION, PathElement, Point,
     PreparedContent, PreparedElementFrame, PreparedFrame, PreparedFrameBundle,
-    PreparedFrameManifest, PreparedGlyph, PreparedGlyphRun, PreparedGlyphStyle, PreparedLayer,
-    PreparedPath, PreparedRaster, PreparedRasterTile, PreparedResource, PreparedResourceKind,
+    PreparedFrameManifest, PreparedGlyph, PreparedGlyphRun, PreparedLayer, PreparedPath,
+    PreparedRaster, PreparedRasterTile, PreparedResource, PreparedResourceKind,
     PreparedResourcePacket, PreparedResourceRef, PreparedResourceStore, PreparedScene,
     PreparedSceneCommand, Presentation, ResourceId, Revision,
 };

--- a/crates/koharu-rasterizer/src/prepared.rs
+++ b/crates/koharu-rasterizer/src/prepared.rs
@@ -11,7 +11,7 @@ use crate::{Error, Result};
 
 const MANIFEST_MAGIC: [u8; 8] = *b"KHRMANF\0";
 const RESOURCE_MAGIC: [u8; 8] = *b"KHRRSRC\0";
-pub const PREPARED_FRAME_MANIFEST_VERSION: u16 = 3;
+pub const PREPARED_FRAME_MANIFEST_VERSION: u16 = 4;
 pub const PREPARED_RESOURCE_FORMAT_VERSION: u16 = 3;
 /// Logical raster tile edge used by portable frames. The one-pixel sampling
 /// gutter is stored outside this logical extent where adjacent pixels exist.
@@ -650,7 +650,7 @@ pub struct PreparedGlyphRun {
     pub glyph_transform: Option<[f64; 6]>,
     pub hint: bool,
     pub embolden: [f32; 2],
-    pub style: PreparedGlyphStyle,
+    pub color: [u8; 4],
     pub glyphs: Vec<PreparedGlyph>,
 }
 
@@ -677,11 +677,6 @@ impl PreparedGlyphRun {
         {
             return Err(Error::invalid("glyph run contains a non-finite position"));
         }
-        if let PreparedGlyphStyle::Stroke { width, .. } = self.style
-            && (!width.is_finite() || width <= 0.0)
-        {
-            return Err(Error::invalid("glyph stroke width is invalid"));
-        }
         Ok(())
     }
 }
@@ -691,18 +686,6 @@ pub struct PreparedGlyph {
     pub id: u32,
     pub x: f32,
     pub y: f32,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
-pub enum PreparedGlyphStyle {
-    Fill {
-        color: [u8; 4],
-    },
-    /// Vello outline width, already doubled from the authored outside radius.
-    Stroke {
-        color: [u8; 4],
-        width: f32,
-    },
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]

--- a/crates/koharu-renderer/src/text_renderer.rs
+++ b/crates/koharu-renderer/src/text_renderer.rs
@@ -4,8 +4,8 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use koharu_rasterizer::{
-    PreparedGlyph, PreparedGlyphRun, PreparedGlyphStyle, PreparedResource, PreparedScene,
-    PreparedSceneCommand, ResourceId,
+    PreparedGlyph, PreparedGlyphRun, PreparedResource, PreparedScene, PreparedSceneCommand,
+    ResourceId,
 };
 use vello::kurbo::Affine;
 
@@ -111,6 +111,10 @@ impl TextRenderer {
         options: &TextRenderOptions,
         transform: Affine,
     ) {
+        // The border is drawn first as an outward-only dilation of the glyph outline (see
+        // `draw_layout`), then the ordinary fill is drawn on top in the foreground color. Unlike a
+        // centered stroke, a dilation never grows inward, so it can't punch a hole through small
+        // features (e.g. dots) once the border width exceeds their radius.
         if let Some(stroke) = options
             .stroke
             .filter(|stroke| stroke.width_px > 0.0 && stroke.color[3] > 0)
@@ -122,7 +126,8 @@ impl TextRenderer {
                 writing_mode,
                 options,
                 transform,
-                DrawStyle::Stroke(stroke),
+                stroke.color,
+                stroke.width_px,
             );
         }
         draw_layout(
@@ -132,7 +137,8 @@ impl TextRenderer {
             writing_mode,
             options,
             transform,
-            DrawStyle::Fill,
+            options.color,
+            0.0,
         );
     }
 
@@ -364,12 +370,6 @@ fn placement(rect: LayoutBox, width: f32, height: f32) -> (f32, f32) {
     (x, y)
 }
 
-#[derive(Clone, Copy)]
-enum DrawStyle {
-    Stroke(StrokeOptions),
-    Fill,
-}
-
 fn draw_layout(
     scene: &mut PreparedScene,
     resources: &mut Vec<PreparedResource>,
@@ -377,7 +377,8 @@ fn draw_layout(
     writing_mode: WritingMode,
     options: &TextRenderOptions,
     transform: Affine,
-    style: DrawStyle,
+    color: [u8; 4],
+    dilation_px: f32,
 ) {
     for line in &layout.lines {
         let (baseline_x, baseline_y) = match writing_mode {
@@ -415,15 +416,7 @@ fn draw_layout(
             let glyph_transform = font
                 .synthetic_skew()
                 .map(|angle| Affine::skew(-(angle.to_radians().tan() as f64), 0.0).as_coeffs());
-            let style = match style {
-                DrawStyle::Fill => PreparedGlyphStyle::Fill {
-                    color: options.color,
-                },
-                DrawStyle::Stroke(stroke) => PreparedGlyphStyle::Stroke {
-                    color: stroke.color,
-                    width: stroke.width_px * 2.0,
-                },
-            };
+            let synthetic_bold = if font.synthetic_bold() { 1.0 } else { 0.0 };
             scene
                 .commands
                 .push(PreparedSceneCommand::GlyphRun(PreparedGlyphRun {
@@ -433,13 +426,12 @@ fn draw_layout(
                     normalized_coords: font.normalized_coords().to_vec(),
                     transform: transform.as_coeffs(),
                     glyph_transform,
-                    hint: options.hint_glyphs,
-                    embolden: if font.synthetic_bold() {
-                        [1.0, 1.0]
-                    } else {
-                        [0.0; 2]
-                    },
-                    style,
+                    // Hinting folds a uniform zoom into `font_size` for crisp fill text, but a
+                    // border needs the real transform so its dilation amount stays proportional
+                    // to that same zoom instead of being rendered at a fixed pixel size.
+                    hint: options.hint_glyphs && dilation_px == 0.0,
+                    embolden: [synthetic_bold + dilation_px; 2],
+                    color,
                     glyphs,
                 }));
             start = end;

--- a/crates/koharu-renderer/src/text_renderer.rs
+++ b/crates/koharu-renderer/src/text_renderer.rs
@@ -126,8 +126,10 @@ impl TextRenderer {
                 writing_mode,
                 options,
                 transform,
-                stroke.color,
-                stroke.width_px,
+                GlyphPaint {
+                    color: stroke.color,
+                    dilation_px: stroke.width_px,
+                },
             );
         }
         draw_layout(
@@ -137,8 +139,10 @@ impl TextRenderer {
             writing_mode,
             options,
             transform,
-            options.color,
-            0.0,
+            GlyphPaint {
+                color: options.color,
+                dilation_px: 0.0,
+            },
         );
     }
 
@@ -370,6 +374,12 @@ fn placement(rect: LayoutBox, width: f32, height: f32) -> (f32, f32) {
     (x, y)
 }
 
+/// Color and outward dilation for one glyph draw pass (border or ordinary fill).
+struct GlyphPaint {
+    color: [u8; 4],
+    dilation_px: f32,
+}
+
 fn draw_layout(
     scene: &mut PreparedScene,
     resources: &mut Vec<PreparedResource>,
@@ -377,8 +387,7 @@ fn draw_layout(
     writing_mode: WritingMode,
     options: &TextRenderOptions,
     transform: Affine,
-    color: [u8; 4],
-    dilation_px: f32,
+    paint: GlyphPaint,
 ) {
     for line in &layout.lines {
         let (baseline_x, baseline_y) = match writing_mode {
@@ -429,9 +438,9 @@ fn draw_layout(
                     // Hinting folds a uniform zoom into `font_size` for crisp fill text, but a
                     // border needs the real transform so its dilation amount stays proportional
                     // to that same zoom instead of being rendered at a fixed pixel size.
-                    hint: options.hint_glyphs && dilation_px == 0.0,
-                    embolden: [synthetic_bold + dilation_px; 2],
-                    color,
+                    hint: options.hint_glyphs && paint.dilation_px == 0.0,
+                    embolden: [synthetic_bold + paint.dilation_px; 2],
+                    color: paint.color,
                     glyphs,
                 }));
             start = end;


### PR DESCRIPTION
> Note: This fix was developed with the assistance of AI tools.

This PR aims to fix issue #447

I'm no Rust developer, so I would suggest taking a closer look at this PR changes. It works, passes tests, and generates correct outputs, but I lack full understanding of the whole project and all its parts.

> The following is an extract of the issue/fix summary from the AI tool I used.

The text stroke previously used a centered stroke (`Stroke::new(width*2.0)`, drawn under a plain fill): a shape that grows both inward and outward from the glyph outline by half the width each way. 
When the border width exceeds a small feature's own radius (a dot, or a thin letter stroke at large border widths), the inward side of that stroke wraps past the shape's center and leaves a genuine transparent hole — producing the detached "ring" you can see in the below screenshots

The fix replaces that centered stroke with **outward-only** path dilation, using Vello's existing `FontEmbolden`/`expand_path` mechanism (previously only used for synthetic bold):

- The border pass is now a normal `Fill` in the border color, with `embolden` set to the border width — this only pushes the outline _outward_, so it can never create an inward-facing hole, regardless of how large the border width gets relative to the glyph's curvature.
- Kept the earlier zoom-scaling fix (disable hinting for this pass) so the dilation amount still scales correctly with canvas zoom.
- Used `Join::Round` for the dilation joins to avoid sharp miter spikes at glyph corners with large border widths.
- Removed the now-fully-unused `PreparedGlyphStyle` enum/`Stroke` variant from `koharu-rasterizer`'s wire format (per the repo's no-backward-compatibility rule) and bumped `PREPARED_FRAME_MANIFEST_VERSION` since the format shape changed.

### Issue example:

**Before the fix**

<img width="837" height="730" alt="dots-pre" src="https://github.com/user-attachments/assets/c7575da5-8338-4d10-8349-505dcb9c059a" />

**After the fix**

<img width="839" height="725" alt="koharu_18-08-2026_23-03-24" src="https://github.com/user-attachments/assets/efe2fdc0-fd47-4ea1-99fc-92776aa3eaf9" />

