### PR TITLE
fix(runtime): normalize Metal device name as MTL0

### DIFF
--- a/crates/koharu-ml/src/backend.rs
+++ b/crates/koharu-ml/src/backend.rs
@@ -45,19 +45,6 @@ impl TryIntoDevice<koharu_torch::Device> for Device {
     }
 }
 
-/// ggml/stable-diffusion.cpp device name for `ContextParams.backend`.
-///
-/// Runtime accelerators are named `{Backend}{index}` (`Metal0`, `CUDA0`). ggml
-/// registers Metal as `MTL{index}`; lowercasing `Metal0` produced `metal0`,
-/// which ggml does not register.
-pub(crate) fn ggml_backend_name(device: &Device) -> String {
-    match device.backend {
-        Backend::Cpu => "cpu".to_owned(),
-        Backend::Metal => format!("MTL{}", device.index),
-        Backend::Cuda | Backend::Rocm | Backend::Vulkan | Backend::Other(_) => device.name.clone(),
-    }
-}
-
 pub(crate) fn set_precision(var_store: &mut nn::VarStore) {
     let hardware = Hardware::discover();
     let device_supports_bfloat16 = hardware

--- a/crates/koharu-ml/src/backend.rs
+++ b/crates/koharu-ml/src/backend.rs
@@ -45,6 +45,19 @@ impl TryIntoDevice<koharu_torch::Device> for Device {
     }
 }
 
