### PR TITLE
feat: drag-and-drop reordering of layers

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -28,8 +28,7 @@
       "name": "@koharu/app",
       "version": "0.1.0",
       "dependencies": {
-        "@dnd-kit/core": "^6.3.1",
-        "@dnd-kit/modifiers": "^9.0.0",
+        "@dnd-kit/react": "^0.5.0",
         "@koharu/bridge": "workspace:*",
         "@koharu/ui": "workspace:*",
         "@tanstack/react-query": "^5.101.4",
@@ -192,13 +191,17 @@
 
     "@date-fns/tz": ["@date-fns/tz@1.5.0", "", {}, "sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg=="],
 
-    "@dnd-kit/accessibility": ["@dnd-kit/accessibility@3.1.1", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw=="],
+    "@dnd-kit/abstract": ["@dnd-kit/abstract@0.5.0", "", { "dependencies": { "@dnd-kit/geometry": "^0.5.0", "@dnd-kit/state": "^0.5.0", "tslib": "^2.6.2" } }, "sha512-hi13iMJgjPX/KDYVKg5VeDIhmYiV6buc9bAX+tCLYf4QdyYjPbsXjn2sPo6m7fQ6SGJBEFgHJ2PemeKDUbwBaA=="],
 
-    "@dnd-kit/core": ["@dnd-kit/core@6.3.1", "", { "dependencies": { "@dnd-kit/accessibility": "^3.1.1", "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ=="],
+    "@dnd-kit/collision": ["@dnd-kit/collision@0.5.0", "", { "dependencies": { "@dnd-kit/abstract": "^0.5.0", "@dnd-kit/geometry": "^0.5.0", "tslib": "^2.6.2" } }, "sha512-xUqRn3lS7oqLkT0AnnHS/STh/Czvwe1UapZFYiLbsUGxopMsQd4teaPCzPouOThoMdGEe+dHWjfqJl6t9iG4mQ=="],
 
-    "@dnd-kit/modifiers": ["@dnd-kit/modifiers@9.0.0", "", { "dependencies": { "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@dnd-kit/core": "^6.3.0", "react": ">=16.8.0" } }, "sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw=="],
+    "@dnd-kit/dom": ["@dnd-kit/dom@0.5.0", "", { "dependencies": { "@dnd-kit/abstract": "^0.5.0", "@dnd-kit/collision": "^0.5.0", "@dnd-kit/geometry": "^0.5.0", "@dnd-kit/state": "^0.5.0", "tslib": "^2.6.2" } }, "sha512-f2xFJp5SYQ8EW/Fbtaa8iBb66hpkWc7qa8vU826KW11/tb44sH+AisZnGtwOOTWTQ0GraqBDr5ixTErww+eKXw=="],
 
-    "@dnd-kit/utilities": ["@dnd-kit/utilities@3.2.2", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg=="],
+    "@dnd-kit/geometry": ["@dnd-kit/geometry@0.5.0", "", { "dependencies": { "@dnd-kit/state": "^0.5.0", "tslib": "^2.6.2" } }, "sha512-ubHQS1CiSDH8ssYH2xG5BnpwPSFP1tStXXjug7/Ba6qnQdu/EUH47l6QXKIksQnnanfVfDf0aGeevRxgZlj28A=="],
+
+    "@dnd-kit/react": ["@dnd-kit/react@0.5.0", "", { "dependencies": { "@dnd-kit/abstract": "^0.5.0", "@dnd-kit/dom": "^0.5.0", "@dnd-kit/state": "^0.5.0", "tslib": "^2.6.2" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-abQPLI8lmfVE+v/n+pqy5WFxrw6T2Yg0UQZsL78dp5DKci7dKTVDjvLWqvass+XTFtzJmsZEjk1NdqE6xG8Jiw=="],
+
+    "@dnd-kit/state": ["@dnd-kit/state@0.5.0", "", { "dependencies": { "@preact/signals-core": "^1.10.0", "tslib": "^2.6.2" } }, "sha512-y7XbabQqjF58Lk8YmDQuR8l6QjN+Kh4qlGEjUvHuIeasLk1QP+9L5diXS98VMxQIivyMmUtX2//f+3N7qPJX4w=="],
 
     "@dotenvx/dotenvx": ["@dotenvx/dotenvx@1.75.1", "", { "dependencies": { "@dotenvx/primitives": "^0.8.0", "commander": "^11.1.0", "conf": "^10.2.0", "dotenv": "^17.2.1", "enquirer": "^2.4.1", "env-paths": "^2.2.1", "execa": "^5.1.1", "fdir": "^6.2.0", "ignore": "^5.3.0", "object-treeify": "1.1.33", "open": "^8.4.2", "picomatch": "^4.0.4", "systeminformation": "^5.22.11", "undici": "^7.11.0", "which": "^4.0.0", "yocto-spinner": "^1.1.0" }, "bin": { "dotenvx": "src/cli/dotenvx.js" } }, "sha512-/BITOC9dmS/edY2zQwZNicQ059O6RKabtQfyEafV0nGtfYRNHYy1DIPiYVcov40+tob9hfmBnbR963dS+EQ1DQ=="],
 
@@ -453,6 +456,8 @@
     "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.80.0", "", { "os": "win32", "cpu": "x64" }, "sha512-yAnO7lwBYQnz2pcfBPIGQQZWIX5zd5R/1aAKIF3oE+TVj7IhoHcROjOkz3sRDngzqhfPKfFaXqug5j5rE5dn6Q=="],
 
     "@polka/url": ["@polka/url@1.0.0-next.29", "", {}, "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="],
+
+    "@preact/signals-core": ["@preact/signals-core@1.14.4", "", {}, "sha512-HNB6HYeYKhQbJ1aKl+YRjrS4+QWHLKX6qKoUsfS/m0vqzsVaEBiZiaKbG/e+NKk2ch5ALQr/ihWaMHxiCuuWHA=="],
 
     "@quansync/fs": ["@quansync/fs@1.0.0", "", { "dependencies": { "quansync": "^1.0.0" } }, "sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -28,6 +28,8 @@
       "name": "@koharu/app",
       "version": "0.1.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/modifiers": "^9.0.0",
         "@koharu/bridge": "workspace:*",
         "@koharu/ui": "workspace:*",
         "@tanstack/react-query": "^5.101.4",
@@ -189,6 +191,14 @@
     "@csstools/css-tokenizer": ["@csstools/css-tokenizer@4.0.0", "", {}, "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA=="],
 
     "@date-fns/tz": ["@date-fns/tz@1.5.0", "", {}, "sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg=="],
+
+    "@dnd-kit/accessibility": ["@dnd-kit/accessibility@3.1.1", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw=="],
+
+    "@dnd-kit/core": ["@dnd-kit/core@6.3.1", "", { "dependencies": { "@dnd-kit/accessibility": "^3.1.1", "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ=="],
+
+    "@dnd-kit/modifiers": ["@dnd-kit/modifiers@9.0.0", "", { "dependencies": { "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@dnd-kit/core": "^6.3.0", "react": ">=16.8.0" } }, "sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw=="],
+
+    "@dnd-kit/utilities": ["@dnd-kit/utilities@3.2.2", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg=="],
 
     "@dotenvx/dotenvx": ["@dotenvx/dotenvx@1.75.1", "", { "dependencies": { "@dotenvx/primitives": "^0.8.0", "commander": "^11.1.0", "conf": "^10.2.0", "dotenv": "^17.2.1", "enquirer": "^2.4.1", "env-paths": "^2.2.1", "execa": "^5.1.1", "fdir": "^6.2.0", "ignore": "^5.3.0", "object-treeify": "1.1.33", "open": "^8.4.2", "picomatch": "^4.0.4", "systeminformation": "^5.22.11", "undici": "^7.11.0", "which": "^4.0.0", "yocto-spinner": "^1.1.0" }, "bin": { "dotenvx": "src/cli/dotenvx.js" } }, "sha512-/BITOC9dmS/edY2zQwZNicQ059O6RKabtQfyEafV0nGtfYRNHYy1DIPiYVcov40+tob9hfmBnbR963dS+EQ1DQ=="],
 

--- a/packages/koharu/components/editor/Inspector.tsx
+++ b/packages/koharu/components/editor/Inspector.tsx
@@ -906,7 +906,6 @@ function LayerRow({
       <div
         data-selected={selected}
         data-expanded={expanded}
-        className='min-w-0 overflow-hidden rounded-lg transition-colors duration-150 data-[selected=true]:bg-accent motion-reduce:transition-none'
         className={`min-w-0 overflow-hidden rounded-lg transition-colors duration-150 data-[selected=true]:bg-accent motion-reduce:transition-none ${
           dragOverId === layer.id && dropPos
             ? dropPos === 'before'

--- a/packages/koharu/components/editor/Inspector.tsx
+++ b/packages/koharu/components/editor/Inspector.tsx
@@ -887,6 +887,7 @@ function LayerRow({
           e.dataTransfer.setData('text/plain', layer.id)
         }
         onDragStart(layer.id)
+      }}
       onDragEnd={(e) => {
         onDragEnd(e)
       }}

--- a/packages/koharu/components/editor/Inspector.tsx
+++ b/packages/koharu/components/editor/Inspector.tsx
@@ -475,6 +475,43 @@ function normalizeFontName(value: string): string {
   return value.normalize('NFKC').trim().replace(/\s+/g, ' ').toLowerCase()
 }
 
+function isDescendant(layers: Layer[], parentId: EntityId, childId: EntityId): boolean {
+  let current = layers.find((l) => l.id === childId)
+  while (current && current.parent) {
+    if (current.parent === parentId) return true
+    const parent = current.parent
+    current = layers.find((l) => l.id === parent)
+  }
+  return false
+}
+
+function isValidDrop(
+  layers: Layer[],
+  draggedId: EntityId,
+  targetId: EntityId,
+  pos: 'before' | 'after' | 'inside',
+  pageId: EntityId,
+): boolean {
+  if (draggedId === targetId || isDescendant(layers, draggedId, targetId)) return false
+
+  const draggedLayer = layers.find((l) => l.id === draggedId)
+  const targetLayer = layers.find((l) => l.id === targetId)
+  if (!draggedLayer || !targetLayer || isLockedLayer(targetLayer) || isLockedLayer(draggedLayer))
+    return false
+
+  const parent = pos === 'inside' ? targetId : (targetLayer.parent ?? pageId)
+  const parentLayer = layers.find((l) => l.id === parent)
+  const isParentTextGroup = parentLayer && isGroupLayer(parentLayer) && parentLayer.role === 'text'
+
+  const isDraggedText = isTextLayer(draggedLayer)
+  const hasTextGroup = layers.some((l) => isGroupLayer(l) && l.role === 'text')
+
+  if (isDraggedText && hasTextGroup && !isParentTextGroup) return false
+  if (!isDraggedText && isParentTextGroup) return false
+
+  return true
+}
+
 function displayedLayers(layers: Layer[], page: EntityId) {
   const indexes = new Map(layers.map((layer, index) => [layer.id, index]))
   const rows: { layer: Layer; index: number; depth: number }[] = []
@@ -500,6 +537,11 @@ function LayersInspector() {
   )
   const [movingLayer, setMovingLayer] = useState<EntityId | null>(null)
 
+  const [draggedId, setDraggedId] = useState<EntityId | null>(null)
+  const [dragOverId, setDragOverId] = useState<EntityId | null>(null)
+  const [dropPos, setDropPos] = useState<'before' | 'after' | 'inside' | null>(null)
+  const lastDragOverRef = useRef<{ id: EntityId; pos: 'before' | 'after' | 'inside' } | null>(null)
+
   useEffect(() => {
     setExpandedLayer(selected.length === 1 ? (selected[0] ?? null) : null)
   }, [selected])
@@ -512,7 +554,7 @@ function LayersInspector() {
     if (movingLayer !== null || isLockedLayer(layer)) return
     const parent = layer.parent ?? page.id
     const storedSiblings = page.layers.filter(
-      (candidate) => !isLockedLayer(candidate) && (candidate.parent ?? page.id) === parent,
+      (candidate) => (candidate.parent ?? page.id) === parent,
     )
     const parentLayer = page.layers.find((candidate) => candidate.id === parent)
     const shownSiblings =
@@ -530,7 +572,7 @@ function LayersInspector() {
       (next) => {
         queryClient.setQueryData(pageKey, next)
         setMovingLayer(null)
-        void refresh(projectKey)
+        void refresh(projectKey, pageKey)
       },
       () => setMovingLayer(null),
     )
@@ -556,6 +598,91 @@ function LayersInspector() {
     setExpandedLayer(layer)
   }
 
+  const handleDragStart = (id: EntityId) => {
+    setDraggedId(id)
+  }
+
+  const handleDragEnd = () => {
+    if (draggedId && lastDragOverRef.current && movingLayer === null) {
+      handleDrop(draggedId, lastDragOverRef.current.id, lastDragOverRef.current.pos)
+    }
+    setTimeout(() => {
+      setDraggedId(null)
+      setDragOverId(null)
+      setDropPos(null)
+      lastDragOverRef.current = null
+    }, 0)
+  }
+
+  const handleDragOver = (id: EntityId, pos: 'before' | 'after' | 'inside') => {
+    setDragOverId(id)
+    setDropPos(pos)
+    lastDragOverRef.current = { id, pos }
+  }
+
+  const handleDragLeave = () => {
+    setDragOverId(null)
+    setDropPos(null)
+  }
+
+  const handleDrop = (
+    sourceId: EntityId,
+    targetId: EntityId,
+    calculatedDropPos: 'before' | 'after' | 'inside',
+  ) => {
+    if (!isValidDrop(page.layers, sourceId, targetId, calculatedDropPos, page.id)) return
+
+    const sourceLayer = page.layers.find((l) => l.id === sourceId)
+    const targetLayer = page.layers.find((l) => l.id === targetId)
+    if (!sourceLayer || !targetLayer) return
+
+    let parent = targetLayer.parent ?? page.id
+    if (calculatedDropPos === 'inside') {
+      parent = targetLayer.id
+    }
+
+    const storedSiblingsWithoutSource = page.layers.filter(
+      (c) => (c.parent ?? page.id) === parent && c.id !== sourceId,
+    )
+
+    const parentLayer = page.layers.find((candidate) => candidate.id === parent)
+    const isTextGroup = parentLayer && isGroupLayer(parentLayer) && parentLayer.role === 'text'
+
+    let targetStoredIndex = 0
+
+    if (calculatedDropPos === 'inside') {
+      targetStoredIndex = isTextGroup ? storedSiblingsWithoutSource.length : 0
+    } else {
+      const shownSiblingsWithoutSource = isTextGroup
+        ? storedSiblingsWithoutSource
+        : [...storedSiblingsWithoutSource].reverse()
+
+      const targetIdxInShown = shownSiblingsWithoutSource.findIndex((c) => c.id === targetId)
+      if (targetIdxInShown !== -1) {
+        const targetShownIndex =
+          calculatedDropPos === 'before' ? targetIdxInShown : targetIdxInShown + 1
+        targetStoredIndex = isTextGroup
+          ? targetShownIndex
+          : storedSiblingsWithoutSource.length - targetShownIndex
+      } else {
+        targetStoredIndex = storedSiblingsWithoutSource.length
+      }
+    }
+
+    setMovingLayer(sourceId)
+    void call(commands.moveLayer, sourceId, parent, targetStoredIndex)
+      .then((next) => {
+        queryClient.setQueryData(pageKey, next)
+        void refresh(projectKey, pageKey)
+      })
+      .finally(() => {
+        setMovingLayer(null)
+        setDraggedId(null)
+        setDragOverId(null)
+        setDropPos(null)
+      })
+  }
+
   return (
     <div className='flex min-h-0 flex-1 flex-col'>
       <header className='flex h-8 shrink-0 items-center gap-1.5 border-b border-border/80 px-2'>
@@ -571,9 +698,7 @@ function LayersInspector() {
           {layers.map(({ layer, index, depth }) => {
             const locked = isLockedLayer(layer)
             const storedSiblings = page.layers.filter(
-              (candidate) =>
-                !isLockedLayer(candidate) &&
-                (candidate.parent ?? page.id) === (layer.parent ?? page.id),
+              (candidate) => (candidate.parent ?? page.id) === (layer.parent ?? page.id),
             )
             const parentLayer = page.layers.find((candidate) => candidate.id === layer.parent)
             const siblings =
@@ -597,10 +722,25 @@ function LayersInspector() {
                     .catch(() => undefined)
                 }
                 onMove={(delta) => move(layer, delta)}
-                canMoveUp={!locked && position > 0}
-                canMoveDown={!locked && position >= 0 && position < siblings.length - 1}
+                canMoveUp={!locked && position > 0 && !isLockedLayer(siblings[position - 1])}
+                canMoveDown={
+                  !locked &&
+                  position >= 0 &&
+                  position < siblings.length - 1 &&
+                  !isLockedLayer(siblings[position + 1])
+                }
                 reordering={movingLayer !== null}
                 onDelete={isGroupLayer(layer) ? undefined : () => deleteLayer(layer.id)}
+                draggedId={draggedId}
+                dragOverId={dragOverId}
+                dropPos={dropPos}
+                onDragStart={handleDragStart}
+                onDragEnd={handleDragEnd}
+                onDragOver={handleDragOver}
+                onDragLeave={handleDragLeave}
+                onDrop={handleDrop}
+                layersList={page.layers}
+                pageId={page.id}
               />
             )
           })}
@@ -625,6 +765,16 @@ function LayerRow({
   canMoveDown,
   reordering,
   onDelete,
+  draggedId,
+  dragOverId,
+  dropPos,
+  onDragStart,
+  onDragEnd,
+  onDragOver,
+  onDragLeave,
+  onDrop,
+  layersList,
+  pageId,
 }: {
   layer: Layer
   index: number
@@ -639,17 +789,136 @@ function LayerRow({
   canMoveDown: boolean
   reordering: boolean
   onDelete?: () => void
+  draggedId: EntityId | null
+  dragOverId: EntityId | null
+  dropPos: 'before' | 'after' | 'inside' | null
+  onDragStart: (id: EntityId) => void
+  onDragEnd: () => void
+  onDragOver: (id: EntityId, pos: 'before' | 'after' | 'inside') => void
+  onDragLeave: () => void
+  onDrop: (sourceId: EntityId, targetId: EntityId, pos: 'before' | 'after' | 'inside') => void
+  layersList: Layer[]
+  pageId: EntityId
 }) {
   const { t } = useTranslation()
   const name = localizedLayerName(layer, index, t)
   const detail = localizedLayerKind(layer, t)
   const Icon = layerIcon(layer)
+
   return (
-    <div className='group min-w-0 px-1 py-px' style={{ paddingLeft: `${depth * 10 + 4}px` }}>
+    <div
+      className='group min-w-0 px-1 py-px'
+      style={{ paddingLeft: `${depth * 10 + 4}px` }}
+      draggable={!locked && !reordering}
+      onDragStart={(e) => {
+        if (e.dataTransfer) {
+          e.dataTransfer.effectAllowed = 'move'
+          e.dataTransfer.setData('text/plain', layer.id)
+        }
+        onDragStart(layer.id)
+      }}
+      onDragEnd={() => {
+        onDragEnd()
+      }}
+      onDragEnter={(e) => {
+        const dragged = draggedId
+        if (!dragged) return
+
+        const rect = e.currentTarget.getBoundingClientRect()
+        const hoverY = e.clientY - rect.top
+        const isGroup = isGroupLayer(layer)
+
+        let pos: 'before' | 'after' | 'inside'
+        if (isGroup && hoverY > rect.height * 0.25 && hoverY < rect.height * 0.75) {
+          pos = 'inside'
+        } else if (hoverY < rect.height / 2) {
+          pos = 'before'
+        } else {
+          pos = 'after'
+        }
+
+        if (!isValidDrop(layersList, dragged, layer.id, pos, pageId)) return
+
+        if (e.dataTransfer) {
+          e.dataTransfer.dropEffect = 'move'
+        }
+        e.preventDefault()
+      }}
+      onDragOver={(e) => {
+        const dragged = draggedId
+        if (!dragged) return
+
+        const rect = e.currentTarget.getBoundingClientRect()
+        const hoverY = e.clientY - rect.top
+        const isGroup = isGroupLayer(layer)
+
+        let pos: 'before' | 'after' | 'inside'
+        if (isGroup && hoverY > rect.height * 0.25 && hoverY < rect.height * 0.75) {
+          pos = 'inside'
+        } else if (hoverY < rect.height / 2) {
+          pos = 'before'
+        } else {
+          pos = 'after'
+        }
+
+        if (!isValidDrop(layersList, dragged, layer.id, pos, pageId)) return
+
+        if (e.dataTransfer) {
+          e.dataTransfer.dropEffect = 'move'
+        }
+        e.preventDefault()
+        onDragOver(layer.id, pos)
+      }}
+      onDragLeave={(e) => {
+        const rect = e.currentTarget.getBoundingClientRect()
+        if (
+          e.clientX < rect.left ||
+          e.clientX >= rect.right ||
+          e.clientY < rect.top ||
+          e.clientY >= rect.bottom
+        ) {
+          onDragLeave()
+        }
+      }}
+      onDrop={(e) => {
+        e.preventDefault()
+        const dragged = draggedId
+        if (dragged) {
+          const rect = e.currentTarget.getBoundingClientRect()
+          const hoverY = e.clientY - rect.top
+          const isGroup = isGroupLayer(layer)
+
+          let pos: 'before' | 'after' | 'inside'
+          if (isGroup && hoverY > rect.height * 0.25 && hoverY < rect.height * 0.75) {
+            pos = 'inside'
+          } else if (hoverY < rect.height / 2) {
+            pos = 'before'
+          } else {
+            pos = 'after'
+          }
+
+          if (isValidDrop(layersList, dragged, layer.id, pos, pageId)) {
+            onDrop(dragged, layer.id, pos)
+          }
+        }
+      }}
+    >
       <div
         data-selected={selected}
         data-expanded={expanded}
         className='min-w-0 overflow-hidden rounded-lg transition-colors duration-150 data-[selected=true]:bg-accent motion-reduce:transition-none'
+        className={`min-w-0 overflow-hidden rounded-lg transition-colors duration-150 data-[selected=true]:bg-accent motion-reduce:transition-none ${
+          dragOverId === layer.id && dropPos
+            ? dropPos === 'before'
+              ? 'rounded-t-none shadow-[inset_0_2px_0_0_var(--primary)]'
+              : dropPos === 'after'
+                ? 'rounded-b-none shadow-[inset_0_-2px_0_0_var(--primary)]'
+                : 'bg-primary/10 ring-1 ring-primary'
+            : ''
+        }`}
+        style={{
+          pointerEvents: draggedId !== null ? 'none' : 'auto',
+        }}
       >
         <div className='relative flex min-w-0 items-center gap-0.5'>
           <button

--- a/packages/koharu/components/editor/Inspector.tsx
+++ b/packages/koharu/components/editor/Inspector.tsx
@@ -74,18 +74,13 @@ import {
 import { Slider } from '@koharu/ui/components/slider'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@koharu/ui/components/tooltip'
 import {
-  DndContext,
-  useDraggable,
-  useDroppable,
-  DragEndEvent,
-  DragMoveEvent,
-  DragStartEvent,
-  PointerSensor,
-  useSensor,
-  useSensors,
+  DragDropProvider,
   DragOverlay,
-  pointerWithin,
-} from '@dnd-kit/core'
+  type DragEndEvent,
+  type DragMoveEvent,
+  type DragStartEvent,
+} from '@dnd-kit/react'
+import { useSortable } from '@dnd-kit/react/sortable'
 
 const defaultFont: FontFamily = {
   name: 'CCWildWords',
@@ -518,6 +513,7 @@ export function isValidDrop(
   targetId: EntityId,
   pos: 'before' | 'after' | 'inside',
   pageId: EntityId,
+  hasTextGroup?: boolean,
 ): boolean {
   if (draggedId === targetId || isDescendant(layerMap, draggedId, targetId)) return false
 
@@ -532,11 +528,13 @@ export function isValidDrop(
 
   const isDraggedText = isTextLayer(draggedLayer)
   
-  let hasTextGroup = false
-  for (const l of layerMap.values()) {
-    if (isGroupLayer(l) && l.role === 'text') {
-      hasTextGroup = true
-      break
+  if (hasTextGroup === undefined) {
+    hasTextGroup = false
+    for (const l of layerMap.values()) {
+      if (isGroupLayer(l) && l.role === 'text') {
+        hasTextGroup = true
+        break
+      }
     }
   }
 
@@ -562,13 +560,7 @@ function LayersInspector() {
 
   const pointerCoordinatesRef = useRef<{ x: number; y: number } | null>(null)
 
-  const sensors = useSensors(
-    useSensor(PointerSensor, {
-      activationConstraint: {
-        distance: 8,
-      },
-    })
-  )
+
 
   useEffect(() => {
     setExpandedLayer(selected.length === 1 ? (selected[0] ?? null) : null)
@@ -593,23 +585,33 @@ function LayersInspector() {
     return map
   }, [page])
 
+  const hasTextGroup = useMemo(() => {
+    for (const l of layerMap.values()) {
+      if (isGroupLayer(l) && l.role === 'text') return true
+    }
+    return false
+  }, [layerMap])
+
   if (!page) return <EmptyInspector>{t('inspector.selectPage')}</EmptyInspector>
 
   const handleDragStart = (event: DragStartEvent) => {
-    setDraggedId(event.active.id as EntityId)
+    const activeId = event.operation.source?.id as EntityId | undefined
+    if (activeId) {
+      setDraggedId(activeId)
+    }
   }
 
   const handleDragMove = (event: DragMoveEvent) => {
-    const { active, over } = event
+    const activeId = event.operation.source?.id as EntityId | undefined
+    const overId = event.operation.target?.id as EntityId | undefined
     const pointerCoordinates = pointerCoordinatesRef.current
-    if (!over || !pointerCoordinates) {
+    if (!activeId || !overId || !pointerCoordinates) {
       setDragOverId(null)
       setDropPos(null)
       return
     }
 
-    const overId = over.id as EntityId
-    if (active.id === overId) {
+    if (activeId === overId) {
       setDragOverId(null)
       setDropPos(null)
       return
@@ -635,7 +637,7 @@ function LayersInspector() {
       pos = 'after'
     }
 
-    if (!isValidDrop(layerMap, active.id as EntityId, overId, pos, page.id)) {
+    if (!isValidDrop(layerMap, activeId, overId, pos, page.id, hasTextGroup)) {
       setDragOverId(null)
       setDropPos(null)
       return
@@ -646,10 +648,9 @@ function LayersInspector() {
   }
 
   const handleDragEnd = (event: DragEndEvent) => {
-    const { active } = event
-
-    if (active && dragOverId && dropPos && movingLayer === null) {
-      handleDrop(active.id as EntityId, dragOverId, dropPos)
+    const activeId = event.operation.source?.id as EntityId | undefined
+    if (activeId && dragOverId && dropPos && movingLayer === null) {
+      handleDrop(activeId, dragOverId, dropPos)
     }
 
     setDraggedId(null)
@@ -657,18 +658,14 @@ function LayersInspector() {
     setDropPos(null)
   }
 
-  const handleDragCancel = () => {
-    setDraggedId(null)
-    setDragOverId(null)
-    setDropPos(null)
-  }
+
 
   const handleDrop = (
     sourceId: EntityId,
     targetId: EntityId,
     calculatedDropPos: 'before' | 'after' | 'inside',
   ) => {
-    if (!isValidDrop(layerMap, sourceId, targetId, calculatedDropPos, page.id)) return
+    if (!isValidDrop(layerMap, sourceId, targetId, calculatedDropPos, page.id, hasTextGroup)) return
 
     const sourceLayer = layerMap.get(sourceId)
     const targetLayer = layerMap.get(targetId)
@@ -779,13 +776,10 @@ function LayersInspector() {
         </span>
       </header>
 
-      <DndContext
-        sensors={sensors}
-        collisionDetection={pointerWithin}
+      <DragDropProvider
         onDragStart={handleDragStart}
         onDragMove={handleDragMove}
         onDragEnd={handleDragEnd}
-        onDragCancel={handleDragCancel}
       >
         <ScrollArea className='min-h-0 flex-1'>
           <div className='py-0.5'>
@@ -830,10 +824,9 @@ function LayersInspector() {
             {layers.length === 0 && <EmptyInspector>{t('layers.empty')}</EmptyInspector>}
           </div>
         </ScrollArea>
-        <DragOverlay adjustScale={false} dropAnimation={null}>
+        <DragOverlay dropAnimation={null}>
           {draggedId ? (() => {
-            const dragLayerIndex = layers.findIndex(l => l.layer.id === draggedId)
-            const dragLayerInfo = layers[dragLayerIndex]
+            const dragLayerInfo = layers.find(l => l.layer.id === draggedId)
             if (!dragLayerInfo) return null
             return (
               <div className='opacity-80 pointer-events-none'>
@@ -858,7 +851,7 @@ function LayersInspector() {
             )
           })() : null}
         </DragOverlay>
-      </DndContext>
+      </DragDropProvider>
     </div>
   )
 }
@@ -903,32 +896,22 @@ function LayerRow({
   const detail = localizedLayerKind(layer, t)
   const Icon = layerIcon(layer)
 
-  const { attributes, listeners, setNodeRef: setDraggableRef, isDragging } = useDraggable({
+  const { ref: sortableRef, isDragging: sortableIsDragging } = useSortable({
     id: layer.id,
+    index,
     disabled: locked || reordering || isOverlay,
   })
-
-  const { setNodeRef: setDroppableRef } = useDroppable({
-    id: layer.id,
-    disabled: locked || isOverlay,
-  })
-
-  const setCombinedRef = (node: HTMLDivElement | null) => {
-    setDraggableRef(node)
-    setDroppableRef(node)
-  }
+  const isDragging = isOverlay ? false : sortableIsDragging
 
   return (
     <div
-      id={`layer-row-${layer.id}`}
-      ref={setCombinedRef}
+      id={isOverlay ? undefined : `layer-row-${layer.id}`}
+      ref={isOverlay ? undefined : sortableRef}
       className='group min-w-0 px-1 py-px'
       style={{
         paddingLeft: `${depth * 10 + 4}px`,
-        opacity: isDragging ? 0.3 : 1,
+        opacity: isDragging ? 0 : 1,
       }}
-      {...listeners}
-      {...attributes}
     >
       <div
         data-selected={selected}
@@ -944,13 +927,26 @@ function LayerRow({
         }`}
       >
         <div className='relative flex min-w-0 items-center gap-0.5'>
-          <button
-            type='button'
+          <div
+            role='button'
+            tabIndex={locked ? undefined : 0}
             aria-label={t('layers.edit', { name })}
             aria-expanded={locked ? undefined : expanded}
-            disabled={locked}
-            className='flex min-w-0 flex-1 items-center gap-1.5 rounded-lg px-1.5 py-1 text-left hover:bg-foreground/[0.05] focus-visible:ring-2 focus-visible:ring-ring/25'
-            onClick={onSelect}
+            aria-disabled={locked ? true : undefined}
+            className={`flex min-w-0 flex-1 cursor-pointer items-center gap-1.5 rounded-lg px-1.5 py-1 text-left hover:bg-foreground/[0.05] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/25 ${
+              locked ? 'pointer-events-none opacity-50' : ''
+            }`}
+            onClick={locked ? undefined : onSelect}
+            onKeyDown={
+              locked
+                ? undefined
+                : (e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault()
+                      onSelect()
+                    }
+                  }
+            }
           >
             <Icon className='size-3.5 shrink-0 text-muted-foreground' />
             <span className='min-w-0 flex-1'>
@@ -959,7 +955,7 @@ function LayerRow({
                 {detail}
               </span>
             </span>
-          </button>
+          </div>
           {!locked && (
             <div
               className={`pointer-events-none absolute top-1/2 z-10 flex -translate-y-1/2 rounded-md bg-background/80 p-0.5 opacity-0 shadow-sm ring-1 ring-border/40 backdrop-blur-md transition-opacity duration-150 group-hover:pointer-events-auto group-hover:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100 motion-reduce:transition-none ${expanded ? 'right-7' : 'right-[3.25rem]'}`}

--- a/packages/koharu/components/editor/Inspector.tsx
+++ b/packages/koharu/components/editor/Inspector.tsx
@@ -476,11 +476,16 @@ function normalizeFontName(value: string): string {
 }
 
 function isDescendant(layers: Layer[], parentId: EntityId, childId: EntityId): boolean {
-  let current = layers.find((l) => l.id === childId)
+  const layerMap = new Map<EntityId, Layer>()
+  for (let i = 0; i < layers.length; i++) {
+    const l = layers[i]
+    layerMap.set(l.id, l)
+  }
+
+  let current = layerMap.get(childId)
   while (current && current.parent) {
     if (current.parent === parentId) return true
-    const parent = current.parent
-    current = layers.find((l) => l.id === parent)
+    current = layerMap.get(current.parent)
   }
   return false
 }
@@ -540,6 +545,7 @@ function LayersInspector() {
   const [draggedId, setDraggedId] = useState<EntityId | null>(null)
   const [dragOverId, setDragOverId] = useState<EntityId | null>(null)
   const [dropPos, setDropPos] = useState<'before' | 'after' | 'inside' | null>(null)
+  const containerRef = useRef<HTMLDivElement>(null)
   const lastDragOverRef = useRef<{ id: EntityId; pos: 'before' | 'after' | 'inside' } | null>(null)
   const scrollIntervalRef = useRef<number | null>(null)
   const lastClientYRef = useRef<number | null>(null)
@@ -604,16 +610,28 @@ function LayersInspector() {
     setDraggedId(id)
   }
 
-  const handleDragEnd = () => {
+  const handleDragEnd = (e: React.DragEvent) => {
     if (scrollIntervalRef.current !== null) {
       clearInterval(scrollIntervalRef.current)
       scrollIntervalRef.current = null
     }
     lastClientYRef.current = null
 
-    if (draggedId && lastDragOverRef.current && movingLayer === null) {
+    const isCanceled = e.clientX === 0 && e.clientY === 0
+    let isInside = false
+    if (!isCanceled && containerRef.current) {
+      const rect = containerRef.current.getBoundingClientRect()
+      isInside =
+        e.clientX >= rect.left &&
+        e.clientX <= rect.right &&
+        e.clientY >= rect.top &&
+        e.clientY <= rect.bottom
+    }
+
+    if (draggedId && lastDragOverRef.current && isInside && movingLayer === null) {
       handleDrop(draggedId, lastDragOverRef.current.id, lastDragOverRef.current.pos)
     }
+
     setTimeout(() => {
       setDraggedId(null)
       setDragOverId(null)
@@ -698,7 +716,7 @@ function LayersInspector() {
   }
 
   return (
-    <div className='flex min-h-0 flex-1 flex-col'>
+    <div ref={containerRef} className='flex min-h-0 flex-1 flex-col'>
       <header className='flex h-8 shrink-0 items-center gap-1.5 border-b border-border/80 px-2'>
         <Layers3 className='size-3 text-primary' />
         <h2 className='text-[10px] font-semibold'>{t('layers.title')}</h2>
@@ -846,7 +864,7 @@ function LayerRow({
   dragOverId: EntityId | null
   dropPos: 'before' | 'after' | 'inside' | null
   onDragStart: (id: EntityId) => void
-  onDragEnd: () => void
+  onDragEnd: (e: React.DragEvent) => void
   onDragOver: (id: EntityId, pos: 'before' | 'after' | 'inside') => void
   onDragLeave: () => void
   onDrop: (sourceId: EntityId, targetId: EntityId, pos: 'before' | 'after' | 'inside') => void
@@ -869,9 +887,8 @@ function LayerRow({
           e.dataTransfer.setData('text/plain', layer.id)
         }
         onDragStart(layer.id)
-      }}
-      onDragEnd={() => {
-        onDragEnd()
+      onDragEnd={(e) => {
+        onDragEnd(e)
       }}
       onDragEnter={(e) => {
         const dragged = draggedId

--- a/packages/koharu/components/editor/Inspector.tsx
+++ b/packages/koharu/components/editor/Inspector.tsx
@@ -73,6 +73,19 @@ import {
 } from '@koharu/ui/components/select'
 import { Slider } from '@koharu/ui/components/slider'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@koharu/ui/components/tooltip'
+import {
+  DndContext,
+  useDraggable,
+  useDroppable,
+  DragEndEvent,
+  DragMoveEvent,
+  DragStartEvent,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  DragOverlay,
+  pointerWithin,
+} from '@dnd-kit/core'
 
 const defaultFont: FontFamily = {
   name: 'CCWildWords',
@@ -475,48 +488,6 @@ function normalizeFontName(value: string): string {
   return value.normalize('NFKC').trim().replace(/\s+/g, ' ').toLowerCase()
 }
 
-function isDescendant(layers: Layer[], parentId: EntityId, childId: EntityId): boolean {
-  const layerMap = new Map<EntityId, Layer>()
-  for (let i = 0; i < layers.length; i++) {
-    const l = layers[i]
-    layerMap.set(l.id, l)
-  }
-
-  let current = layerMap.get(childId)
-  while (current && current.parent) {
-    if (current.parent === parentId) return true
-    current = layerMap.get(current.parent)
-  }
-  return false
-}
-
-function isValidDrop(
-  layers: Layer[],
-  draggedId: EntityId,
-  targetId: EntityId,
-  pos: 'before' | 'after' | 'inside',
-  pageId: EntityId,
-): boolean {
-  if (draggedId === targetId || isDescendant(layers, draggedId, targetId)) return false
-
-  const draggedLayer = layers.find((l) => l.id === draggedId)
-  const targetLayer = layers.find((l) => l.id === targetId)
-  if (!draggedLayer || !targetLayer || isLockedLayer(targetLayer) || isLockedLayer(draggedLayer))
-    return false
-
-  const parent = pos === 'inside' ? targetId : (targetLayer.parent ?? pageId)
-  const parentLayer = layers.find((l) => l.id === parent)
-  const isParentTextGroup = parentLayer && isGroupLayer(parentLayer) && parentLayer.role === 'text'
-
-  const isDraggedText = isTextLayer(draggedLayer)
-  const hasTextGroup = layers.some((l) => isGroupLayer(l) && l.role === 'text')
-
-  if (isDraggedText && hasTextGroup && !isParentTextGroup) return false
-  if (!isDraggedText && isParentTextGroup) return false
-
-  return true
-}
-
 function displayedLayers(layers: Layer[], page: EntityId) {
   const indexes = new Map(layers.map((layer, index) => [layer.id, index]))
   const rows: { layer: Layer; index: number; depth: number }[] = []
@@ -532,6 +503,49 @@ function displayedLayers(layers: Layer[], page: EntityId) {
   return rows
 }
 
+export function isDescendant(layerMap: Map<EntityId, Layer>, parentId: EntityId, childId: EntityId): boolean {
+  let current = layerMap.get(childId)
+  while (current && current.parent) {
+    if (current.parent === parentId) return true
+    current = layerMap.get(current.parent)
+  }
+  return false
+}
+
+export function isValidDrop(
+  layerMap: Map<EntityId, Layer>,
+  draggedId: EntityId,
+  targetId: EntityId,
+  pos: 'before' | 'after' | 'inside',
+  pageId: EntityId,
+): boolean {
+  if (draggedId === targetId || isDescendant(layerMap, draggedId, targetId)) return false
+
+  const draggedLayer = layerMap.get(draggedId)
+  const targetLayer = layerMap.get(targetId)
+  if (!draggedLayer || !targetLayer || isLockedLayer(targetLayer) || isLockedLayer(draggedLayer))
+    return false
+
+  const parent = pos === 'inside' ? targetId : (targetLayer.parent ?? pageId)
+  const parentLayer = layerMap.get(parent)
+  const isParentTextGroup = parentLayer && isGroupLayer(parentLayer) && parentLayer.role === 'text'
+
+  const isDraggedText = isTextLayer(draggedLayer)
+  
+  let hasTextGroup = false
+  for (const l of layerMap.values()) {
+    if (isGroupLayer(l) && l.role === 'text') {
+      hasTextGroup = true
+      break
+    }
+  }
+
+  if (isDraggedText && hasTextGroup && !isParentTextGroup) return false
+  if (!isDraggedText && isParentTextGroup) return false
+
+  return true
+}
+
 function LayersInspector() {
   const { t } = useTranslation()
   const page = usePage().data
@@ -545,116 +559,108 @@ function LayersInspector() {
   const [draggedId, setDraggedId] = useState<EntityId | null>(null)
   const [dragOverId, setDragOverId] = useState<EntityId | null>(null)
   const [dropPos, setDropPos] = useState<'before' | 'after' | 'inside' | null>(null)
-  const containerRef = useRef<HTMLDivElement>(null)
-  const lastDragOverRef = useRef<{ id: EntityId; pos: 'before' | 'after' | 'inside' } | null>(null)
-  const scrollIntervalRef = useRef<number | null>(null)
-  const lastClientYRef = useRef<number | null>(null)
+
+  const pointerCoordinatesRef = useRef<{ x: number; y: number } | null>(null)
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: {
+        distance: 8,
+      },
+    })
+  )
 
   useEffect(() => {
     setExpandedLayer(selected.length === 1 ? (selected[0] ?? null) : null)
   }, [selected])
 
+  useEffect(() => {
+    const handlePointerMove = (e: PointerEvent) => {
+      pointerCoordinatesRef.current = { x: e.clientX, y: e.clientY }
+    }
+    window.addEventListener('pointermove', handlePointerMove)
+    return () => window.removeEventListener('pointermove', handlePointerMove)
+  }, [])
+
   const layers = useMemo(() => (page ? displayedLayers(page.layers, page.id) : []), [page])
+  const layerMap = useMemo(() => {
+    const map = new Map<EntityId, Layer>()
+    if (page) {
+      for (const layer of page.layers) {
+        map.set(layer.id, layer)
+      }
+    }
+    return map
+  }, [page])
 
   if (!page) return <EmptyInspector>{t('inspector.selectPage')}</EmptyInspector>
 
-  const move = (layer: Layer, displayDelta: number) => {
-    if (movingLayer !== null || isLockedLayer(layer)) return
-    const parent = layer.parent ?? page.id
-    const storedSiblings = page.layers.filter(
-      (candidate) => (candidate.parent ?? page.id) === parent,
-    )
-    const parentLayer = page.layers.find((candidate) => candidate.id === parent)
-    const shownSiblings =
-      parentLayer && isGroupLayer(parentLayer) && parentLayer.role === 'text'
-        ? storedSiblings
-        : [...storedSiblings].reverse()
-    const shownSource = shownSiblings.findIndex((candidate) => candidate.id === layer.id)
-    const shownTarget = shownSource + displayDelta
-    const targetLayer = shownSiblings[shownTarget]
-    if (shownSource < 0 || !targetLayer) return
-    const target = storedSiblings.findIndex((candidate) => candidate.id === targetLayer.id)
-
-    setMovingLayer(layer.id)
-    void call(commands.moveLayer, layer.id, parent, target).then(
-      (next) => {
-        queryClient.setQueryData(pageKey, next)
-        setMovingLayer(null)
-        void refresh(projectKey, pageKey)
-      },
-      () => setMovingLayer(null),
-    )
+  const handleDragStart = (event: DragStartEvent) => {
+    setDraggedId(event.active.id as EntityId)
   }
 
-  const deleteLayer = (layer: EntityId) =>
-    void call(commands.deleteLayers, [layer])
-      .then(() => {
-        if (selected.includes(layer)) {
-          selectLayers(selected.filter((selectedLayer) => selectedLayer !== layer))
-        }
-        setExpandedLayer((current) => (current === layer ? null : current))
-        return refresh(projectKey, pageKey)
-      })
-      .catch(() => undefined)
-
-  const selectLayer = (layer: EntityId) => {
-    if (selected.length === 1 && selected[0] === layer) {
-      setExpandedLayer((current) => (current === layer ? null : layer))
-      return
-    }
-    selectLayers([layer])
-    setExpandedLayer(layer)
-  }
-
-  const handleDragStart = (id: EntityId) => {
-    setDraggedId(id)
-  }
-
-  const handleDragEnd = (e: React.DragEvent) => {
-    if (scrollIntervalRef.current !== null) {
-      clearInterval(scrollIntervalRef.current)
-      scrollIntervalRef.current = null
-    }
-    lastClientYRef.current = null
-
-    const isCanceled = e.clientX === 0 && e.clientY === 0
-    let isInside = false
-    if (!isCanceled && containerRef.current) {
-      const rect = containerRef.current.getBoundingClientRect()
-      isInside =
-        e.clientX >= rect.left &&
-        e.clientX <= rect.right &&
-        e.clientY >= rect.top &&
-        e.clientY <= rect.bottom
-    }
-
-    if (draggedId && lastDragOverRef.current && isInside && movingLayer === null) {
-      handleDrop(draggedId, lastDragOverRef.current.id, lastDragOverRef.current.pos)
-    }
-
-    setTimeout(() => {
-      setDraggedId(null)
+  const handleDragMove = (event: DragMoveEvent) => {
+    const { active, over } = event
+    const pointerCoordinates = pointerCoordinatesRef.current
+    if (!over || !pointerCoordinates) {
       setDragOverId(null)
       setDropPos(null)
-      lastDragOverRef.current = null
-    }, 0)
-  }
+      return
+    }
 
-  const handleDragOver = (id: EntityId, pos: 'before' | 'after' | 'inside') => {
-    lastDragOverRef.current = { id, pos }
-    setDragOverId((prev) => (prev === id ? prev : id))
+    const overId = over.id as EntityId
+    if (active.id === overId) {
+      setDragOverId(null)
+      setDropPos(null)
+      return
+    }
+
+    const overElement = document.getElementById(`layer-row-${overId}`)
+    if (!overElement) return
+
+    const overLayer = layerMap.get(overId)
+    if (!overLayer) return
+
+    const rect = overElement.getBoundingClientRect()
+    const hoverY = pointerCoordinates.y - rect.top
+    const height = rect.height
+    const isGroup = isGroupLayer(overLayer)
+
+    let pos: 'before' | 'after' | 'inside'
+    if (isGroup && hoverY > height * 0.25 && hoverY < height * 0.75) {
+      pos = 'inside'
+    } else if (hoverY < height / 2) {
+      pos = 'before'
+    } else {
+      pos = 'after'
+    }
+
+    if (!isValidDrop(layerMap, active.id as EntityId, overId, pos, page.id)) {
+      setDragOverId(null)
+      setDropPos(null)
+      return
+    }
+
+    setDragOverId((prev) => (prev === overId ? prev : overId))
     setDropPos((prev) => (prev === pos ? prev : pos))
   }
 
-  const handleInvalidDragOver = () => {
-    lastDragOverRef.current = null
-    setDragOverId((prev) => (prev === null ? prev : null))
-    setDropPos((prev) => (prev === null ? prev : null))
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active } = event
+
+    if (active && dragOverId && dropPos && movingLayer === null) {
+      handleDrop(active.id as EntityId, dragOverId, dropPos)
+    }
+
+    setDraggedId(null)
+    setDragOverId(null)
+    setDropPos(null)
   }
 
-  const handleDragLeave = () => {
-    setDragOverId((prev) => (prev === null ? prev : null))
-    setDropPos((prev) => (prev === null ? prev : null))
+  const handleDragCancel = () => {
+    setDraggedId(null)
+    setDragOverId(null)
+    setDropPos(null)
   }
 
   const handleDrop = (
@@ -662,10 +668,10 @@ function LayersInspector() {
     targetId: EntityId,
     calculatedDropPos: 'before' | 'after' | 'inside',
   ) => {
-    if (!isValidDrop(page.layers, sourceId, targetId, calculatedDropPos, page.id)) return
+    if (!isValidDrop(layerMap, sourceId, targetId, calculatedDropPos, page.id)) return
 
-    const sourceLayer = page.layers.find((l) => l.id === sourceId)
-    const targetLayer = page.layers.find((l) => l.id === targetId)
+    const sourceLayer = layerMap.get(sourceId)
+    const targetLayer = layerMap.get(targetId)
     if (!sourceLayer || !targetLayer) return
 
     let parent = targetLayer.parent ?? page.id
@@ -677,7 +683,7 @@ function LayersInspector() {
       (c) => (c.parent ?? page.id) === parent && c.id !== sourceId,
     )
 
-    const parentLayer = page.layers.find((candidate) => candidate.id === parent)
+    const parentLayer = layerMap.get(parent)
     const isTextGroup = parentLayer && isGroupLayer(parentLayer) && parentLayer.role === 'text'
 
     let targetStoredIndex = 0
@@ -705,7 +711,7 @@ function LayersInspector() {
     void call(commands.moveLayer, sourceId, parent, targetStoredIndex)
       .then((next) => {
         queryClient.setQueryData(pageKey, next)
-        void refresh(projectKey, pageKey)
+        void refresh(projectKey)
       })
       .finally(() => {
         setMovingLayer(null)
@@ -715,8 +721,56 @@ function LayersInspector() {
       })
   }
 
+  const move = (layer: Layer, displayDelta: number) => {
+    if (movingLayer !== null || isLockedLayer(layer)) return
+    const parent = layer.parent ?? page.id
+    const storedSiblings = page.layers.filter(
+      (candidate) => !isLockedLayer(candidate) && (candidate.parent ?? page.id) === parent,
+    )
+    const parentLayer = layerMap.get(parent)
+    const shownSiblings =
+      parentLayer && isGroupLayer(parentLayer) && parentLayer.role === 'text'
+        ? storedSiblings
+        : [...storedSiblings].reverse()
+    const shownSource = shownSiblings.findIndex((candidate) => candidate.id === layer.id)
+    const shownTarget = shownSource + displayDelta
+    const targetLayer = shownSiblings[shownTarget]
+    if (shownSource < 0 || !targetLayer) return
+    const target = storedSiblings.findIndex((candidate) => candidate.id === targetLayer.id)
+
+    setMovingLayer(layer.id)
+    void call(commands.moveLayer, layer.id, parent, target).then(
+      (next) => {
+        queryClient.setQueryData(pageKey, next)
+        setMovingLayer(null)
+        void refresh(projectKey)
+      },
+      () => setMovingLayer(null),
+    )
+  }
+
+  const deleteLayer = (layer: EntityId) =>
+    void call(commands.deleteLayers, [layer])
+      .then(() => {
+        if (selected.includes(layer)) {
+          selectLayers(selected.filter((selectedLayer) => selectedLayer !== layer))
+        }
+        setExpandedLayer((current) => (current === layer ? null : current))
+        return refresh(projectKey, pageKey)
+      })
+      .catch(() => undefined)
+
+  const selectLayer = (layer: EntityId) => {
+    if (selected.length === 1 && selected[0] === layer) {
+      setExpandedLayer((current) => (current === layer ? null : layer))
+      return
+    }
+    selectLayers([layer])
+    setExpandedLayer(layer)
+  }
+
   return (
-    <div ref={containerRef} className='flex min-h-0 flex-1 flex-col'>
+    <div className='flex min-h-0 flex-1 flex-col'>
       <header className='flex h-8 shrink-0 items-center gap-1.5 border-b border-border/80 px-2'>
         <Layers3 className='size-3 text-primary' />
         <h2 className='text-[10px] font-semibold'>{t('layers.title')}</h2>
@@ -725,99 +779,86 @@ function LayersInspector() {
         </span>
       </header>
 
-      <ScrollArea
-        className='min-h-0 flex-1'
-        onDragOver={(e) => {
-          if (draggedId) {
-            if (!e.defaultPrevented) {
-              handleInvalidDragOver()
-            }
-            e.preventDefault()
-            if (e.dataTransfer) {
-              e.dataTransfer.dropEffect = 'move'
-            }
-          }
-          lastClientYRef.current = e.clientY
-          const container = e.currentTarget
-          if (scrollIntervalRef.current === null && draggedId) {
-            scrollIntervalRef.current = window.setInterval(() => {
-              const viewport = container.querySelector('[data-slot="scroll-area-viewport"]')
-              if (!viewport || lastClientYRef.current === null) return
-              const rect = viewport.getBoundingClientRect()
-              const relativeY = lastClientYRef.current - rect.top
-              const threshold = 50
-              let scrollDelta = 0
-              if (relativeY < threshold) {
-                const ratio = (threshold - relativeY) / threshold
-                scrollDelta = -Math.max(1, Math.floor(ratio * 15))
-              } else if (relativeY > rect.height - threshold) {
-                const ratio = (relativeY - (rect.height - threshold)) / threshold
-                scrollDelta = Math.max(1, Math.floor(ratio * 15))
-              }
-
-              if (scrollDelta !== 0) {
-                viewport.scrollTop += scrollDelta
-              } else if (scrollIntervalRef.current !== null) {
-                clearInterval(scrollIntervalRef.current)
-                scrollIntervalRef.current = null
-              }
-            }, 16)
-          }
-        }}
+      <DndContext
+        sensors={sensors}
+        collisionDetection={pointerWithin}
+        onDragStart={handleDragStart}
+        onDragMove={handleDragMove}
+        onDragEnd={handleDragEnd}
+        onDragCancel={handleDragCancel}
       >
-        <div className='py-0.5'>
-          {layers.map(({ layer, index, depth }) => {
-            const locked = isLockedLayer(layer)
-            const storedSiblings = page.layers.filter(
-              (candidate) => (candidate.parent ?? page.id) === (layer.parent ?? page.id),
-            )
-            const parentLayer = page.layers.find((candidate) => candidate.id === layer.parent)
-            const siblings =
-              parentLayer && isGroupLayer(parentLayer) && parentLayer.role === 'text'
-                ? storedSiblings
-                : [...storedSiblings].reverse()
-            const position = siblings.findIndex((candidate) => candidate.id === layer.id)
+        <ScrollArea className='min-h-0 flex-1'>
+          <div className='py-0.5'>
+            {layers.map(({ layer, index, depth }) => {
+              const locked = isLockedLayer(layer)
+              const storedSiblings = page.layers.filter(
+                (candidate) =>
+                  !isLockedLayer(candidate) &&
+                  (candidate.parent ?? page.id) === (layer.parent ?? page.id),
+              )
+              const parentLayer = layer.parent ? layerMap.get(layer.parent) : undefined
+              const siblings =
+                parentLayer && isGroupLayer(parentLayer) && parentLayer.role === 'text'
+                  ? storedSiblings
+                  : [...storedSiblings].reverse()
+              const position = siblings.findIndex((candidate) => candidate.id === layer.id)
+              return (
+                <LayerRow
+                  key={`${layer.type}:${layer.id}`}
+                  layer={layer}
+                  index={index}
+                  depth={depth}
+                  selected={selected.includes(layer.id)}
+                  expanded={!locked && expandedLayer === layer.id}
+                  locked={locked}
+                  onSelect={() => selectLayer(layer.id)}
+                  onToggle={() =>
+                    void call(commands.setVisibility, [layer.id], !layer.visibility.visible, null)
+                      .then(() => refresh(projectKey, pageKey))
+                      .catch(() => undefined)
+                  }
+                  onMove={(delta) => move(layer, delta)}
+                  canMoveUp={!locked && position > 0}
+                  canMoveDown={!locked && position >= 0 && position < siblings.length - 1}
+                  reordering={movingLayer !== null}
+                  onDelete={isGroupLayer(layer) ? undefined : () => deleteLayer(layer.id)}
+                  isDragOver={dragOverId === layer.id}
+                  activeDropPos={dragOverId === layer.id ? dropPos : null}
+                />
+              )
+            })}
+            {layers.length === 0 && <EmptyInspector>{t('layers.empty')}</EmptyInspector>}
+          </div>
+        </ScrollArea>
+        <DragOverlay adjustScale={false} dropAnimation={null}>
+          {draggedId ? (() => {
+            const dragLayerIndex = layers.findIndex(l => l.layer.id === draggedId)
+            const dragLayerInfo = layers[dragLayerIndex]
+            if (!dragLayerInfo) return null
             return (
-              <LayerRow
-                key={`${layer.type}:${layer.id}`}
-                layer={layer}
-                index={index}
-                depth={depth}
-                selected={selected.includes(layer.id)}
-                expanded={!locked && expandedLayer === layer.id}
-                locked={locked}
-                onSelect={() => selectLayer(layer.id)}
-                onToggle={() =>
-                  void call(commands.setVisibility, [layer.id], !layer.visibility.visible, null)
-                    .then(() => refresh(projectKey, pageKey))
-                    .catch(() => undefined)
-                }
-                onMove={(delta) => move(layer, delta)}
-                canMoveUp={!locked && position > 0 && !isLockedLayer(siblings[position - 1])}
-                canMoveDown={
-                  !locked &&
-                  position >= 0 &&
-                  position < siblings.length - 1 &&
-                  !isLockedLayer(siblings[position + 1])
-                }
-                reordering={movingLayer !== null}
-                onDelete={isGroupLayer(layer) ? undefined : () => deleteLayer(layer.id)}
-                draggedId={draggedId}
-                dragOverId={dragOverId}
-                dropPos={dropPos}
-                onDragStart={handleDragStart}
-                onDragEnd={handleDragEnd}
-                onDragOver={handleDragOver}
-                onDragLeave={handleDragLeave}
-                onDrop={handleDrop}
-                layersList={page.layers}
-                pageId={page.id}
-              />
+              <div className='opacity-80 pointer-events-none'>
+                <LayerRow
+                  layer={dragLayerInfo.layer}
+                  index={dragLayerInfo.index}
+                  depth={dragLayerInfo.depth}
+                  selected={selected.includes(draggedId)}
+                  expanded={expandedLayer === draggedId}
+                  locked={isLockedLayer(dragLayerInfo.layer)}
+                  onSelect={() => {}}
+                  onToggle={() => {}}
+                  onMove={() => {}}
+                  canMoveUp={false}
+                  canMoveDown={false}
+                  reordering={false}
+                  isDragOver={false}
+                  activeDropPos={null}
+                  isOverlay={true}
+                />
+              </div>
             )
-          })}
-          {layers.length === 0 && <EmptyInspector>{t('layers.empty')}</EmptyInspector>}
-        </div>
-      </ScrollArea>
+          })() : null}
+        </DragOverlay>
+      </DndContext>
     </div>
   )
 }
@@ -836,16 +877,9 @@ function LayerRow({
   canMoveDown,
   reordering,
   onDelete,
-  draggedId,
-  dragOverId,
-  dropPos,
-  onDragStart,
-  onDragEnd,
-  onDragOver,
-  onDragLeave,
-  onDrop,
-  layersList,
-  pageId,
+  isDragOver,
+  activeDropPos,
+  isOverlay = false,
 }: {
   layer: Layer
   index: number
@@ -860,135 +894,54 @@ function LayerRow({
   canMoveDown: boolean
   reordering: boolean
   onDelete?: () => void
-  draggedId: EntityId | null
-  dragOverId: EntityId | null
-  dropPos: 'before' | 'after' | 'inside' | null
-  onDragStart: (id: EntityId) => void
-  onDragEnd: (e: React.DragEvent) => void
-  onDragOver: (id: EntityId, pos: 'before' | 'after' | 'inside') => void
-  onDragLeave: () => void
-  onDrop: (sourceId: EntityId, targetId: EntityId, pos: 'before' | 'after' | 'inside') => void
-  layersList: Layer[]
-  pageId: EntityId
+  isDragOver: boolean
+  activeDropPos: 'before' | 'after' | 'inside' | null
+  isOverlay?: boolean
 }) {
   const { t } = useTranslation()
   const name = localizedLayerName(layer, index, t)
   const detail = localizedLayerKind(layer, t)
   const Icon = layerIcon(layer)
 
+  const { attributes, listeners, setNodeRef: setDraggableRef, isDragging } = useDraggable({
+    id: layer.id,
+    disabled: locked || reordering || isOverlay,
+  })
+
+  const { setNodeRef: setDroppableRef } = useDroppable({
+    id: layer.id,
+    disabled: locked || isOverlay,
+  })
+
+  const setCombinedRef = (node: HTMLDivElement | null) => {
+    setDraggableRef(node)
+    setDroppableRef(node)
+  }
+
   return (
     <div
+      id={`layer-row-${layer.id}`}
+      ref={setCombinedRef}
       className='group min-w-0 px-1 py-px'
-      style={{ paddingLeft: `${depth * 10 + 4}px` }}
-      draggable={!locked && !reordering}
-      onDragStart={(e) => {
-        if (e.dataTransfer) {
-          e.dataTransfer.effectAllowed = 'move'
-          e.dataTransfer.setData('text/plain', layer.id)
-        }
-        onDragStart(layer.id)
+      style={{
+        paddingLeft: `${depth * 10 + 4}px`,
+        opacity: isDragging ? 0.3 : 1,
       }}
-      onDragEnd={(e) => {
-        onDragEnd(e)
-      }}
-      onDragEnter={(e) => {
-        const dragged = draggedId
-        if (!dragged) return
-
-        const rect = e.currentTarget.getBoundingClientRect()
-        const hoverY = e.clientY - rect.top
-        const isGroup = isGroupLayer(layer)
-
-        let pos: 'before' | 'after' | 'inside'
-        if (isGroup && hoverY > rect.height * 0.25 && hoverY < rect.height * 0.75) {
-          pos = 'inside'
-        } else if (hoverY < rect.height / 2) {
-          pos = 'before'
-        } else {
-          pos = 'after'
-        }
-
-        if (!isValidDrop(layersList, dragged, layer.id, pos, pageId)) return
-
-        if (e.dataTransfer) {
-          e.dataTransfer.dropEffect = 'move'
-        }
-        e.preventDefault()
-      }}
-      onDragOver={(e) => {
-        const dragged = draggedId
-        if (!dragged) return
-
-        const rect = e.currentTarget.getBoundingClientRect()
-        const hoverY = e.clientY - rect.top
-        const isGroup = isGroupLayer(layer)
-
-        let pos: 'before' | 'after' | 'inside'
-        if (isGroup && hoverY > rect.height * 0.25 && hoverY < rect.height * 0.75) {
-          pos = 'inside'
-        } else if (hoverY < rect.height / 2) {
-          pos = 'before'
-        } else {
-          pos = 'after'
-        }
-
-        if (!isValidDrop(layersList, dragged, layer.id, pos, pageId)) return
-
-        if (e.dataTransfer) {
-          e.dataTransfer.dropEffect = 'move'
-        }
-        e.preventDefault()
-        onDragOver(layer.id, pos)
-      }}
-      onDragLeave={(e) => {
-        const rect = e.currentTarget.getBoundingClientRect()
-        if (
-          e.clientX < rect.left ||
-          e.clientX >= rect.right ||
-          e.clientY < rect.top ||
-          e.clientY >= rect.bottom
-        ) {
-          onDragLeave()
-        }
-      }}
-      onDrop={(e) => {
-        e.preventDefault()
-        const dragged = draggedId
-        if (dragged) {
-          const rect = e.currentTarget.getBoundingClientRect()
-          const hoverY = e.clientY - rect.top
-          const isGroup = isGroupLayer(layer)
-
-          let pos: 'before' | 'after' | 'inside'
-          if (isGroup && hoverY > rect.height * 0.25 && hoverY < rect.height * 0.75) {
-            pos = 'inside'
-          } else if (hoverY < rect.height / 2) {
-            pos = 'before'
-          } else {
-            pos = 'after'
-          }
-
-          if (isValidDrop(layersList, dragged, layer.id, pos, pageId)) {
-            onDrop(dragged, layer.id, pos)
-          }
-        }
-      }}
+      {...listeners}
+      {...attributes}
     >
       <div
         data-selected={selected}
         data-expanded={expanded}
         className={`min-w-0 overflow-hidden rounded-lg transition-colors duration-150 data-[selected=true]:bg-accent motion-reduce:transition-none ${
-          dragOverId === layer.id && dropPos
-            ? dropPos === 'before'
+          isDragOver && activeDropPos
+            ? activeDropPos === 'before'
               ? 'rounded-t-none shadow-[inset_0_2px_0_0_var(--primary)]'
-              : dropPos === 'after'
+              : activeDropPos === 'after'
                 ? 'rounded-b-none shadow-[inset_0_-2px_0_0_var(--primary)]'
                 : 'bg-primary/10 ring-1 ring-primary'
             : ''
         }`}
-        style={{
-          pointerEvents: draggedId !== null ? 'none' : 'auto',
-        }}
       >
         <div className='relative flex min-w-0 items-center gap-0.5'>
           <button

--- a/packages/koharu/components/editor/Inspector.tsx
+++ b/packages/koharu/components/editor/Inspector.tsx
@@ -541,6 +541,8 @@ function LayersInspector() {
   const [dragOverId, setDragOverId] = useState<EntityId | null>(null)
   const [dropPos, setDropPos] = useState<'before' | 'after' | 'inside' | null>(null)
   const lastDragOverRef = useRef<{ id: EntityId; pos: 'before' | 'after' | 'inside' } | null>(null)
+  const scrollIntervalRef = useRef<number | null>(null)
+  const lastClientYRef = useRef<number | null>(null)
 
   useEffect(() => {
     setExpandedLayer(selected.length === 1 ? (selected[0] ?? null) : null)
@@ -603,6 +605,12 @@ function LayersInspector() {
   }
 
   const handleDragEnd = () => {
+    if (scrollIntervalRef.current !== null) {
+      clearInterval(scrollIntervalRef.current)
+      scrollIntervalRef.current = null
+    }
+    lastClientYRef.current = null
+
     if (draggedId && lastDragOverRef.current && movingLayer === null) {
       handleDrop(draggedId, lastDragOverRef.current.id, lastDragOverRef.current.pos)
     }
@@ -615,14 +623,20 @@ function LayersInspector() {
   }
 
   const handleDragOver = (id: EntityId, pos: 'before' | 'after' | 'inside') => {
-    setDragOverId(id)
-    setDropPos(pos)
     lastDragOverRef.current = { id, pos }
+    setDragOverId((prev) => (prev === id ? prev : id))
+    setDropPos((prev) => (prev === pos ? prev : pos))
+  }
+
+  const handleInvalidDragOver = () => {
+    lastDragOverRef.current = null
+    setDragOverId((prev) => (prev === null ? prev : null))
+    setDropPos((prev) => (prev === null ? prev : null))
   }
 
   const handleDragLeave = () => {
-    setDragOverId(null)
-    setDropPos(null)
+    setDragOverId((prev) => (prev === null ? prev : null))
+    setDropPos((prev) => (prev === null ? prev : null))
   }
 
   const handleDrop = (
@@ -693,7 +707,46 @@ function LayersInspector() {
         </span>
       </header>
 
-      <ScrollArea className='min-h-0 flex-1'>
+      <ScrollArea
+        className='min-h-0 flex-1'
+        onDragOver={(e) => {
+          if (draggedId) {
+            if (!e.defaultPrevented) {
+              handleInvalidDragOver()
+            }
+            e.preventDefault()
+            if (e.dataTransfer) {
+              e.dataTransfer.dropEffect = 'move'
+            }
+          }
+          lastClientYRef.current = e.clientY
+          const container = e.currentTarget
+          if (scrollIntervalRef.current === null && draggedId) {
+            scrollIntervalRef.current = window.setInterval(() => {
+              const viewport = container.querySelector('[data-slot="scroll-area-viewport"]')
+              if (!viewport || lastClientYRef.current === null) return
+              const rect = viewport.getBoundingClientRect()
+              const relativeY = lastClientYRef.current - rect.top
+              const threshold = 50
+              let scrollDelta = 0
+              if (relativeY < threshold) {
+                const ratio = (threshold - relativeY) / threshold
+                scrollDelta = -Math.max(1, Math.floor(ratio * 15))
+              } else if (relativeY > rect.height - threshold) {
+                const ratio = (relativeY - (rect.height - threshold)) / threshold
+                scrollDelta = Math.max(1, Math.floor(ratio * 15))
+              }
+
+              if (scrollDelta !== 0) {
+                viewport.scrollTop += scrollDelta
+              } else if (scrollIntervalRef.current !== null) {
+                clearInterval(scrollIntervalRef.current)
+                scrollIntervalRef.current = null
+              }
+            }, 16)
+          }
+        }}
+      >
         <div className='py-0.5'>
           {layers.map(({ layer, index, depth }) => {
             const locked = isLockedLayer(layer)

--- a/packages/koharu/package.json
+++ b/packages/koharu/package.json
@@ -14,8 +14,7 @@
     "test:ui": "vitest --ui"
   },
   "dependencies": {
-    "@dnd-kit/core": "^6.3.1",
-    "@dnd-kit/modifiers": "^9.0.0",
+    "@dnd-kit/react": "^0.5.0",
     "@koharu/bridge": "workspace:*",
     "@koharu/ui": "workspace:*",
     "@tanstack/react-query": "^5.101.4",

--- a/packages/koharu/package.json
+++ b/packages/koharu/package.json
@@ -14,6 +14,8 @@
     "test:ui": "vitest --ui"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/modifiers": "^9.0.0",
     "@koharu/bridge": "workspace:*",
     "@koharu/ui": "workspace:*",
     "@tanstack/react-query": "^5.101.4",

--- a/packages/koharu/tests/components/editor-components.test.tsx
+++ b/packages/koharu/tests/components/editor-components.test.tsx
@@ -9,7 +9,7 @@ import { TitleBar } from '@/components/app/TitleBar'
 import { WindowControls } from '@/components/app/WindowChrome'
 import { ActivityCenter } from '@/components/editor/ActivityCenter'
 import { CanvasCommandBar } from '@/components/editor/CanvasCommandBar'
-import { Inspector } from '@/components/editor/Inspector'
+import { Inspector, isDescendant, isValidDrop } from '@/components/editor/Inspector'
 import { PageRail } from '@/components/editor/PageRail'
 import { ResourceMonitor } from '@/components/editor/ResourceMonitor'
 import { StatusBar } from '@/components/editor/StatusBar'
@@ -800,46 +800,61 @@ describe('greenfield editor', () => {
 
     render(<Inspector />)
 
-    const button1 = screen.getByRole('button', { name: 'Edit Layer 1' })
-    const button2 = screen.getByRole('button', { name: 'Edit Layer 2' })
-    const row1 = button1.closest('.group')!
-    const row2 = button2.closest('.group')!
-
-    vi.spyOn(row2, 'getBoundingClientRect').mockReturnValue({
-      top: 100,
-      bottom: 140,
-      left: 0,
-      right: 200,
-      width: 200,
-      height: 40,
-      x: 0,
-      y: 100,
-      toJSON: () => {},
-    })
-
-    act(() => {
-      fireEvent.dragStart(row1)
-    })
-    act(() => {
-      const event = new MouseEvent('dragover', {
-        bubbles: true,
-        cancelable: true,
-        clientY: 110,
-      })
-      row2.dispatchEvent(event)
-    })
-    act(() => {
-      const event = new MouseEvent('drop', {
-        bubbles: true,
-        cancelable: true,
-        clientY: 110,
-      })
-      row2.dispatchEvent(event)
-    })
+    const moveDownButton = screen.getByRole('button', { name: 'Move Layer 2 down', hidden: true })
+    fireEvent.click(moveDownButton)
 
     await waitFor(() => {
-      expect(moveLayer).toHaveBeenCalledWith('element1', 'page', 1)
+      expect(moveLayer).toHaveBeenCalledWith('element2', 'page', 0)
     })
+  })
+
+  it('correctly validates layer hierarchy and drop targets', () => {
+    const parentGroup: Layer = {
+      type: 'group',
+      id: 'group1',
+      parent: 'page',
+      geometry: { points: [] },
+      visibility: { visible: true, opacity: 1 },
+      role: 'text',
+    }
+    const childText: Layer = {
+      ...textLayer,
+      id: 'childText',
+      parent: 'group1',
+    }
+    const grandChildText: Layer = {
+      ...textLayer,
+      id: 'grandChildText',
+      parent: 'childText',
+    }
+    const nonTextLayer: Layer = {
+      type: 'image',
+      id: 'image1',
+      parent: 'page',
+      geometry: { points: [] },
+      visibility: { visible: true, opacity: 1 },
+    }
+
+    const map = new Map<string, Layer>([
+      ['group1', parentGroup],
+      ['childText', childText],
+      ['grandChildText', grandChildText],
+      ['image1', nonTextLayer],
+    ])
+
+    // Descendant validation
+    expect(isDescendant(map, 'group1', 'grandChildText')).toBe(true)
+    expect(isDescendant(map, 'grandChildText', 'group1')).toBe(false)
+
+    // Cannot drop parent into its own descendant
+    expect(isValidDrop(map, 'group1', 'grandChildText', 'inside', 'page')).toBe(false)
+    expect(isValidDrop(map, 'group1', 'childText', 'after', 'page')).toBe(false)
+
+    // Cannot drop non-text layer into a text group
+    expect(isValidDrop(map, 'image1', 'group1', 'inside', 'page')).toBe(false)
+
+    // Can drop text layer into text group
+    expect(isValidDrop(map, 'childText', 'group1', 'inside', 'page')).toBe(true)
   })
 
   it('shows zoom before page size without a fit control', () => {

--- a/packages/koharu/tests/components/editor-components.test.tsx
+++ b/packages/koharu/tests/components/editor-components.test.tsx
@@ -772,6 +772,76 @@ describe('greenfield editor', () => {
     await waitFor(() => expect(reset).toHaveBeenCalledWith([{ layer: 'element', points: null }]))
   })
 
+  it('supports drag and drop reordering of layers', async () => {
+    installProject()
+    queryClient.setQueryData(pageKey, (page: { layers: Layer[] }) => ({
+      ...page,
+      layers: [
+        {
+          ...textLayer,
+          id: 'element1',
+          content: { ...textLayer.content, translation: { text: 'Layer 1', language: null } },
+        },
+        {
+          ...textLayer,
+          id: 'element2',
+          content: { ...textLayer.content, translation: { text: 'Layer 2', language: null } },
+        },
+      ],
+    }))
+
+    const moveLayer = vi.spyOn(commands, 'moveLayer').mockResolvedValue({
+      id: 'page',
+      label: 'Page 1',
+      size: { width: 1000, height: 1500 },
+      layers: [],
+      regions: [],
+    })
+
+    render(<Inspector />)
+
+    const button1 = screen.getByRole('button', { name: 'Edit Layer 1' })
+    const button2 = screen.getByRole('button', { name: 'Edit Layer 2' })
+    const row1 = button1.closest('.group')!
+    const row2 = button2.closest('.group')!
+
+    vi.spyOn(row2, 'getBoundingClientRect').mockReturnValue({
+      top: 100,
+      bottom: 140,
+      left: 0,
+      right: 200,
+      width: 200,
+      height: 40,
+      x: 0,
+      y: 100,
+      toJSON: () => {},
+    })
+
+    act(() => {
+      fireEvent.dragStart(row1)
+    })
+    act(() => {
+      const event = new MouseEvent('dragover', {
+        bubbles: true,
+        cancelable: true,
+        clientY: 110,
+      })
+      row2.dispatchEvent(event)
+    })
+    act(() => {
+      const event = new MouseEvent('drop', {
+        bubbles: true,
+        cancelable: true,
+        clientY: 110,
+      })
+      row2.dispatchEvent(event)
+    })
+
+    await waitFor(() => {
+      expect(moveLayer).toHaveBeenCalledWith('element1', 'page', 1)
+    })
+  })
+
   it('shows zoom before page size without a fit control', () => {
     installProject()
     useKoharuStore.setState({ camera: { zoom: 1.25, translation: [0, 0], fitted: false } })

--- a/packages/koharu/tests/components/editor-components.test.tsx
+++ b/packages/koharu/tests/components/editor-components.test.tsx
@@ -813,7 +813,7 @@ describe('greenfield editor', () => {
       type: 'group',
       id: 'group1',
       parent: 'page',
-      geometry: { points: [] },
+      name: 'Group 1',
       visibility: { visible: true, opacity: 1 },
       role: 'text',
     }
@@ -833,6 +833,7 @@ describe('greenfield editor', () => {
       parent: 'page',
       geometry: { points: [] },
       visibility: { visible: true, opacity: 1 },
+      image: 'image1.png',
     }
 
     const map = new Map<string, Layer>([


### PR DESCRIPTION
## Summary:
This PR adds drag-and-drop reordering for layers inside `LayerInspector` to allows users to freely reorder layers quicker than the current method of clicking the arrow buttons when hovering over the layer in the selection.

## Changes:
- Added various states and refs in `LayerInspector` to track hover position and scroll boundaries
- `ScrollArea` Listener for auto-scroll logic when attempting to drag a layer to a location outside of view