+/// ggml/stable-diffusion.cpp device name for `ContextParams.backend`.
+///
+/// Runtime accelerators are named `{Backend}{index}` (`Metal0`, `CUDA0`). ggml
+/// registers Metal as `MTL{index}`; lowercasing `Metal0` produced `metal0`,
+/// which ggml does not register.
+pub(crate) fn ggml_backend_name(device: &Device) -> String {
+    match device.backend {
+        Backend::Cpu => "cpu".to_owned(),
+        Backend::Metal => format!("MTL{}", device.index),
+        Backend::Cuda | Backend::Rocm | Backend::Vulkan | Backend::Other(_) => device.name.clone(),
+    }
+}
+
 pub(crate) fn set_precision(var_store: &mut nn::VarStore) {
     let hardware = Hardware::discover();
     let device_supports_bfloat16 = hardware
@@ -71,5 +84,25 @@ pub(crate) fn set_precision(var_store: &mut nn::VarStore) {
         var_store.bfloat16();
     } else {
         var_store.float();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ggml_backend_name;
+    use koharu_runtime::Device;
+
+    #[test]
+    fn metal_uses_ggml_mtl_device_name() {
+        assert_eq!(ggml_backend_name(&Device::metal(0)), "MTL0");
+        assert_eq!(ggml_backend_name(&Device::metal(1)), "MTL1");
+    }
+
+    #[test]
+    fn cpu_cuda_rocm_vulkan_keep_runtime_names() {
+        assert_eq!(ggml_backend_name(&Device::cpu()), "cpu");
+        assert_eq!(ggml_backend_name(&Device::cuda(0)), "CUDA0");
+        assert_eq!(ggml_backend_name(&Device::rocm(0)), "ROCm0");
+        assert_eq!(ggml_backend_name(&Device::vulkan(0)), "Vulkan0");
     }
 }

--- a/crates/koharu-ml/src/backend.rs
+++ b/crates/koharu-ml/src/backend.rs
@@ -86,23 +86,3 @@ pub(crate) fn set_precision(var_store: &mut nn::VarStore) {
         var_store.float();
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::ggml_backend_name;
-    use koharu_runtime::Device;
-
-    #[test]
-    fn metal_uses_ggml_mtl_device_name() {
-        assert_eq!(ggml_backend_name(&Device::metal(0)), "MTL0");
-        assert_eq!(ggml_backend_name(&Device::metal(1)), "MTL1");
-    }
-
-    #[test]
-    fn cpu_cuda_rocm_vulkan_keep_runtime_names() {
-        assert_eq!(ggml_backend_name(&Device::cpu()), "cpu");
-        assert_eq!(ggml_backend_name(&Device::cuda(0)), "CUDA0");
-        assert_eq!(ggml_backend_name(&Device::rocm(0)), "ROCm0");
-        assert_eq!(ggml_backend_name(&Device::vulkan(0)), "Vulkan0");
-    }
-}

--- a/crates/koharu-ml/src/flux2_klein/model.rs
+++ b/crates/koharu-ml/src/flux2_klein/model.rs
@@ -64,7 +64,7 @@ fn context_params(device: &crate::Device, paths: ModelPaths) -> ContextParams {
         diffusion_conv_direct: use_cuda,
         vae_conv_direct: use_cuda,
         vae_format: VaeFormat::Flux2,
-        backend: Some(crate::backend::ggml_backend_name(device)),
+        backend: Some(device.name.clone()),
         // The text encoder and denoiser run in separate phases. Cards with less
         // headroom keep source parameters in RAM; high-VRAM cards avoid repeated
         // staging by retaining both quantized models on the accelerator.

--- a/crates/koharu-ml/src/flux2_klein/model.rs
+++ b/crates/koharu-ml/src/flux2_klein/model.rs
@@ -64,11 +64,7 @@ fn context_params(device: &crate::Device, paths: ModelPaths) -> ContextParams {
         diffusion_conv_direct: use_cuda,
         vae_conv_direct: use_cuda,
         vae_format: VaeFormat::Flux2,
-        backend: Some(if use_accelerator {
-            device.name.to_ascii_lowercase()
-        } else {
-            "cpu".to_owned()
-        }),
+        backend: Some(crate::backend::ggml_backend_name(device)),
         // The text encoder and denoiser run in separate phases. Cards with less
         // headroom keep source parameters in RAM; high-VRAM cards avoid repeated
         // staging by retaining both quantized models on the accelerator.

--- a/crates/koharu-ml/src/rorem_mixed/model.rs
+++ b/crates/koharu-ml/src/rorem_mixed/model.rs
@@ -64,11 +64,7 @@ fn context_params(device: &crate::Device, paths: ModelPaths) -> ContextParams {
         diffusion_flash_attention: use_cuda,
         diffusion_conv_direct: use_cuda,
         vae_conv_direct: use_cuda,
-        backend: Some(if use_accelerator {
-            device.name.to_ascii_lowercase()
-        } else {
-            "cpu".to_owned()
-        }),
+        backend: Some(crate::backend::ggml_backend_name(device)),
         ..ContextParams::default()
     }
 }

--- a/crates/koharu-ml/src/rorem_mixed/model.rs
+++ b/crates/koharu-ml/src/rorem_mixed/model.rs
@@ -51,7 +51,6 @@ impl Model {
 }
 
 fn context_params(device: &crate::Device, paths: ModelPaths) -> ContextParams {
-    let use_accelerator = device.backend != Backend::Cpu;
     let use_cuda = device.backend == Backend::Cuda;
     ContextParams {
         model_path: Some(paths.version_marker),
@@ -64,7 +63,7 @@ fn context_params(device: &crate::Device, paths: ModelPaths) -> ContextParams {
         diffusion_flash_attention: use_cuda,
         diffusion_conv_direct: use_cuda,
         vae_conv_direct: use_cuda,
-        backend: Some(crate::backend::ggml_backend_name(device)),
+        backend: Some(device.name.clone()),
         ..ContextParams::default()
     }
 }

--- a/crates/koharu-runtime/src/device.rs
+++ b/crates/koharu-runtime/src/device.rs
@@ -1,35 +1,20 @@
-use std::fmt;
-
 use serde::{Deserialize, Serialize};
 
 /// Compute backend used by a machine-learning device.
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq, Hash, Serialize)]
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq, Hash, Serialize, strum::Display)]
 pub enum Backend {
+    #[strum(serialize = "CPU")]
     Cpu,
+    #[strum(serialize = "CUDA")]
     Cuda,
+    #[strum(serialize = "ROCm")]
     Rocm,
+    #[strum(serialize = "Vulkan")]
     Vulkan,
+    #[strum(serialize = "MTL")]
     Metal,
+    #[strum(transparent)]
     Other(String),
-}
-
-impl Backend {
-    fn as_str(&self) -> &str {
-        match self {
-            Self::Cpu => "CPU",
-            Self::Cuda => "CUDA",
-            Self::Rocm => "ROCm",
-            Self::Vulkan => "Vulkan",
-            Self::Metal => "Metal",
-            Self::Other(value) => value,
-        }
-    }
-}
-
-impl fmt::Display for Backend {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_str(self.as_str())
-    }
 }
 
 /// Broad device category shared by native model backends.


### PR DESCRIPTION
## Summary
FLUX.2 Klein inpainting on Apple Silicon fails with `backend 'metal0' was not found` while GGML lists the device as `MTL0` ([#1003](https://github.com/koharu-rs/koharu/issues/1003)).

Koharu previously displayed `Backend::Metal` as `Metal`, so `Device::metal(0)` was normalized as `Metal0`. Define the backend's display string as `MTL` with Strum instead, making the shared normalized device name `MTL0`, and pass normalized device names directly to stable-diffusion.cpp.

llama.cpp continues selecting the same GGML device by index, so it does not need a separate name conversion.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p koharu-runtime -p koharu-ml -- -D warnings`
- [ ] On Apple Silicon: FLUX.2 Klein inpaint against Metal (issue reporter case: M-series, `GPU name: MTL0`)

Fixes #1003