### PR TITLE
feat(export): add CBZ archive export

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4811,6 +4811,7 @@ dependencies = [
  "hayro",
  "image",
  "koharu-agent",
+ "koharu-config",
  "koharu-desktop",
  "koharu-metrics",
  "koharu-ml",

--- a/crates/koharu-app/Cargo.toml
+++ b/crates/koharu-app/Cargo.toml
@@ -23,6 +23,7 @@ koharu-agent = { workspace = true }
 koharu-desktop = { workspace = true }
 koharu-ml = { workspace = true }
 koharu-metrics = { workspace = true }
+koharu-config = { workspace = true }
 koharu-pipeline = { workspace = true }
 koharu-psd = { workspace = true }
 koharu-renderer = { workspace = true }

--- a/crates/koharu-app/src/commands/output.rs
+++ b/crates/koharu-app/src/commands/output.rs
@@ -1,19 +1,31 @@
 use anyhow::{Context as _, Result};
-use futures::{StreamExt as _, TryStreamExt as _, stream};
+use futures::{StreamExt as _, stream};
 use image::{
-    ExtendedColorType, ImageEncoder as _,
-    codecs::png::{CompressionType, FilterType, PngEncoder},
+    ExtendedColorType, ImageEncoder as _, Rgb, RgbImage, RgbaImage,
+    codecs::{
+        jpeg::JpegEncoder,
+        png::{CompressionType, FilterType, PngEncoder},
+    },
 };
+use koharu_pipeline::StopToken;
 use koharu_psd::{PsdExportOptions, export_page};
 use koharu_rasterizer::{Raster, RasterOptions, Rasterizer};
 use koharu_renderer::{Frame, Renderer};
 use koharu_scene::{AssetRole, EntityId, Snapshot};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use specta::Type;
-use std::sync::Arc;
-use tauri::{Cef, State, WebviewWindow, ipc::IpcResponse};
+use std::{
+    io::Write as _,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+use tauri::{AppHandle, Cef, Manager as _, State, WebviewWindow, ipc::IpcResponse};
 
-use super::{Error, project::CurrentProject};
+use super::{
+    ChannelExt as _, Error,
+    processing::{Job, JobChannel, JobId, JobKind, JobState, Processing},
+    project::CurrentProject,
+};
 use koharu_desktop::Desktop;
 
 const THUMBNAIL_EDGE: u32 = 128;
@@ -33,6 +45,357 @@ impl IpcResponse for ThumbnailBytes {
 pub enum ExportFormat {
     Png,
     Psd,
+    Cbz(ImageEncoding),
+}
+
+/// How each page is encoded inside a CBZ archive. Every variant is also an
+/// importable format, so an exported archive can be opened again as a project.
+#[derive(Clone, Copy, Debug, Deserialize, Type)]
+#[serde(rename_all = "snake_case")]
+pub enum ImageEncoding {
+    Png,
+    Jpeg,
+    Webp,
+}
+
+impl ImageEncoding {
+    fn extension(self) -> &'static str {
+        match self {
+            Self::Png => "png",
+            Self::Jpeg => "jpg",
+            Self::Webp => "webp",
+        }
+    }
+}
+
+/// Quality of the lossy page encodings, owned by export because nothing else
+/// consumes it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize, Type)]
+#[serde(default)]
+pub struct ExportConfig {
+    pub jpeg_quality: u8,
+    pub webp_quality: u8,
+}
+
+impl Default for ExportConfig {
+    fn default() -> Self {
+        // Manga pages carry screentone and fine line work, which compress badly,
+        // so these sit above the usual photographic defaults.
+        Self {
+            jpeg_quality: 90,
+            webp_quality: 85,
+        }
+    }
+}
+
+impl ExportConfig {
+    pub fn load() -> Result<koharu_config::Config<Self>> {
+        koharu_config::load("export")
+    }
+
+    /// Reads the stored quality, clamped so a hand-edited config file cannot
+    /// hand an out-of-range value to an encoder.
+    fn quality(self, encoding: ImageEncoding) -> u8 {
+        match encoding {
+            ImageEncoding::Png => 100,
+            ImageEncoding::Jpeg => self.jpeg_quality.clamp(1, 100),
+            ImageEncoding::Webp => self.webp_quality.clamp(1, 100),
+        }
+    }
+}
+
+/// Where a single export run writes its output.
+///
+/// Page formats produce one file per page inside a chosen directory; archive
+/// formats collect every page into one chosen file.
+enum Destination {
+    Directory(PathBuf),
+    Archive(PathBuf),
+}
+
+/// Replaces characters that are invalid in common filesystem names.
+fn sanitize_filename(name: &str) -> String {
+    name.chars()
+        .map(|character| {
+            if matches!(
+                character,
+                '<' | '>' | ':' | '"' | '/' | '\\' | '|' | '?' | '*'
+            ) {
+                '_'
+            } else {
+                character
+            }
+        })
+        .collect()
+}
+
+/// Output file stem for one page, without an extension.
+///
+/// Archive members follow the comic archive convention of `P001`, `P002`, and
+/// are numbered by position and nothing else. A page label is not ordered --
+/// pages can be reordered after import -- and usually already carries its own
+/// number from the source file, so including it would both misorder the archive
+/// and repeat the numbering. Loose files keep the label, where it is what makes
+/// a file identifiable on disk.
+fn page_stem(format: ExportFormat, index: usize, total: usize, label: &str) -> String {
+    let number = index + 1;
+    match format {
+        ExportFormat::Cbz(_) => {
+            // Widen past three digits for a project that needs it, so members
+            // still sort correctly. Matches how PDF import numbers its pages.
+            let width = total.to_string().len().max(3);
+            format!("P{number:0width$}")
+        }
+        ExportFormat::Png | ExportFormat::Psd => {
+            let name = label
+                .trim()
+                .trim_end_matches(|character: char| character == '.' || character.is_whitespace());
+            let name = name.rsplit_once('.').map_or(name, |(stem, _)| stem);
+            let name = sanitize_filename(name);
+            format!(
+                "{number:04}_{}",
+                if name.is_empty() { "page" } else { &name }
+            )
+        }
+    }
+}
+
+/// Writes received members into a CBZ archive, in the order they arrive.
+///
+/// `ZipWriter` is a single sequential writer, so one task owns it and pages are
+/// handed over through a channel rather than written concurrently.
+fn write_cbz(
+    path: &Path,
+    receiver: &mut tokio::sync::mpsc::Receiver<(String, Vec<u8>)>,
+) -> Result<()> {
+    let file = std::fs::File::create(path)
+        .with_context(|| format!("failed to create {}", path.display()))?;
+    let mut archive = zip::ZipWriter::new(file);
+    // Page images are already PNG-compressed; deflating them again costs time
+    // for no meaningful size reduction.
+    let options =
+        zip::write::SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+    while let Some((name, bytes)) = receiver.blocking_recv() {
+        archive.start_file(name, options)?;
+        archive.write_all(&bytes)?;
+    }
+    archive.finish()?;
+    Ok(())
+}
+
+/// Composes an image over white.
+///
+/// JPEG has no alpha channel and its encoder rejects RGBA input, so transparency
+/// has to be resolved first. Dropping the channel would darken transparent areas
+/// toward black, so compose the way the PSD preview does.
+fn flatten_onto_white(image: &RgbaImage) -> RgbImage {
+    let mut flattened = RgbImage::new(image.width(), image.height());
+    for (target, source) in flattened.pixels_mut().zip(image.pixels()) {
+        let [red, green, blue, alpha] = source.0;
+        let alpha = f32::from(alpha) / 255.0;
+        let over = |channel: u8| f32::from(channel).mul_add(alpha, 255.0 * (1.0 - alpha)) as u8;
+        *target = Rgb([over(red), over(green), over(blue)]);
+    }
+    flattened
+}
+
+async fn encode_page(
+    image: RgbaImage,
+    encoding: ImageEncoding,
+    config: ExportConfig,
+) -> Result<Vec<u8>> {
+    let quality = config.quality(encoding);
+    tokio::task::spawn_blocking(move || -> Result<Vec<u8>> {
+        let mut bytes = Vec::new();
+        match encoding {
+            ImageEncoding::Png => {
+                PngEncoder::new_with_quality(
+                    &mut bytes,
+                    CompressionType::Best,
+                    FilterType::Adaptive,
+                )
+                .write_image(
+                    image.as_raw(),
+                    image.width(),
+                    image.height(),
+                    ExtendedColorType::Rgba8,
+                )?;
+            }
+            ImageEncoding::Jpeg => {
+                let flattened = flatten_onto_white(&image);
+                JpegEncoder::new_with_quality(&mut bytes, quality).write_image(
+                    flattened.as_raw(),
+                    flattened.width(),
+                    flattened.height(),
+                    ExtendedColorType::Rgb8,
+                )?;
+            }
+            ImageEncoding::Webp => {
+                // libwebp keeps the alpha channel and takes a quality factor,
+                // which the `image` encoder does not expose.
+                bytes = webp::Encoder::from_rgba(image.as_raw(), image.width(), image.height())
+                    .encode(f32::from(quality))
+                    .to_vec();
+            }
+        }
+        Ok(bytes)
+    })
+    .await
+    .context("page encode worker stopped unexpectedly")?
+}
+
+/// Advances a running export job and publishes the update.
+fn advance_export(handle: &AppHandle<Cef>, id: JobId, completed: usize) {
+    let job = {
+        let processing = handle.state::<Processing>();
+        let mut jobs = processing.jobs.lock();
+        jobs.get_mut(&id).map(|job| {
+            job.completed = completed;
+            job.clone()
+        })
+    };
+    if let Some(job) = job {
+        handle.state::<JobChannel>().channel.publish(job);
+    }
+}
+
+/// Retires an export job in its terminal state and publishes the update.
+fn finish_export(handle: &AppHandle<Cef>, id: JobId, state: JobState, error: Option<String>) {
+    let processing = handle.state::<Processing>();
+    processing.exports.lock().remove(&id);
+    let job = processing.jobs.lock().remove(&id).map(|mut job| {
+        job.state = state;
+        job.error = error;
+        job
+    });
+    if let Some(job) = job {
+        handle.state::<JobChannel>().channel.publish(job);
+    }
+}
+
+enum Outcome {
+    Finished,
+    Stopped,
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_export(
+    handle: &AppHandle<Cef>,
+    id: JobId,
+    stop: &StopToken,
+    format: ExportFormat,
+    destination: Destination,
+    snapshot: Snapshot,
+    renderer: Renderer,
+    rasterizer: Arc<Rasterizer>,
+    jobs: Vec<(EntityId, String)>,
+    config: ExportConfig,
+) -> Result<Outcome> {
+    // Renders one page and returns its output file name and encoded bytes. Both
+    // destinations share this stage; only the write side differs.
+    let render_page = move |(page_id, stem): (EntityId, String)| {
+        let renderer = renderer.clone();
+        let rasterizer = Arc::clone(&rasterizer);
+        let snapshot = snapshot.clone();
+        async move {
+            let frame = renderer.render(&snapshot, page_id).await?;
+            let output = match format {
+                ExportFormat::Png => {
+                    let image = rasterize(rasterizer, &frame, RasterOptions::default())
+                        .await?
+                        .image;
+                    (
+                        format!("{stem}.png"),
+                        encode_page(image, ImageEncoding::Png, config).await?,
+                    )
+                }
+                ExportFormat::Cbz(encoding) => {
+                    let image = rasterize(rasterizer, &frame, RasterOptions::default())
+                        .await?
+                        .image;
+                    (
+                        format!("{stem}.{}", encoding.extension()),
+                        encode_page(image, encoding, config).await?,
+                    )
+                }
+                ExportFormat::Psd => {
+                    let bytes =
+                        export_page(rasterizer, &snapshot, &frame, &PsdExportOptions::default())
+                            .await?;
+                    (format!("{stem}.psd"), bytes)
+                }
+            };
+            tracing::info!(
+                target: "koharu_metrics",
+                metric = "page_exported",
+                format = ?format,
+            );
+            Ok::<_, anyhow::Error>(output)
+        }
+    };
+    match destination {
+        Destination::Directory(directory) => {
+            let mut pages = stream::iter(jobs).map(render_page).buffer_unordered(4);
+            let mut completed = 0_usize;
+            while let Some(page) = pages.next().await {
+                if stop.stopped() {
+                    return Ok(Outcome::Stopped);
+                }
+                let (name, bytes) = page?;
+                let path = directory.join(name);
+                tokio::fs::write(&path, bytes)
+                    .await
+                    .with_context(|| format!("failed to write {}", path.display()))?;
+                completed += 1;
+                advance_export(handle, id, completed);
+            }
+            Ok(Outcome::Finished)
+        }
+        Destination::Archive(path) => {
+            // `ZipWriter` is a single sequential writer, so pages are rendered
+            // concurrently but handed over in page order to one owning task.
+            let (sender, mut receiver) = tokio::sync::mpsc::channel::<(String, Vec<u8>)>(4);
+            let archive_path = path.clone();
+            let writer =
+                tokio::task::spawn_blocking(move || write_cbz(&archive_path, &mut receiver));
+            let mut outcome = Ok(Outcome::Finished);
+            {
+                let mut pages = stream::iter(jobs).map(render_page).buffered(4);
+                let mut completed = 0_usize;
+                while let Some(page) = pages.next().await {
+                    if stop.stopped() {
+                        outcome = Ok(Outcome::Stopped);
+                        break;
+                    }
+                    match page {
+                        Ok(member) => {
+                            if sender.send(member).await.is_err() {
+                                outcome = Err(anyhow::anyhow!("CBZ writer stopped unexpectedly"));
+                                break;
+                            }
+                            completed += 1;
+                            advance_export(handle, id, completed);
+                        }
+                        Err(error) => {
+                            outcome = Err(error);
+                            break;
+                        }
+                    }
+                }
+            }
+            drop(sender);
+            let written = writer.await.context("CBZ writer stopped unexpectedly")?;
+            let outcome = match (outcome, written) {
+                (Err(error), _) | (Ok(_), Err(error)) => Err(error),
+                (Ok(outcome), Ok(())) => Ok(outcome),
+            };
+            if !matches!(outcome, Ok(Outcome::Finished)) {
+                // A partial archive is unreadable; do not leave one behind.
+                let _ = tokio::fs::remove_file(&path).await;
+            }
+            outcome
+        }
+    }
 }
 
 #[tracing::instrument(
@@ -43,25 +406,21 @@ pub enum ExportFormat {
 )]
 #[tauri::command]
 #[specta::specta]
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn export_pages(
+    handle: AppHandle<Cef>,
     window: WebviewWindow<Cef>,
     pages: Vec<EntityId>,
     format: ExportFormat,
     project: State<'_, CurrentProject>,
     desktop: State<'_, Desktop>,
-) -> std::result::Result<(), Error> {
-    let snapshot = {
+    processing: State<'_, Processing>,
+    job_channel: State<'_, JobChannel>,
+) -> std::result::Result<Option<JobId>, Error> {
+    let (snapshot, project_name) = {
         let project = project.project.lock().await;
         let project = project.as_ref().context("no project is open")?;
-        project.snapshot()
-    };
-    let Some(directory) = rfd::AsyncFileDialog::new()
-        .set_parent(&window)
-        .pick_folder()
-        .await
-        .map(|directory| directory.path().to_owned())
-    else {
-        return Ok(());
+        (project.snapshot(), project.name.clone())
     };
     let pages = if pages.is_empty() {
         snapshot.pages().map(|page| page.id()).collect()
@@ -71,95 +430,102 @@ pub(crate) async fn export_pages(
     if pages.is_empty() {
         return Err(anyhow::anyhow!("there are no pages to export").into());
     }
+    let dialog = rfd::AsyncFileDialog::new().set_parent(&window);
+    let destination = match format {
+        ExportFormat::Png | ExportFormat::Psd => {
+            let Some(directory) = dialog
+                .pick_folder()
+                .await
+                .map(|directory| directory.path().to_owned())
+            else {
+                return Ok(None);
+            };
+            Destination::Directory(directory)
+        }
+        ExportFormat::Cbz(_) => {
+            let name = sanitize_filename(project_name.trim());
+            let name = if name.is_empty() { "export" } else { &name };
+            let Some(path) = dialog
+                .add_filter("Comic archive", &["cbz"])
+                .set_file_name(format!("{name}.cbz"))
+                .save_file()
+                .await
+                .map(|path| path.path().to_owned())
+            else {
+                return Ok(None);
+            };
+            Destination::Archive(path)
+        }
+    };
     let renderer = desktop.renderer();
     let rasterizer = desktop.rasterizer().await?;
+    let config = {
+        let config = ExportConfig::load()?;
+        let value = config.read()?;
+        *value
+    };
+    let total = pages.len();
     let jobs = pages
         .into_iter()
         .enumerate()
         .map(|(index, page_id)| {
             let page = snapshot.page(page_id)?.page()?;
-            let name = page
-                .label
-                .trim()
-                .trim_end_matches(|character: char| character == '.' || character.is_whitespace());
-            let name = name.rsplit_once('.').map_or(name, |(stem, _)| stem);
-            let name = name
-                .chars()
-                .map(|character| {
-                    if matches!(
-                        character,
-                        '<' | '>' | ':' | '"' | '/' | '\\' | '|' | '?' | '*'
-                    ) {
-                        '_'
-                    } else {
-                        character
-                    }
-                })
-                .collect::<String>();
-            let stem = format!(
-                "{:04}_{}",
-                index + 1,
-                if name.is_empty() { "page" } else { &name }
-            );
-            Ok::<_, anyhow::Error>((page_id, stem))
+            Ok::<_, anyhow::Error>((page_id, page_stem(format, index, total, &page.label)))
         })
         .collect::<Result<Vec<_>>>()?;
-    stream::iter(jobs)
-        .map(|(page_id, stem)| {
-            let renderer = renderer.clone();
-            let rasterizer = Arc::clone(&rasterizer);
-            let snapshot = snapshot.clone();
-            let directory = directory.clone();
-            async move {
-                let frame = renderer.render(&snapshot, page_id).await?;
-                match format {
-                    ExportFormat::Png => {
-                        let image =
-                            rasterize(Arc::clone(&rasterizer), &frame, RasterOptions::default())
-                                .await?
-                                .image;
-                        tokio::task::spawn_blocking(move || -> Result<()> {
-                            let file =
-                                std::fs::File::create(directory.join(format!("{stem}.png")))?;
-                            PngEncoder::new_with_quality(
-                                file,
-                                CompressionType::Best,
-                                FilterType::Adaptive,
-                            )
-                            .write_image(
-                                image.as_raw(),
-                                image.width(),
-                                image.height(),
-                                ExtendedColorType::Rgba8,
-                            )?;
-                            Ok(())
-                        })
-                        .await
-                        .context("PNG export worker stopped unexpectedly")??;
-                    }
-                    ExportFormat::Psd => {
-                        let bytes = export_page(
-                            Arc::clone(&rasterizer),
-                            &snapshot,
-                            &frame,
-                            &PsdExportOptions::default(),
-                        )
-                        .await?;
-                        tokio::fs::write(directory.join(format!("{stem}.psd")), bytes).await?;
-                    }
-                }
-                tracing::info!(
-                    target: "koharu_metrics",
-                    metric = "page_exported",
-                    format = ?format,
-                );
-                Ok::<_, anyhow::Error>(())
+
+    let id = JobId::new();
+    let stop = StopToken::default();
+    processing.exports.lock().insert(id, stop.clone());
+    let job = Job {
+        id,
+        kind: JobKind::Export,
+        state: JobState::Running,
+        completed: 0,
+        total: jobs.len(),
+        page: None,
+        stage: None,
+        model: None,
+        error: None,
+    };
+    processing.jobs.lock().insert(id, job.clone());
+    job_channel.channel.publish(job);
+
+    let task_handle = handle.clone();
+    drop(tokio::spawn(async move {
+        let result = run_export(
+            &task_handle,
+            id,
+            &stop,
+            format,
+            destination,
+            snapshot,
+            renderer,
+            rasterizer,
+            jobs,
+            config,
+        )
+        .await;
+        let (state, error) = match result {
+            Ok(Outcome::Finished) => (JobState::Finished, None),
+            Ok(Outcome::Stopped) => (JobState::Stopped, None),
+            Err(error) => {
+                tracing::error!(%error, "export failed");
+                (JobState::Failed, Some(format!("{error:#}")))
             }
-        })
-        .buffer_unordered(4)
-        .try_collect::<Vec<_>>()
-        .await?;
-    Ok(())
+        };
+        tracing::info!(
+            target: "koharu_metrics",
+            metric = "export_result",
+            outcome = match state {
+                JobState::Stopped => "stopped",
+                JobState::Failed => "failed",
+                _ => "completed",
+            },
+        );
+        finish_export(&task_handle, id, state, error);
+    }));
+    Ok(Some(id))
 }
 
 #[tauri::command]
@@ -227,4 +593,173 @@ async fn rasterize(
         .await
         .context("rasterizer worker stopped unexpectedly")?
         .map_err(Into::into)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitize_filename_replaces_path_and_reserved_characters() {
+        assert_eq!(sanitize_filename("ch1/page:2"), "ch1_page_2");
+        assert_eq!(sanitize_filename(r#"a<b>c"d|e?f*g\h"#), "a_b_c_d_e_f_g_h");
+        assert_eq!(sanitize_filename("plain name"), "plain name");
+    }
+
+    fn sample() -> RgbaImage {
+        RgbaImage::from_fn(8, 8, |x, y| {
+            // Half opaque, half fully transparent, so the JPEG matte is exercised.
+            let alpha = if x < 4 { 255 } else { 0 };
+            image::Rgba([10 * x as u8, 10 * y as u8, 200, alpha])
+        })
+    }
+
+    #[tokio::test]
+    async fn every_encoding_produces_its_own_importable_format() {
+        for (encoding, expected) in [
+            (ImageEncoding::Png, image::ImageFormat::Png),
+            (ImageEncoding::Jpeg, image::ImageFormat::Jpeg),
+            (ImageEncoding::Webp, image::ImageFormat::WebP),
+        ] {
+            let bytes = encode_page(sample(), encoding, ExportConfig::default())
+                .await
+                .expect("encode page");
+            assert_eq!(
+                image::guess_format(&bytes).expect("identify encoded page"),
+                expected,
+                "{encoding:?} produced the wrong container",
+            );
+            // Koharu must be able to import what it exports.
+            image::load_from_memory(&bytes).expect("decode encoded page");
+        }
+    }
+
+    #[test]
+    fn jpeg_matte_composes_transparent_pixels_onto_white() {
+        let flattened = flatten_onto_white(&sample());
+        // Column 4 is fully transparent, so it must resolve to white rather than
+        // to the pixel's own colour.
+        assert_eq!(flattened.get_pixel(4, 0).0, [255, 255, 255]);
+        // Column 0 is opaque and must be untouched.
+        assert_eq!(flattened.get_pixel(0, 0).0, [0, 0, 200]);
+    }
+
+    #[test]
+    fn quality_is_clamped_for_hand_edited_config() {
+        let config = ExportConfig {
+            jpeg_quality: 0,
+            webp_quality: 200,
+        };
+        assert_eq!(config.quality(ImageEncoding::Jpeg), 1);
+        assert_eq!(config.quality(ImageEncoding::Webp), 100);
+    }
+
+    #[test]
+    fn archive_members_follow_the_comic_archive_convention() {
+        let cbz = ExportFormat::Cbz(ImageEncoding::Jpeg);
+        // A label that already carries its own number must not repeat it.
+        assert_eq!(page_stem(cbz, 0, 20, "001.jpg"), "P001");
+        assert_eq!(page_stem(cbz, 9, 20, "010.jpg"), "P010");
+        // Nor should a label leak into the archive in any other form.
+        assert_eq!(page_stem(cbz, 1, 20, "pages/page2.png"), "P002");
+        assert_eq!(page_stem(cbz, 2, 20, ""), "P003");
+    }
+
+    #[test]
+    fn archive_numbering_widens_for_large_projects() {
+        let cbz = ExportFormat::Cbz(ImageEncoding::Png);
+        // Three digits is the convention, but members must still sort.
+        assert_eq!(page_stem(cbz, 0, 999, "a"), "P001");
+        assert_eq!(page_stem(cbz, 0, 1000, "a"), "P0001");
+        assert_eq!(page_stem(cbz, 1233, 1500, "a"), "P1234");
+    }
+
+    #[test]
+    fn loose_files_keep_the_page_label() {
+        assert_eq!(
+            page_stem(ExportFormat::Png, 0, 3, "cover.png"),
+            "0001_cover",
+            "the label is what identifies a loose file on disk",
+        );
+        assert_eq!(
+            page_stem(ExportFormat::Psd, 1, 3, "ch1/page.psd"),
+            "0002_ch1_page"
+        );
+        assert_eq!(page_stem(ExportFormat::Png, 2, 3, "   "), "0003_page");
+    }
+
+    #[test]
+    fn encodings_use_distinct_extensions() {
+        assert_eq!(ImageEncoding::Png.extension(), "png");
+        assert_eq!(ImageEncoding::Jpeg.extension(), "jpg");
+        assert_eq!(ImageEncoding::Webp.extension(), "webp");
+    }
+
+    #[tokio::test]
+    async fn write_cbz_preserves_member_order() {
+        let members = ["0001_a.png", "0002_b.png", "0010_c.png"];
+        let path = std::env::temp_dir().join(format!(
+            "koharu-export-order-{}-{:?}.cbz",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+
+        let (sender, mut receiver) = tokio::sync::mpsc::channel::<(String, Vec<u8>)>(4);
+        let archive_path = path.clone();
+        let writer = tokio::task::spawn_blocking(move || write_cbz(&archive_path, &mut receiver));
+        for name in members {
+            sender
+                .send((name.to_owned(), b"payload".to_vec()))
+                .await
+                .expect("send member");
+        }
+        drop(sender);
+        writer.await.expect("writer task").expect("write archive");
+
+        let file = std::fs::File::open(&path).expect("open archive");
+        let mut archive = zip::ZipArchive::new(file).expect("read archive");
+        let names = (0..archive.len())
+            .map(|index| archive.by_index(index).expect("member").name().to_owned())
+            .collect::<Vec<_>>();
+        drop(archive);
+        std::fs::remove_file(&path).expect("remove archive");
+
+        // Page order, not archive-internal sorting, is what readers rely on.
+        assert_eq!(names, members);
+    }
+
+    #[tokio::test]
+    async fn write_cbz_stores_members_uncompressed_and_intact() {
+        let payload = b"page-bytes".to_vec();
+        let path = std::env::temp_dir().join(format!(
+            "koharu-export-stored-{}-{:?}.cbz",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+
+        let (sender, mut receiver) = tokio::sync::mpsc::channel::<(String, Vec<u8>)>(4);
+        let archive_path = path.clone();
+        let writer = tokio::task::spawn_blocking(move || write_cbz(&archive_path, &mut receiver));
+        sender
+            .send(("0001_page.png".to_owned(), payload.clone()))
+            .await
+            .expect("send member");
+        drop(sender);
+        writer.await.expect("writer task").expect("write archive");
+
+        let file = std::fs::File::open(&path).expect("open archive");
+        let mut archive = zip::ZipArchive::new(file).expect("read archive");
+        let (compression, bytes) = {
+            let mut member = archive.by_index(0).expect("member");
+            let compression = member.compression();
+            let mut bytes = Vec::new();
+            std::io::Read::read_to_end(&mut member, &mut bytes).expect("read member");
+            (compression, bytes)
+        };
+        drop(archive);
+        std::fs::remove_file(&path).expect("remove archive");
+
+        assert_eq!(compression, zip::CompressionMethod::Stored);
+        assert_eq!(bytes, payload);
+    }
 }

--- a/crates/koharu-app/src/commands/preferences.rs
+++ b/crates/koharu-app/src/commands/preferences.rs
@@ -8,13 +8,14 @@ use koharu_translator::{Language, Model, Provider, ProviderConfig, ProvidersConf
 use serde::{Deserialize, Serialize};
 use specta::Type;
 
-use super::Error;
+use super::{Error, output::ExportConfig};
 
 #[derive(Clone, Debug, Serialize, Type)]
 pub struct Preferences {
     pub pipeline: PipelineConfig,
     pub providers: ProviderPreferences,
     pub typesetting: TypesettingConfig,
+    pub export: ExportConfig,
     pub languages: Vec<LanguageChoice>,
 }
 
@@ -23,13 +24,16 @@ impl Preferences {
         let pipeline = PipelineConfig::load()?;
         let providers = ProvidersConfig::load()?;
         let typesetting = TypesettingConfig::load()?;
+        let export = ExportConfig::load()?;
         let pipeline = pipeline.read()?;
         let providers = providers.read()?;
         let typesetting = typesetting.read()?;
+        let export = export.read()?;
         Ok(Self {
             pipeline: pipeline.clone(),
             providers: ProviderPreferences::from_config(&providers)?,
             typesetting: typesetting.clone(),
+            export: *export,
             languages: Language::ALL
                 .iter()
                 .map(|language| LanguageChoice {
@@ -160,12 +164,14 @@ pub(crate) async fn save_preferences(
     mut pipeline: PipelineConfig,
     providers: ProviderPreferences,
     typesetting: TypesettingConfig,
+    export_config: ExportConfig,
 ) -> std::result::Result<Preferences, Error> {
     remember_pipeline_profiles(&mut pipeline);
     let providers = providers.into_config()?;
     let pipeline_config = PipelineConfig::load()?;
     let providers_config = ProvidersConfig::load()?;
     let typesetting_config = TypesettingConfig::load()?;
+    let export_section = ExportConfig::load()?;
     {
         let mut current = pipeline_config.write()?;
         *current = pipeline;
@@ -179,6 +185,11 @@ pub(crate) async fn save_preferences(
     {
         let mut current = typesetting_config.write()?;
         *current = typesetting;
+        current.save()?;
+    }
+    {
+        let mut current = export_section.write()?;
+        *current = export_config;
         current.save()?;
     }
     let preferences = Preferences::load()?;

--- a/crates/koharu-app/src/commands/processing.rs
+++ b/crates/koharu-app/src/commands/processing.rs
@@ -38,6 +38,7 @@ impl fmt::Display for JobId {
 #[derive(Clone, Debug, Serialize, Type)]
 pub struct Job {
     pub id: JobId,
+    pub kind: JobKind,
     pub state: JobState,
     #[specta(type = f64)]
     pub completed: usize,
@@ -58,9 +59,22 @@ pub enum JobState {
     Stopped,
 }
 
+/// What kind of work a job represents, so the activity view can describe it.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Type)]
+#[serde(rename_all = "snake_case")]
+pub enum JobKind {
+    Processing,
+    Export,
+}
+
 #[derive(Default)]
 pub(crate) struct Processing {
+    /// Pipeline runs. These are mutually exclusive with each other and with
+    /// imports, which is why `process` refuses to start while this is not empty.
     pub(crate) stops: Mutex<HashMap<JobId, StopToken>>,
+    /// Export runs. Exports read an immutable snapshot, so they neither block
+    /// nor are blocked by a pipeline run and are tracked separately.
+    pub(crate) exports: Mutex<HashMap<JobId, StopToken>>,
     pub(crate) jobs: Mutex<HashMap<JobId, Job>>,
     pub(crate) inpainting_mask: Mutex<Option<koharu_pipeline::InpaintingMask>>,
 }
@@ -99,6 +113,7 @@ pub(crate) async fn process(
     }
     let job = Job {
         id,
+        kind: JobKind::Processing,
         state: JobState::Running,
         completed: 0,
         total: 0,
@@ -289,9 +304,12 @@ pub(crate) async fn stop_job(
     job: JobId,
     processing: State<'_, Processing>,
 ) -> std::result::Result<(), Error> {
-    let stops = processing.stops.lock();
-    let stop = stops
+    let stop = processing
+        .stops
+        .lock()
         .get(&job)
+        .cloned()
+        .or_else(|| processing.exports.lock().get(&job).cloned())
         .with_context(|| format!("job {job} is not running"))?;
     stop.stop();
     Ok(())

--- a/docs/reference/formats-and-data.md
+++ b/docs/reference/formats-and-data.md
@@ -11,6 +11,7 @@ description: Supported import and export formats, project layout, settings, cred
 | --- | --- |
 | Page import | PNG, JPEG, WebP, CBZ, ZIP, RAR, PDF |
 | Flattened export | PNG |
+| Archive export | CBZ, with PNG, JPEG, or WebP pages |
 | Layered interchange export | PSD |
 | Koharu working project | `.khrproj` directory |
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -49,6 +49,15 @@ Configure the ordered default font-family stack. When a text layer has no usable
 
 This is a fallback policy; individual text layers can still choose their own font, weight, style, size, colors, alignment, and writing mode.
 
+## Export
+
+Quality for the lossy page formats offered when exporting a CBZ archive, from 1 to 100.
+
+- **JPEG quality** defaults to 90.
+- **WebP quality** defaults to 85.
+
+Both default higher than a typical photographic setting because screentone and fine line work compress poorly. PNG pages are always lossless and are not affected.
+
 ## Shortcuts
 
 Assign one character to Select, Text, Brush, Eraser, Color picker, Remove, Pan, and Fit Window. The current shortcut editor updates the running UI session; custom tool bindings are not part of `~/.koharu/config.toml`.

--- a/docs/workflow/export.md
+++ b/docs/workflow/export.md
@@ -1,17 +1,21 @@
 ---
-title: Export PNG and PSD
-description: Export the active or selected pages as flattened PNG or layered PSD files.
+title: Export PNG, PSD, and CBZ
+description: Export the active or selected pages as flattened PNG or layered PSD files, or the whole project as a CBZ archive.
 ---
 
-# Export PNG and PSD
+# Export PNG, PSD, and CBZ
 
-Use **File -> Export PNG** or **File -> Export PSD** after reviewing the page composite.
+Use **File -> Export** and choose **PNG**, **PSD**, or **CBZ** after reviewing the page composite.
+
+Export runs in the background. The activity panel reports progress and can stop a run; a stopped CBZ export removes its incomplete archive.
 
 ## Which pages are exported
 
-If the page rail contains a selection, Koharu exports those pages. Otherwise it exports the active page. Choose an output directory in the native folder dialog.
+PNG and PSD follow the page rail: if it contains a selection, Koharu exports those pages, otherwise it exports the active page. Choose an output directory in the native folder dialog.
 
-Files receive a project-order prefix and a sanitized page label:
+CBZ always exports every page in the project, in project order, because a comic archive with a single page is rarely useful. Koharu asks which image format the pages should use, then asks where to save the archive.
+
+Loose PNG and PSD files receive a project-order prefix and a sanitized page label:
 
 ```text
 0001_page-name.png
@@ -19,6 +23,15 @@ Files receive a project-order prefix and a sanitized page label:
 ```
 
 Characters that are invalid in common filenames are replaced. Existing extensions in page labels are removed before the new export extension is added.
+
+Archive members follow the comic archive convention and carry no label:
+
+```text
+P001.png
+P002.png
+```
+
+Page labels come from the imported filename, which usually already contains its own number, and a label does not follow the page order after pages are reordered. Numbering members by position keeps an archive in project order without repeating that number. Numbering widens past three digits for a project that needs it.
 
 ## PNG
 
@@ -32,8 +45,26 @@ PSD preserves a layered representation for further work in compatible editors. I
 
 PSD interchange is not a lossless serialization of a `.khrproj` project. Koharu's semantic OCR data, analysis regions, model provenance, revision history, and every renderer behavior do not become native Photoshop concepts. Keep the Koharu project as the authoritative editable source.
 
+## CBZ
+
+CBZ is a comic archive: every page is exported as a flattened image and the pages are stored together in one `.cbz` file. Members are named for their position in the project, so readers that sort entries by name show the pages in the correct order.
+
+Choose the page format when the export starts:
+
+| Format | Use it for |
+| --- | --- |
+| PNG | Lossless delivery. The largest archives. |
+| JPEG | The smallest archives. Transparency is composed onto white, because JPEG has no alpha channel. |
+| WebP | Smaller than PNG while keeping transparency. |
+
+Quality for the lossy formats lives in **Settings -> Export**. PNG is always lossless and ignores it.
+
+Members are stored without additional compression, because every supported page format is already compressed. All three are also import formats, so an exported archive can be opened again as a new project.
+
+Use CBZ to deliver a finished chapter to a comic reader.
+
 ## Consistency
 
-Canvas, PNG, and PSD export all begin from the same scene and retained rendering result. If an export looks different, record the project revision, affected page, format, and screenshot and report it as a rendering bug.
+Canvas, PNG, PSD, and CBZ export all begin from the same scene and retained rendering result. If an export looks different, record the project revision, affected page, format, and screenshot and report it as a rendering bug.
 
 Koharu does not currently provide a separate “inpainted image only” export.

--- a/packages/bridge/src/protocol.ts
+++ b/packages/bridge/src/protocol.ts
@@ -55,11 +55,11 @@ export const commands = {
 	redo: () => __TAURI_INVOKE<null>("redo"),
 	process: (scope: Scope, operation: Operation) => __TAURI_INVOKE<JobId>("process", { scope, operation }),
 	stopJob: (job: JobId) => __TAURI_INVOKE<null>("stop_job", { job }),
-	exportPages: (pages: EntityId[], format: ExportFormat) => __TAURI_INVOKE<null>("export_pages", { pages, format }),
+	exportPages: (pages: EntityId[], format: ExportFormat) => __TAURI_INVOKE<string | null>("export_pages", { pages, format }),
 	getThumbnail: (page: EntityId) => __TAURI_INVOKE<ThumbnailBytes>("get_thumbnail", { page }),
 	getFonts: () => __TAURI_INVOKE<FontFamily[]>("get_fonts"),
 	getFontPreview: (familyName: string) => __TAURI_INVOKE<FontPreviewBytes>("get_font_preview", { familyName }),
-	savePreferences: (pipeline: PipelineConfig, providers: ProviderPreferences, typesetting: TypesettingConfig) => __TAURI_INVOKE<Preferences>("save_preferences", { pipeline: ({...pipeline,translation:({...pipeline.translation,generation:({...pipeline.translation.generation,temperature:pipeline.translation.generation.temperature==null?pipeline.translation.generation.temperature:pipeline.translation.generation.temperature,top_p:pipeline.translation.generation.top_p==null?pipeline.translation.generation.top_p:pipeline.translation.generation.top_p,min_p:pipeline.translation.generation.min_p==null?pipeline.translation.generation.min_p:pipeline.translation.generation.min_p,repeat_penalty:pipeline.translation.generation.repeat_penalty==null?pipeline.translation.generation.repeat_penalty:pipeline.translation.generation.repeat_penalty,frequency_penalty:pipeline.translation.generation.frequency_penalty==null?pipeline.translation.generation.frequency_penalty:pipeline.translation.generation.frequency_penalty,presence_penalty:pipeline.translation.generation.presence_penalty==null?pipeline.translation.generation.presence_penalty:pipeline.translation.generation.presence_penalty})}),processor:({...pipeline.processor,"koharu-layout-rfdetr-seg-2xl":pipeline.processor["koharu-layout-rfdetr-seg-2xl"]==null?pipeline.processor["koharu-layout-rfdetr-seg-2xl"]:({...pipeline.processor["koharu-layout-rfdetr-seg-2xl"],text_threshold:pipeline.processor["koharu-layout-rfdetr-seg-2xl"].text_threshold==null?pipeline.processor["koharu-layout-rfdetr-seg-2xl"].text_threshold:pipeline.processor["koharu-layout-rfdetr-seg-2xl"].text_threshold,bubble_threshold:pipeline.processor["koharu-layout-rfdetr-seg-2xl"].bubble_threshold==null?pipeline.processor["koharu-layout-rfdetr-seg-2xl"].bubble_threshold:pipeline.processor["koharu-layout-rfdetr-seg-2xl"].bubble_threshold,panel_threshold:pipeline.processor["koharu-layout-rfdetr-seg-2xl"].panel_threshold==null?pipeline.processor["koharu-layout-rfdetr-seg-2xl"].panel_threshold:pipeline.processor["koharu-layout-rfdetr-seg-2xl"].panel_threshold})})}), providers, typesetting }).then((v) => (({...v,pipeline:({...v.pipeline,translation:({...v.pipeline.translation,generation:({...v.pipeline.translation.generation,temperature:v.pipeline.translation.generation.temperature==null?v.pipeline.translation.generation.temperature:v.pipeline.translation.generation.temperature,top_p:v.pipeline.translation.generation.top_p==null?v.pipeline.translation.generation.top_p:v.pipeline.translation.generation.top_p,min_p:v.pipeline.translation.generation.min_p==null?v.pipeline.translation.generation.min_p:v.pipeline.translation.generation.min_p,repeat_penalty:v.pipeline.translation.generation.repeat_penalty==null?v.pipeline.translation.generation.repeat_penalty:v.pipeline.translation.generation.repeat_penalty,frequency_penalty:v.pipeline.translation.generation.frequency_penalty==null?v.pipeline.translation.generation.frequency_penalty:v.pipeline.translation.generation.frequency_penalty,presence_penalty:v.pipeline.translation.generation.presence_penalty==null?v.pipeline.translation.generation.presence_penalty:v.pipeline.translation.generation.presence_penalty})}),processor:({...v.pipeline.processor,"koharu-layout-rfdetr-seg-2xl":v.pipeline.processor["koharu-layout-rfdetr-seg-2xl"]==null?v.pipeline.processor["koharu-layout-rfdetr-seg-2xl"]:({...v.pipeline.processor["koharu-layout-rfdetr-seg-2xl"],text_threshold:v.pipeline.processor["koharu-layout-rfdetr-seg-2xl"].text_threshold==null?v.pipeline.processor["koharu-layout-rfdetr-seg-2xl"].text_threshold:v.pipeline.processor["koharu-layout-rfdetr-seg-2xl"].text_threshold,bubble_threshold:v.pipeline.processor["koharu-layout-rfdetr-seg-2xl"].bubble_threshold==null?v.pipeline.processor["koharu-layout-rfdetr-seg-2xl"].bubble_threshold:v.pipeline.processor["koharu-layout-rfdetr-seg-2xl"].bubble_threshold,panel_threshold:v.pipeline.processor["koharu-layout-rfdetr-seg-2xl"].panel_threshold==null?v.pipeline.processor["koharu-layout-rfdetr-seg-2xl"].panel_threshold:v.pipeline.processor["koharu-layout-rfdetr-seg-2xl"].panel_threshold})})})}) as typeof v)),
+	savePreferences: (pipeline: PipelineConfig, providers: ProviderPreferences, typesetting: TypesettingConfig, exportConfig: ExportConfig) => __TAURI_INVOKE<Preferences>("save_preferences", { pipeline: ({...pipeline,translation:({...pipeline.translation,generation:({...pipeline.translation.generation,temperature:pipeline.translation.generation.temperature==null?pipeline.translation.generation.temperature:pipeline.translation.generation.temperature,top_p:pipeline.translation.generation.top_p==null?pipeline.translation.generation.top_p:pipeline.translation.generation.top_p,min_p:pipeline.translation.generation.min_p==null?pipeline.translation.generation.min_p:pipeline.translation.generation.min_p,repeat_penalty:pipeline.translation.generation.repeat_penalty==null?pipeline.translation.generation.repeat_penalty:pipeline.translation.generation.repeat_penalty,frequency_penalty:pipeline.translation.generation.frequency_penalty==null?pipeline.translation.generation.frequency_penalty:pipeline.translation.generation.frequency_penalty,presence_penalty:pipeline.translation.generation.presence_penalty==null?pipeline.translation.generation.presence_penalty:pipeline.translation.generation.presence_penalty})}),processor:({...pipeline.processor,"koharu-layout-rfdetr-seg-2xl":pipeline.processor["koharu-layout-rfdetr-seg-2xl"]==null?pipeline.processor["koharu-layout-rfdetr-seg-2xl"]:({...pipeline.processor["koharu-layout-rfdetr-seg-2xl"],text_threshold:pipeline.processor["koharu-layout-rfdetr-seg-2xl"].text_threshold==null?pipeline.processor["koharu-layout-rfdetr-seg-2xl"].text_threshold:pipeline.processor["koharu-layout-rfdetr-seg-2xl"].text_threshold,bubble_threshold:pipeline.processor["koharu-layout-rfdetr-seg-2xl"].bubble_threshold==null?pipeline.processor["koharu-layout-rfdetr-seg-2xl"].bubble_threshold:pipeline.processor["koharu-layout-rfdetr-seg-2xl"].bubble_threshold,panel_threshold:pipeline.processor["koharu-layout-rfdetr-seg-2xl"].panel_threshold==null?pipeline.processor["koharu-layout-rfdetr-seg-2xl"].panel_threshold:pipeline.processor["koharu-layout-rfdetr-seg-2xl"].panel_threshold})})}), providers, typesetting, exportConfig }).then((v) => (({...v,pipeline:({...v.pipeline,translation:({...v.pipeline.translation,generation:({...v.pipeline.translation.generation,temperature:v.pipeline.translation.generation.temperature==null?v.pipeline.translation.generation.temperature:v.pipeline.translation.generation.temperature,top_p:v.pipeline.translation.generation.top_p==null?v.pipeline.translation.generation.top_p:v.pipeline.translation.generation.top_p,min_p:v.pipeline.translation.generation.min_p==null?v.pipeline.translation.generation.min_p:v.pipeline.translation.generation.min_p,repeat_penalty:v.pipeline.translation.generation.repeat_penalty==null?v.pipeline.translation.generation.repeat_penalty:v.pipeline.translation.generation.repeat_penalty,frequency_penalty:v.pipeline.translation.generation.frequency_penalty==null?v.pipeline.translation.generation.frequency_penalty:v.pipeline.translation.generation.frequency_penalty,presence_penalty:v.pipeline.translation.generation.presence_penalty==null?v.pipeline.translation.generation.presence_penalty:v.pipeline.translation.generation.presence_penalty})}),processor:({...v.pipeline.processor,"koharu-layout-rfdetr-seg-2xl":v.pipeline.processor["koharu-layout-rfdetr-seg-2xl"]==null?v.pipeline.processor["koharu-layout-rfdetr-seg-2xl"]:({...v.pipeline.processor["koharu-layout-rfdetr-seg-2xl"],text_threshold:v.pipeline.processor["koharu-layout-rfdetr-seg-2xl"].text_threshold==null?v.pipeline.processor["koharu-layout-rfdetr-seg-2xl"].text_threshold:v.pipeline.processor["koharu-layout-rfdetr-seg-2xl"].text_threshold,bubble_threshold:v.pipeline.processor["koharu-layout-rfdetr-seg-2xl"].bubble_threshold==null?v.pipeline.processor["koharu-layout-rfdetr-seg-2xl"].bubble_threshold:v.pipeline.processor["koharu-layout-rfdetr-seg-2xl"].bubble_threshold,panel_threshold:v.pipeline.processor["koharu-layout-rfdetr-seg-2xl"].panel_threshold==null?v.pipeline.processor["koharu-layout-rfdetr-seg-2xl"].panel_threshold:v.pipeline.processor["koharu-layout-rfdetr-seg-2xl"].panel_threshold})})})}) as typeof v)),
 	getPreferences: () => __TAURI_INVOKE<Preferences>("get_preferences").then((v) => (({...v,pipeline:({...v.pipeline,translation:({...v.pipeline.translation,generation:({...v.pipeline.translation.generation,temperature:v.pipeline.translation.generation.temperature==null?v.pipeline.translation.generation.temperature:v.pipeline.translation.generation.temperature,top_p:v.pipeline.translation.generation.top_p==null?v.pipeline.translation.generation.top_p:v.pipeline.translation.generation.top_p,min_p:v.pipeline.translation.generation.min_p==null?v.pipeline.translation.generation.min_p:v.pipeline.translation.generation.min_p,repeat_penalty:v.pipeline.translation.generation.repeat_penalty==null?v.pipeline.translation.generation.repeat_penalty:v.pipeline.translation.generation.repeat_penalty,frequency_penalty:v.pipeline.translation.generation.frequency_penalty==null?v.pipeline.translation.generation.frequency_penalty:v.pipeline.translation.generation.frequency_penalty,presence_penalty:v.pipeline.translation.generation.presence_penalty==null?v.pipeline.translation.generation.presence_penalty:v.pipeline.translation.generation.presence_penalty})}),processor:({...v.pipeline.processor,"koharu-layout-rfdetr-seg-2xl":v.pipeline.processor["koharu-layout-rfdetr-seg-2xl"]==null?v.pipeline.processor["koharu-layout-rfdetr-seg-2xl"]:({...v.pipeline.processor["koharu-layout-rfdetr-seg-2xl"],text_threshold:v.pipeline.processor["koharu-layout-rfdetr-seg-2xl"].text_threshold==null?v.pipeline.processor["koharu-layout-rfdetr-seg-2xl"].text_threshold:v.pipeline.processor["koharu-layout-rfdetr-seg-2xl"].text_threshold,bubble_threshold:v.pipeline.processor["koharu-layout-rfdetr-seg-2xl"].bubble_threshold==null?v.pipeline.processor["koharu-layout-rfdetr-seg-2xl"].bubble_threshold:v.pipeline.processor["koharu-layout-rfdetr-seg-2xl"].bubble_threshold,panel_threshold:v.pipeline.processor["koharu-layout-rfdetr-seg-2xl"].panel_threshold==null?v.pipeline.processor["koharu-layout-rfdetr-seg-2xl"].panel_threshold:v.pipeline.processor["koharu-layout-rfdetr-seg-2xl"].panel_threshold})})})}) as typeof v)),
 	getTranslationModels: () => __TAURI_INVOKE<Model[]>("get_translation_models"),
 	getCanvasManifest: (generation: CanvasGeneration) => __TAURI_INVOKE<CanvasBytes>("get_canvas_manifest", { generation }),
@@ -182,7 +182,16 @@ export type Error = string;
 
 export type Event = { type: "started"; run: RunId } | { type: "text_delta"; run: RunId; delta: string } | { type: "reasoning_delta"; run: RunId; delta: string } | { type: "tool_started"; run: RunId; call_id: string; name: string } | { type: "tool_finished"; run: RunId; call_id: string; name: string; changed: boolean; output: string } | { type: "completed"; run: RunId; message: string } | { type: "failed"; run: RunId; message: string } | { type: "cancelled"; run: RunId };
 
-export type ExportFormat = "png" | "psd";
+/**
+ *  Quality of the lossy page encodings, owned by export because nothing else
+ *  consumes it.
+ */
+export type ExportConfig = {
+	jpeg_quality?: number,
+	webp_quality?: number,
+};
+
+export type ExportFormat = "png" | "psd" | { cbz: ImageEncoding };
 
 export type Flux2KleinConfig = {
 	prompt?: string,
@@ -260,6 +269,12 @@ export type GrokConfig = Record<string, never>;
 
 export type GroupRole = "text";
 
+/**
+ *  How each page is encoded inside a CBZ archive. Every variant is also an
+ *  importable format, so an exported archive can be opened again as a project.
+ */
+export type ImageEncoding = "png" | "jpeg" | "webp";
+
 export type InpaintingModel = { model: "lama" } | { model: "aot-inpainting" } | {
 	model: "flux2-klein",
 } & Flux2KleinConfig | {
@@ -268,6 +283,7 @@ export type InpaintingModel = { model: "lama" } | { model: "aot-inpainting" } | 
 
 export type Job = {
 	id: JobId,
+	kind: JobKind,
 	state: JobState,
 	completed: number,
 	total: number,
@@ -278,6 +294,9 @@ export type Job = {
 };
 
 export type JobId = string;
+
+/**  What kind of work a job represents, so the activity view can describe it. */
+export type JobKind = "processing" | "export";
 
 export type JobState = "running" | "finished" | "failed" | "stopped";
 
@@ -404,6 +423,7 @@ export type Preferences = {
 	pipeline: PipelineConfig,
 	providers: ProviderPreferences,
 	typesetting: TypesettingConfig,
+	export: ExportConfig,
 	languages: LanguageChoice[],
 };
 

--- a/packages/koharu/components/app/ExportCbzDialog.tsx
+++ b/packages/koharu/components/app/ExportCbzDialog.tsx
@@ -1,0 +1,79 @@
+'use client'
+
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { cbzEncodings } from '@/lib/export'
+import type { ImageEncoding } from '@koharu/bridge/protocol'
+import { Button } from '@koharu/ui/components/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@koharu/ui/components/dialog'
+import { Label } from '@koharu/ui/components/label'
+import { RadioGroup, RadioGroupItem } from '@koharu/ui/components/radio-group'
+
+export function ExportCbzDialog({
+  open,
+  onOpenChange,
+  onConfirm,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onConfirm: (encoding: ImageEncoding) => void
+}) {
+  const { t } = useTranslation()
+  const [encoding, setEncoding] = useState<ImageEncoding>('png')
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className='max-w-sm gap-4 p-5'>
+        <DialogHeader className='gap-1'>
+          <DialogTitle className='text-[15px]'>{t('export.cbzTitle')}</DialogTitle>
+          <DialogDescription className='text-[11px]'>
+            {t('export.cbzDescription')}
+          </DialogDescription>
+        </DialogHeader>
+        <RadioGroup
+          value={encoding}
+          onValueChange={(value) => setEncoding(value as ImageEncoding)}
+          aria-label={t('export.cbzTitle')}
+        >
+          {cbzEncodings.map((option) => (
+            <Label
+              key={option}
+              className='flex items-start gap-2.5 rounded-lg border border-border/80 p-3 has-[[data-checked]]:border-primary'
+            >
+              <RadioGroupItem value={option} className='mt-0.5' />
+              <span className='grid gap-0.5'>
+                <span className='text-[12px] font-medium'>{t(`export.format.${option}`)}</span>
+                <span className='text-[10px] leading-4 font-normal text-muted-foreground'>
+                  {t(`export.formatHint.${option}`)}
+                </span>
+              </span>
+            </Label>
+          ))}
+        </RadioGroup>
+        <DialogFooter>
+          <Button type='button' variant='ghost' size='sm' onClick={() => onOpenChange(false)}>
+            {t('common.cancel')}
+          </Button>
+          <Button
+            type='button'
+            size='sm'
+            onClick={() => {
+              onOpenChange(false)
+              onConfirm(encoding)
+            }}
+          >
+            {t('export.start')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/packages/koharu/components/app/TitleBar.tsx
+++ b/packages/koharu/components/app/TitleBar.tsx
@@ -7,6 +7,7 @@ import { useState, type ComponentProps } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { AboutDialog } from '@/components/app/AboutDialog'
+import { ExportCbzDialog } from '@/components/app/ExportCbzDialog'
 import { useMacOS, WindowControls } from '@/components/app/WindowChrome'
 import { call } from '@/lib/backend'
 import { selectableLayer } from '@/lib/geometry'
@@ -39,6 +40,7 @@ import { cn } from '@koharu/ui/lib/utils'
 export function TitleBar() {
   const { t } = useTranslation()
   const [aboutOpen, setAboutOpen] = useState(false)
+  const [cbzOpen, setCbzOpen] = useState(false)
   const macOS = useMacOS()
   const project = useProject().data
   const pagesQuery = usePages(Boolean(project))
@@ -102,22 +104,39 @@ export function TitleBar() {
                   </MenubarItem>
                 </MenubarSubContent>
               </MenubarSub>
-              <MenubarItem
-                disabled={!project || pages.length === 0}
-                onClick={() =>
-                  void call(commands.exportPages, exportSelection(selectedPages, page?.id), 'png')
-                }
-              >
-                {t('menu.exportPng')}
-              </MenubarItem>
-              <MenubarItem
-                disabled={!project || pages.length === 0}
-                onClick={() =>
-                  void call(commands.exportPages, exportSelection(selectedPages, page?.id), 'psd')
-                }
-              >
-                {t('menu.exportPsd')}
-              </MenubarItem>
+              <MenubarSub>
+                <MenubarSubTrigger
+                  disabled={!project || pages.length === 0}
+                  className='min-h-8 gap-1.5 px-2 py-1 text-xs'
+                >
+                  {t('menu.export')}
+                </MenubarSubTrigger>
+                <MenubarSubContent className='min-w-40 p-1'>
+                  <MenubarItem
+                    onClick={() =>
+                      void call(
+                        commands.exportPages,
+                        exportSelection(selectedPages, page?.id),
+                        'png',
+                      )
+                    }
+                  >
+                    {t('menu.exportPng')}
+                  </MenubarItem>
+                  <MenubarItem
+                    onClick={() =>
+                      void call(
+                        commands.exportPages,
+                        exportSelection(selectedPages, page?.id),
+                        'psd',
+                      )
+                    }
+                  >
+                    {t('menu.exportPsd')}
+                  </MenubarItem>
+                  <MenubarItem onClick={() => setCbzOpen(true)}>{t('menu.exportCbz')}</MenubarItem>
+                </MenubarSubContent>
+              </MenubarSub>
               <MenubarSeparator />
               <MenubarItem disabled={!project} onClick={closeProject}>
                 {t('menu.closeProject')}
@@ -271,6 +290,11 @@ export function TitleBar() {
         {!macOS && <WindowControls />}
       </header>
       <AboutDialog open={aboutOpen} onOpenChange={setAboutOpen} />
+      <ExportCbzDialog
+        open={cbzOpen}
+        onOpenChange={setCbzOpen}
+        onConfirm={(encoding) => void call(commands.exportPages, [], { cbz: encoding })}
+      />
     </>
   )
 }

--- a/packages/koharu/components/editor/ActivityCenter.tsx
+++ b/packages/koharu/components/editor/ActivityCenter.tsx
@@ -76,10 +76,11 @@ function DownloadGroup({ downloads }: { downloads: DownloadState[] }) {
 function JobItem({ job }: { job: Job }) {
   const { t } = useTranslation()
   const dismiss = useKoharuStore((state) => state.dismissJob)
+  const exporting = job.kind === 'export'
   if (job.state === 'failed') {
     return (
       <Failure
-        message={job.error || t('activity.processingFailed')}
+        message={job.error || t(exporting ? 'activity.exportFailed' : 'activity.processingFailed')}
         onDismiss={() => dismiss(job.id)}
       />
     )
@@ -91,11 +92,15 @@ function JobItem({ job }: { job: Job }) {
         <span className='mt-1.5 size-1.5 justify-self-center rounded-full bg-primary' />
         <div className='min-w-0'>
           <span className='block truncate text-[12px] font-medium capitalize'>
-            {job.stage
-              ? t(`phase.${job.stage}`, { defaultValue: job.stage })
-              : t('activity.processing')}
+            {exporting
+              ? t('activity.exporting')
+              : job.stage
+                ? t(`phase.${job.stage}`, { defaultValue: job.stage })
+                : t('activity.processing')}
           </span>
-          <p className='mt-0.5 truncate text-[10px] text-muted-foreground'>{job.model}</p>
+          <p className='mt-0.5 truncate text-[10px] text-muted-foreground'>
+            {exporting ? `${job.completed} / ${job.total}` : job.model}
+          </p>
         </div>
         <span className='pt-0.5 text-right text-[10px] tabular-nums'>
           {percent !== null ? `${percent}%` : null}

--- a/packages/koharu/components/editor/InferenceControl.tsx
+++ b/packages/koharu/components/editor/InferenceControl.tsx
@@ -146,7 +146,12 @@ function RuntimeSelector({
         model: modelSelection(next),
       },
     }
-    void savePreferences(pipeline, preferences.providers, preferences.typesetting)
+    void savePreferences(
+      pipeline,
+      preferences.providers,
+      preferences.typesetting,
+      preferences.export,
+    )
       .then((saved) => {
         receivePreferences(saved)
       })
@@ -170,7 +175,12 @@ function RuntimeSelector({
         instructions: draft.instructions || null,
       },
     }
-    void savePreferences(pipeline, preferences.providers, preferences.typesetting)
+    void savePreferences(
+      pipeline,
+      preferences.providers,
+      preferences.typesetting,
+      preferences.export,
+    )
       .then((saved) => {
         receivePreferences(saved)
       })

--- a/packages/koharu/components/preferences/ExportPreferences.tsx
+++ b/packages/koharu/components/preferences/ExportPreferences.tsx
@@ -1,0 +1,65 @@
+'use client'
+
+import { useTranslation } from 'react-i18next'
+
+import {
+  NumberField,
+  PreferencePage,
+  PreferenceRow,
+  PreferenceSection,
+} from '@/components/preferences/PreferenceFields'
+import { defaultExportQuality } from '@/lib/export'
+import type { ExportConfig } from '@koharu/bridge/protocol'
+
+export function ExportPreferences({
+  value,
+  onChange,
+}: {
+  value: ExportConfig
+  onChange: (value: ExportConfig) => void
+}) {
+  const { t } = useTranslation()
+
+  return (
+    <PreferencePage
+      title={t('settings.export.title')}
+      description={t('settings.export.description')}
+    >
+      <PreferenceSection
+        title={t('settings.export.quality')}
+        description={t('settings.export.qualityDescription')}
+      >
+        <PreferenceRow
+          title={t('settings.export.jpegQuality')}
+          description={t('settings.export.jpegQualityDescription')}
+        >
+          <NumberField
+            label={t('settings.export.qualityLabel')}
+            value={value.jpeg_quality ?? defaultExportQuality.jpeg}
+            min={1}
+            max={100}
+            step={1}
+            onChange={(quality) =>
+              onChange({ ...value, jpeg_quality: quality ?? defaultExportQuality.jpeg })
+            }
+          />
+        </PreferenceRow>
+        <PreferenceRow
+          title={t('settings.export.webpQuality')}
+          description={t('settings.export.webpQualityDescription')}
+        >
+          <NumberField
+            label={t('settings.export.qualityLabel')}
+            value={value.webp_quality ?? defaultExportQuality.webp}
+            min={1}
+            max={100}
+            step={1}
+            onChange={(quality) =>
+              onChange({ ...value, webp_quality: quality ?? defaultExportQuality.webp })
+            }
+          />
+        </PreferenceRow>
+      </PreferenceSection>
+    </PreferencePage>
+  )
+}

--- a/packages/koharu/components/preferences/SettingsPage.tsx
+++ b/packages/koharu/components/preferences/SettingsPage.tsx
@@ -3,6 +3,7 @@
 import {
   ArrowLeft,
   Cpu,
+  FileDown,
   KeyRound,
   Keyboard,
   Languages,
@@ -16,6 +17,7 @@ import { useTheme } from 'next-themes'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { ExportPreferences } from '@/components/preferences/ExportPreferences'
 import { PipelinePreferences } from '@/components/preferences/PipelinePreferences'
 import {
   PreferencePage,
@@ -29,6 +31,7 @@ import { refreshPreferences, refreshTranslationModels, savePreferences } from '@
 import { supportedLanguages } from '@/lib/i18n'
 import { receivePreferences, useKoharuStore, type ShortcutAction } from '@/lib/store'
 import {
+  type ExportConfig,
   type PipelineConfig,
   type Preferences,
   type ProviderPreferences as ProviderSettings,
@@ -51,6 +54,7 @@ const tabs = [
   ['providers', KeyRound],
   ['translation', Languages],
   ['typesetting', Type],
+  ['export', FileDown],
   ['shortcuts', Keyboard],
 ] as const
 type Tab = (typeof tabs)[number][0]
@@ -69,6 +73,7 @@ export function SettingsPage() {
   const [typesetting, setTypesetting] = useState<TypesettingConfig | null>(
     preferences?.typesetting ?? null,
   )
+  const [exportConfig, setExportConfig] = useState<ExportConfig | null>(preferences?.export ?? null)
   const translation = pipeline?.translation ?? null
   const lastSaved = useRef<string | null>(null)
   const lastSavedProviders = useRef<string | null>(null)
@@ -77,15 +82,18 @@ export function SettingsPage() {
   const lastPending = useRef<{ serialized: string; promise: Promise<Preferences> } | null>(null)
   const currentDraft = useRef<string | null>(null)
   currentDraft.current =
-    pipeline && providers && typesetting ? JSON.stringify([pipeline, providers, typesetting]) : null
+    pipeline && providers && typesetting && exportConfig
+      ? JSON.stringify([pipeline, providers, typesetting, exportConfig])
+      : null
 
   const saveDraft = useCallback(
     async (
       pipeline: PipelineConfig,
       providers: ProviderSettings,
       typesetting: TypesettingConfig,
+      exportConfig: ExportConfig,
     ) => {
-      const serialized = JSON.stringify([pipeline, providers, typesetting])
+      const serialized = JSON.stringify([pipeline, providers, typesetting, exportConfig])
       if (serialized === lastSaved.current) {
         const pending = lastPending.current
         if (pending?.serialized === serialized) await pending.promise
@@ -97,7 +105,7 @@ export function SettingsPage() {
       const generation = ++saveGeneration.current
       const pending = saveQueue.current
         .catch(() => undefined)
-        .then(() => savePreferences(pipeline, providers, typesetting))
+        .then(() => savePreferences(pipeline, providers, typesetting, exportConfig))
       lastPending.current = { serialized, promise: pending }
       saveQueue.current = pending.then(
         () => undefined,
@@ -131,25 +139,27 @@ export function SettingsPage() {
     setPipeline(preferences?.pipeline ?? null)
     setProviders(preferences?.providers ?? null)
     setTypesetting(preferences?.typesetting ?? null)
+    setExportConfig(preferences?.export ?? null)
     if (preferences) {
       lastSaved.current = JSON.stringify([
         preferences.pipeline,
         preferences.providers,
         preferences.typesetting,
+        preferences.export,
       ])
       lastSavedProviders.current = JSON.stringify(preferences.providers)
     }
   }, [open, preferences])
 
   useEffect(() => {
-    if (!open || !pipeline || !providers || !typesetting) return
-    const serialized = JSON.stringify([pipeline, providers, typesetting])
+    if (!open || !pipeline || !providers || !typesetting || !exportConfig) return
+    const serialized = JSON.stringify([pipeline, providers, typesetting, exportConfig])
     if (serialized === lastSaved.current) return
     const timeout = window.setTimeout(() => {
-      void saveDraft(pipeline, providers, typesetting).catch(() => undefined)
+      void saveDraft(pipeline, providers, typesetting, exportConfig).catch(() => undefined)
     }, 260)
     return () => window.clearTimeout(timeout)
-  }, [open, pipeline, providers, saveDraft, typesetting])
+  }, [exportConfig, open, pipeline, providers, saveDraft, typesetting])
 
   if (!open) return null
 
@@ -161,11 +171,11 @@ export function SettingsPage() {
           variant='ghost'
           className='mb-5 h-9 justify-start gap-2 rounded-lg px-2 text-[12px] text-muted-foreground hover:bg-foreground/[0.06] hover:text-foreground'
           onClick={() => {
-            if (!pipeline || !providers || !typesetting) {
+            if (!pipeline || !providers || !typesetting || !exportConfig) {
               setOpen(false)
               return
             }
-            void saveDraft(pipeline, providers, typesetting)
+            void saveDraft(pipeline, providers, typesetting, exportConfig)
               .then(() => setOpen(false))
               .catch(() => undefined)
           }}
@@ -227,6 +237,12 @@ export function SettingsPage() {
             {tab === 'typesetting' &&
               (typesetting ? (
                 <TypesettingPreferences value={typesetting} onChange={setTypesetting} />
+              ) : (
+                <LoadingPreferences />
+              ))}
+            {tab === 'export' &&
+              (exportConfig ? (
+                <ExportPreferences value={exportConfig} onChange={setExportConfig} />
               ) : (
                 <LoadingPreferences />
               ))}

--- a/packages/koharu/lib/backend.ts
+++ b/packages/koharu/lib/backend.ts
@@ -2,6 +2,7 @@
 
 import { commands } from '@koharu/bridge/protocol'
 import type {
+  ExportConfig,
   PipelineConfig,
   Preferences,
   ProviderPreferences,
@@ -46,11 +47,12 @@ export function savePreferences(
   pipeline: PipelineConfig,
   providers: ProviderPreferences,
   typesetting: TypesettingConfig,
+  exportConfig: ExportConfig,
 ): Promise<Preferences> {
   preferencesWriteGeneration += 1
   const pending = preferencesWriteQueue
     .catch(() => undefined)
-    .then(() => call(commands.savePreferences, pipeline, providers, typesetting))
+    .then(() => call(commands.savePreferences, pipeline, providers, typesetting, exportConfig))
   preferencesWriteQueue = pending.then(
     () => undefined,
     () => undefined,

--- a/packages/koharu/lib/export.ts
+++ b/packages/koharu/lib/export.ts
@@ -1,0 +1,11 @@
+import type { ImageEncoding } from '@koharu/bridge/protocol'
+
+/// Mirrors `ExportConfig::default()` in `crates/koharu-app/src/commands/output.rs`.
+/// The stored fields are optional because the section is serde-defaulted, so the
+/// UI needs a value to show before the user has ever saved one.
+export const defaultExportQuality = {
+  jpeg: 90,
+  webp: 85,
+} as const
+
+export const cbzEncodings: readonly ImageEncoding[] = ['png', 'jpeg', 'webp']

--- a/packages/koharu/public/locales/en-US/translation.json
+++ b/packages/koharu/public/locales/en-US/translation.json
@@ -11,6 +11,8 @@
     "downloadingFiles": "Downloading {{count}} files",
     "downloadingFiles_one": "Downloading {{count}} file",
     "downloadingFiles_other": "Downloading {{count}} files",
+    "exportFailed": "Export failed.",
+    "exporting": "Exporting",
     "modelDownload": "Model download",
     "processing": "Processing",
     "processingFailed": "Processing failed.",
@@ -74,6 +76,21 @@
   "errors": {
     "fatalTitle": "Koharu could not continue",
     "tryAgain": "Try again"
+  },
+  "export": {
+    "cbzTitle": "Export CBZ",
+    "cbzDescription": "Choose how the pages inside the archive are encoded.",
+    "start": "Export",
+    "format": {
+      "png": "PNG",
+      "jpeg": "JPEG",
+      "webp": "WebP"
+    },
+    "formatHint": {
+      "png": "Lossless. Largest files.",
+      "jpeg": "Smallest files. Transparency is flattened onto white.",
+      "webp": "Smaller than PNG and keeps transparency."
+    }
   },
   "fontPicker": {
     "activeFilterCount": "{{count}} active filters",
@@ -245,8 +262,10 @@
     "delete": "Delete Selected",
     "discord": "Discord",
     "edit": "Edit",
-    "exportPng": "Export PNG…",
-    "exportPsd": "Export PSD…",
+    "export": "Export",
+    "exportCbz": "CBZ (All Pages)…",
+    "exportPng": "PNG…",
+    "exportPsd": "PSD…",
     "file": "File",
     "fit": "Fit Window",
     "github": "GitHub",
@@ -359,6 +378,17 @@
       "title": "Appearance"
     },
     "backToEditor": "Back to editor",
+    "export": {
+      "title": "Export",
+      "description": "Control how pages are encoded when you export an archive.",
+      "quality": "Archive quality",
+      "qualityDescription": "Applies to the lossy formats offered when exporting a CBZ. PNG is always lossless.",
+      "qualityLabel": "Quality",
+      "jpegQuality": "JPEG quality",
+      "jpegQualityDescription": "1-100. Higher keeps screentone cleaner and files larger.",
+      "webpQuality": "WebP quality",
+      "webpQualityDescription": "1-100. Higher keeps screentone cleaner and files larger."
+    },
     "generation": {
       "description": "Fine-tune how language models generate translated text.",
       "enableReasoning": "Enable reasoning",
@@ -425,6 +455,7 @@
     },
     "tabs": {
       "appearance": "Appearance",
+      "export": "Export",
       "pipeline": "Pipeline",
       "providers": "Providers",
       "shortcuts": "Shortcuts",

--- a/packages/koharu/public/locales/es-ES/translation.json
+++ b/packages/koharu/public/locales/es-ES/translation.json
@@ -11,6 +11,8 @@
     "downloadingFiles": "Descargando {{count}} archivos",
     "downloadingFiles_one": "Descargando {{count}} archivos",
     "downloadingFiles_other": "Descargando {{count}} archivos",
+    "exportFailed": "Error de exportación.",
+    "exporting": "Exportando",
     "modelDownload": "Descarga del modelo",
     "processing": "Procesando",
     "processingFailed": "Error de procesamiento.",
@@ -74,6 +76,21 @@
   "errors": {
     "fatalTitle": "Koharu no pudo continuar",
     "tryAgain": "Intentar de nuevo"
+  },
+  "export": {
+    "cbzTitle": "Exportar CBZ",
+    "cbzDescription": "Elige cómo se codifican las páginas dentro del archivo.",
+    "start": "Exportar",
+    "format": {
+      "png": "PNG",
+      "jpeg": "JPEG",
+      "webp": "WebP"
+    },
+    "formatHint": {
+      "png": "Sin pérdidas. Archivos más grandes.",
+      "jpeg": "Archivos más pequeños. La transparencia se aplana sobre blanco.",
+      "webp": "Más pequeño que PNG y conserva la transparencia."
+    }
   },
   "fontPicker": {
     "activeFilterCount": "{{count}} filtros activos",
@@ -245,8 +262,10 @@
     "delete": "Eliminar selección",
     "discord": "Discord",
     "edit": "Editar",
-    "exportPng": "Exportar PNG…",
-    "exportPsd": "Exportar PSD…",
+    "export": "Exportar",
+    "exportCbz": "CBZ (todas las páginas)…",
+    "exportPng": "PNG…",
+    "exportPsd": "PSD…",
     "file": "Archivo",
     "fit": "Ajustar a la ventana",
     "github": "GitHub",
@@ -359,6 +378,17 @@
       "title": "Apariencia"
     },
     "backToEditor": "Volver al editor",
+    "export": {
+      "title": "Exportación",
+      "description": "Controla cómo se codifican las páginas al exportar un archivo.",
+      "quality": "Calidad del archivo",
+      "qualityDescription": "Se aplica a los formatos con pérdidas al exportar un CBZ. PNG siempre es sin pérdidas.",
+      "qualityLabel": "Calidad",
+      "jpegQuality": "Calidad JPEG",
+      "jpegQualityDescription": "1-100. Un valor mayor conserva mejor las tramas y aumenta el tamaño.",
+      "webpQuality": "Calidad WebP",
+      "webpQualityDescription": "1-100. Un valor mayor conserva mejor las tramas y aumenta el tamaño."
+    },
     "generation": {
       "description": "Ajusta cómo los modelos de lenguaje generan el texto traducido.",
       "enableReasoning": "Activar razonamiento",
@@ -425,6 +455,7 @@
     },
     "tabs": {
       "appearance": "Apariencia",
+      "export": "Exportación",
       "pipeline": "Canalización",
       "providers": "Proveedores",
       "shortcuts": "Atajos",

--- a/packages/koharu/public/locales/ja-JP/translation.json
+++ b/packages/koharu/public/locales/ja-JP/translation.json
@@ -11,6 +11,8 @@
     "downloadingFiles": "{{count}}件のファイルをダウンロード中",
     "downloadingFiles_one": "{{count}}件のファイルをダウンロード中",
     "downloadingFiles_other": "{{count}}件のファイルをダウンロード中",
+    "exportFailed": "書き出しに失敗しました。",
+    "exporting": "書き出し中",
     "modelDownload": "モデルのダウンロード",
     "processing": "処理中",
     "processingFailed": "処理に失敗しました。",
@@ -74,6 +76,21 @@
   "errors": {
     "fatalTitle": "Koharuを続行できませんでした",
     "tryAgain": "再試行"
+  },
+  "export": {
+    "cbzTitle": "CBZを書き出す",
+    "cbzDescription": "アーカイブ内のページの形式を選択します。",
+    "start": "書き出す",
+    "format": {
+      "png": "PNG",
+      "jpeg": "JPEG",
+      "webp": "WebP"
+    },
+    "formatHint": {
+      "png": "可逆圧縮。ファイルは最大です。",
+      "jpeg": "ファイルは最小です。透明部分は白で塗り潰されます。",
+      "webp": "PNGより小さく、透明部分を保持します。"
+    }
   },
   "fontPicker": {
     "activeFilterCount": "有効なフィルター: {{count}}件",
@@ -245,8 +262,10 @@
     "delete": "選択項目を削除",
     "discord": "Discord",
     "edit": "編集",
-    "exportPng": "PNGを書き出す…",
-    "exportPsd": "PSDを書き出す…",
+    "export": "書き出す",
+    "exportCbz": "CBZ（全ページ）…",
+    "exportPng": "PNG…",
+    "exportPsd": "PSD…",
     "file": "ファイル",
     "fit": "ウィンドウに合わせる",
     "github": "GitHub",
@@ -359,6 +378,17 @@
       "title": "外観"
     },
     "backToEditor": "エディターに戻る",
+    "export": {
+      "title": "書き出し",
+      "description": "アーカイブを書き出すときのページの符号化方法を設定します。",
+      "quality": "アーカイブの品質",
+      "qualityDescription": "CBZ書き出し時の非可逆形式に適用されます。PNGは常に可逆です。",
+      "qualityLabel": "品質",
+      "jpegQuality": "JPEG品質",
+      "jpegQualityDescription": "1〜100。高いほどスクリーントーンが綺麗になり、ファイルは大きくなります。",
+      "webpQuality": "WebP品質",
+      "webpQualityDescription": "1〜100。高いほどスクリーントーンが綺麗になり、ファイルは大きくなります。"
+    },
     "generation": {
       "description": "言語モデルによる翻訳文の生成方法を調整します。",
       "enableReasoning": "推論を有効化",
@@ -425,6 +455,7 @@
     },
     "tabs": {
       "appearance": "外観",
+      "export": "書き出し",
       "pipeline": "パイプライン",
       "providers": "プロバイダー",
       "shortcuts": "ショートカット",

--- a/packages/koharu/public/locales/ko-KR/translation.json
+++ b/packages/koharu/public/locales/ko-KR/translation.json
@@ -11,6 +11,8 @@
     "downloadingFiles": "{{count}}개 파일 다운로드 중",
     "downloadingFiles_one": "{{count}}개 파일 다운로드 중",
     "downloadingFiles_other": "{{count}}개 파일 다운로드 중",
+    "exportFailed": "내보내기에 실패했습니다.",
+    "exporting": "내보내는 중",
     "modelDownload": "모델 다운로드",
     "processing": "처리 중",
     "processingFailed": "처리에 실패했습니다.",
@@ -74,6 +76,21 @@
   "errors": {
     "fatalTitle": "Koharu를 계속 실행할 수 없습니다",
     "tryAgain": "다시 시도"
+  },
+  "export": {
+    "cbzTitle": "CBZ 내보내기",
+    "cbzDescription": "아카이브 안의 페이지를 어떤 형식으로 저장할지 선택하세요.",
+    "start": "내보내기",
+    "format": {
+      "png": "PNG",
+      "jpeg": "JPEG",
+      "webp": "WebP"
+    },
+    "formatHint": {
+      "png": "무손실. 파일이 가장 큽니다.",
+      "jpeg": "파일이 가장 작습니다. 투명도는 흰색으로 합성됩니다.",
+      "webp": "PNG보다 작고 투명도를 유지합니다."
+    }
   },
   "fontPicker": {
     "activeFilterCount": "활성 필터 {{count}}개",
@@ -245,8 +262,10 @@
     "delete": "선택 항목 삭제",
     "discord": "Discord",
     "edit": "편집",
-    "exportPng": "PNG 내보내기…",
-    "exportPsd": "PSD 내보내기…",
+    "export": "내보내기",
+    "exportCbz": "CBZ(모든 페이지)…",
+    "exportPng": "PNG…",
+    "exportPsd": "PSD…",
     "file": "파일",
     "fit": "창에 맞춤",
     "github": "GitHub",
@@ -359,6 +378,17 @@
       "title": "모양"
     },
     "backToEditor": "편집기로 돌아가기",
+    "export": {
+      "title": "내보내기",
+      "description": "아카이브를 내보낼 때 페이지를 인코딩하는 방식을 설정합니다.",
+      "quality": "아카이브 품질",
+      "qualityDescription": "CBZ 내보내기의 손실 형식에 적용됩니다. PNG는 항상 무손실입니다.",
+      "qualityLabel": "품질",
+      "jpegQuality": "JPEG 품질",
+      "jpegQualityDescription": "1~100. 높을수록 스크린톤이 깨끗하고 파일이 커집니다.",
+      "webpQuality": "WebP 품질",
+      "webpQualityDescription": "1~100. 높을수록 스크린톤이 깨끗하고 파일이 커집니다."
+    },
     "generation": {
       "description": "언어 모델이 번역문을 생성하는 방식을 조정합니다.",
       "enableReasoning": "추론 활성화",
@@ -425,6 +455,7 @@
     },
     "tabs": {
       "appearance": "모양",
+      "export": "내보내기",
       "pipeline": "파이프라인",
       "providers": "제공자",
       "shortcuts": "단축키",

--- a/packages/koharu/public/locales/pt-BR/translation.json
+++ b/packages/koharu/public/locales/pt-BR/translation.json
@@ -11,6 +11,8 @@
     "downloadingFiles": "Baixando {{count}} arquivos",
     "downloadingFiles_one": "Baixando {{count}} arquivos",
     "downloadingFiles_other": "Baixando {{count}} arquivos",
+    "exportFailed": "Falha na exportação.",
+    "exporting": "Exportando",
     "modelDownload": "Download do modelo",
     "processing": "Processando",
     "processingFailed": "Falha no processamento.",
@@ -74,6 +76,21 @@
   "errors": {
     "fatalTitle": "O Koharu não pôde continuar",
     "tryAgain": "Tentar novamente"
+  },
+  "export": {
+    "cbzTitle": "Exportar CBZ",
+    "cbzDescription": "Escolha como as páginas dentro do arquivo são codificadas.",
+    "start": "Exportar",
+    "format": {
+      "png": "PNG",
+      "jpeg": "JPEG",
+      "webp": "WebP"
+    },
+    "formatHint": {
+      "png": "Sem perdas. Arquivos maiores.",
+      "jpeg": "Arquivos menores. A transparência é achatada sobre branco.",
+      "webp": "Menor que PNG e mantém a transparência."
+    }
   },
   "fontPicker": {
     "activeFilterCount": "{{count}} filtros ativos",
@@ -245,8 +262,10 @@
     "delete": "Excluir seleção",
     "discord": "Discord",
     "edit": "Editar",
-    "exportPng": "Exportar PNG…",
-    "exportPsd": "Exportar PSD…",
+    "export": "Exportar",
+    "exportCbz": "CBZ (todas as páginas)…",
+    "exportPng": "PNG…",
+    "exportPsd": "PSD…",
     "file": "Arquivo",
     "fit": "Ajustar à janela",
     "github": "GitHub",
@@ -359,6 +378,17 @@
       "title": "Aparência"
     },
     "backToEditor": "Voltar ao editor",
+    "export": {
+      "title": "Exportação",
+      "description": "Controle como as páginas são codificadas ao exportar um arquivo.",
+      "quality": "Qualidade do arquivo",
+      "qualityDescription": "Vale para os formatos com perdas ao exportar um CBZ. PNG é sempre sem perdas.",
+      "qualityLabel": "Qualidade",
+      "jpegQuality": "Qualidade JPEG",
+      "jpegQualityDescription": "1-100. Valores altos preservam melhor as retículas e aumentam o tamanho.",
+      "webpQuality": "Qualidade WebP",
+      "webpQualityDescription": "1-100. Valores altos preservam melhor as retículas e aumentam o tamanho."
+    },
     "generation": {
       "description": "Ajuste como os modelos de linguagem geram o texto traduzido.",
       "enableReasoning": "Ativar raciocínio",
@@ -425,6 +455,7 @@
     },
     "tabs": {
       "appearance": "Aparência",
+      "export": "Exportação",
       "pipeline": "Pipeline",
       "providers": "Provedores",
       "shortcuts": "Atalhos",

--- a/packages/koharu/public/locales/ru-RU/translation.json
+++ b/packages/koharu/public/locales/ru-RU/translation.json
@@ -11,6 +11,8 @@
     "downloadingFiles": "Скачивание файлов: {{count}}",
     "downloadingFiles_one": "Скачивание файлов: {{count}}",
     "downloadingFiles_other": "Скачивание файлов: {{count}}",
+    "exportFailed": "Ошибка экспорта.",
+    "exporting": "Экспорт",
     "modelDownload": "Скачивание модели",
     "processing": "Обработка",
     "processingFailed": "Ошибка обработки.",
@@ -74,6 +76,21 @@
   "errors": {
     "fatalTitle": "Koharu не может продолжить работу",
     "tryAgain": "Повторить"
+  },
+  "export": {
+    "cbzTitle": "Экспорт CBZ",
+    "cbzDescription": "Выберите, как кодировать страницы внутри архива.",
+    "start": "Экспорт",
+    "format": {
+      "png": "PNG",
+      "jpeg": "JPEG",
+      "webp": "WebP"
+    },
+    "formatHint": {
+      "png": "Без потерь. Самые большие файлы.",
+      "jpeg": "Самые маленькие файлы. Прозрачность сводится на белый.",
+      "webp": "Меньше PNG и сохраняет прозрачность."
+    }
   },
   "fontPicker": {
     "activeFilterCount": "Активных фильтров: {{count}}",
@@ -245,8 +262,10 @@
     "delete": "Удалить выбранное",
     "discord": "Discord",
     "edit": "Правка",
-    "exportPng": "Экспорт PNG…",
-    "exportPsd": "Экспорт PSD…",
+    "export": "Экспорт",
+    "exportCbz": "CBZ (все страницы)…",
+    "exportPng": "PNG…",
+    "exportPsd": "PSD…",
     "file": "Файл",
     "fit": "Вписать в окно",
     "github": "GitHub",
@@ -359,6 +378,17 @@
       "title": "Оформление"
     },
     "backToEditor": "Вернуться в редактор",
+    "export": {
+      "title": "Экспорт",
+      "description": "Настройте кодирование страниц при экспорте архива.",
+      "quality": "Качество архива",
+      "qualityDescription": "Применяется к форматам с потерями при экспорте CBZ. PNG всегда без потерь.",
+      "qualityLabel": "Качество",
+      "jpegQuality": "Качество JPEG",
+      "jpegQualityDescription": "1-100. Выше — чище растр и больше файл.",
+      "webpQuality": "Качество WebP",
+      "webpQualityDescription": "1-100. Выше — чище растр и больше файл."
+    },
     "generation": {
       "description": "Настройте генерацию переведённого текста языковыми моделями.",
       "enableReasoning": "Включить рассуждение",
@@ -425,6 +455,7 @@
     },
     "tabs": {
       "appearance": "Оформление",
+      "export": "Экспорт",
       "pipeline": "Конвейер",
       "providers": "Провайдеры",
       "shortcuts": "Сочетания клавиш",

--- a/packages/koharu/public/locales/tr-TR/translation.json
+++ b/packages/koharu/public/locales/tr-TR/translation.json
@@ -11,6 +11,8 @@
     "downloadingFiles": "{{count}} dosya indiriliyor",
     "downloadingFiles_one": "{{count}} dosya indiriliyor",
     "downloadingFiles_other": "{{count}} dosya indiriliyor",
+    "exportFailed": "Dışa aktarma başarısız oldu.",
+    "exporting": "Dışa aktarılıyor",
     "modelDownload": "Model indirme",
     "processing": "İşleniyor",
     "processingFailed": "İşleme başarısız oldu.",
@@ -74,6 +76,21 @@
   "errors": {
     "fatalTitle": "Koharu devam edemedi",
     "tryAgain": "Tekrar dene"
+  },
+  "export": {
+    "cbzTitle": "CBZ Dışa Aktar",
+    "cbzDescription": "Arşivdeki sayfaların nasıl kodlanacağını seçin.",
+    "start": "Dışa Aktar",
+    "format": {
+      "png": "PNG",
+      "jpeg": "JPEG",
+      "webp": "WebP"
+    },
+    "formatHint": {
+      "png": "Kayıpsız. En büyük dosyalar.",
+      "jpeg": "En küçük dosyalar. Saydamlık beyaz üzerine düzleştirilir.",
+      "webp": "PNG'den küçük ve saydamlığı korur."
+    }
   },
   "fontPicker": {
     "activeFilterCount": "{{count}} etkin filtre",
@@ -245,8 +262,10 @@
     "delete": "Seçilenleri Sil",
     "discord": "Discord",
     "edit": "Düzenle",
-    "exportPng": "PNG Dışa Aktar…",
-    "exportPsd": "PSD Dışa Aktar…",
+    "export": "Dışa Aktar",
+    "exportCbz": "CBZ (Tüm Sayfalar)…",
+    "exportPng": "PNG…",
+    "exportPsd": "PSD…",
     "file": "Dosya",
     "fit": "Pencereye Sığdır",
     "github": "GitHub",
@@ -359,6 +378,17 @@
       "title": "Görünüm"
     },
     "backToEditor": "Düzenleyiciye dön",
+    "export": {
+      "title": "Dışa Aktarma",
+      "description": "Bir arşivi dışa aktarırken sayfaların nasıl kodlanacağını denetleyin.",
+      "quality": "Arşiv kalitesi",
+      "qualityDescription": "CBZ dışa aktarımındaki kayıplı biçimler için geçerlidir. PNG her zaman kayıpsızdır.",
+      "qualityLabel": "Kalite",
+      "jpegQuality": "JPEG kalitesi",
+      "jpegQualityDescription": "1-100. Yüksek değer tramları korur ve dosyayı büyütür.",
+      "webpQuality": "WebP kalitesi",
+      "webpQualityDescription": "1-100. Yüksek değer tramları korur ve dosyayı büyütür."
+    },
     "generation": {
       "description": "Dil modellerinin çevrilmiş metni nasıl ürettiğini ayarlayın.",
       "enableReasoning": "Akıl yürütmeyi etkinleştir",
@@ -425,6 +455,7 @@
     },
     "tabs": {
       "appearance": "Görünüm",
+      "export": "Dışa Aktarma",
       "pipeline": "İşlem hattı",
       "providers": "Sağlayıcılar",
       "shortcuts": "Kısayollar",

--- a/packages/koharu/public/locales/zh-CN/translation.json
+++ b/packages/koharu/public/locales/zh-CN/translation.json
@@ -11,6 +11,8 @@
     "downloadingFiles": "正在下载 {{count}} 个文件",
     "downloadingFiles_one": "正在下载 {{count}} 个文件",
     "downloadingFiles_other": "正在下载 {{count}} 个文件",
+    "exportFailed": "导出失败。",
+    "exporting": "正在导出",
     "modelDownload": "模型下载",
     "processing": "正在处理",
     "processingFailed": "处理失败。",
@@ -74,6 +76,21 @@
   "errors": {
     "fatalTitle": "Koharu 无法继续运行",
     "tryAgain": "重试"
+  },
+  "export": {
+    "cbzTitle": "导出 CBZ",
+    "cbzDescription": "选择存档内页面的编码方式。",
+    "start": "导出",
+    "format": {
+      "png": "PNG",
+      "jpeg": "JPEG",
+      "webp": "WebP"
+    },
+    "formatHint": {
+      "png": "无损。文件最大。",
+      "jpeg": "文件最小。透明区域会合成到白色上。",
+      "webp": "比 PNG 更小，并保留透明度。"
+    }
   },
   "fontPicker": {
     "activeFilterCount": "{{count}} 个启用的筛选条件",
@@ -245,8 +262,10 @@
     "delete": "删除所选项",
     "discord": "Discord",
     "edit": "编辑",
-    "exportPng": "导出 PNG…",
-    "exportPsd": "导出 PSD…",
+    "export": "导出",
+    "exportCbz": "CBZ（全部页面）…",
+    "exportPng": "PNG…",
+    "exportPsd": "PSD…",
     "file": "文件",
     "fit": "适应窗口",
     "github": "GitHub",
@@ -359,6 +378,17 @@
       "title": "外观"
     },
     "backToEditor": "返回编辑器",
+    "export": {
+      "title": "导出",
+      "description": "控制导出存档时页面的编码方式。",
+      "quality": "存档质量",
+      "qualityDescription": "适用于导出 CBZ 时的有损格式。PNG 始终无损。",
+      "qualityLabel": "质量",
+      "jpegQuality": "JPEG 质量",
+      "jpegQualityDescription": "1-100。数值越高网点越清晰，文件越大。",
+      "webpQuality": "WebP 质量",
+      "webpQualityDescription": "1-100。数值越高网点越清晰，文件越大。"
+    },
     "generation": {
       "description": "微调语言模型生成译文的方式。",
       "enableReasoning": "启用推理",
@@ -425,6 +455,7 @@
     },
     "tabs": {
       "appearance": "外观",
+      "export": "导出",
       "pipeline": "流水线",
       "providers": "提供商",
       "shortcuts": "快捷键",

--- a/packages/koharu/public/locales/zh-TW/translation.json
+++ b/packages/koharu/public/locales/zh-TW/translation.json
@@ -11,6 +11,8 @@
     "downloadingFiles": "正在下載 {{count}} 個檔案",
     "downloadingFiles_one": "正在下載 {{count}} 個檔案",
     "downloadingFiles_other": "正在下載 {{count}} 個檔案",
+    "exportFailed": "匯出失敗。",
+    "exporting": "正在匯出",
     "modelDownload": "模型下載",
     "processing": "正在處理",
     "processingFailed": "處理失敗。",
@@ -74,6 +76,21 @@
   "errors": {
     "fatalTitle": "Koharu 無法繼續執行",
     "tryAgain": "再試一次"
+  },
+  "export": {
+    "cbzTitle": "匯出 CBZ",
+    "cbzDescription": "選擇封存檔中頁面的編碼方式。",
+    "start": "匯出",
+    "format": {
+      "png": "PNG",
+      "jpeg": "JPEG",
+      "webp": "WebP"
+    },
+    "formatHint": {
+      "png": "無損。檔案最大。",
+      "jpeg": "檔案最小。透明區域會合成到白色上。",
+      "webp": "比 PNG 更小，並保留透明度。"
+    }
   },
   "fontPicker": {
     "activeFilterCount": "{{count}} 個啟用的篩選條件",
@@ -245,8 +262,10 @@
     "delete": "刪除所選項目",
     "discord": "Discord",
     "edit": "編輯",
-    "exportPng": "匯出 PNG…",
-    "exportPsd": "匯出 PSD…",
+    "export": "匯出",
+    "exportCbz": "CBZ（所有頁面）…",
+    "exportPng": "PNG…",
+    "exportPsd": "PSD…",
     "file": "檔案",
     "fit": "適應視窗",
     "github": "GitHub",
@@ -359,6 +378,17 @@
       "title": "外觀"
     },
     "backToEditor": "返回編輯器",
+    "export": {
+      "title": "匯出",
+      "description": "控制匯出封存檔時頁面的編碼方式。",
+      "quality": "封存品質",
+      "qualityDescription": "適用於匯出 CBZ 時的有損格式。PNG 一律無損。",
+      "qualityLabel": "品質",
+      "jpegQuality": "JPEG 品質",
+      "jpegQualityDescription": "1-100。數值越高網點越清晰，檔案越大。",
+      "webpQuality": "WebP 品質",
+      "webpQualityDescription": "1-100。數值越高網點越清晰，檔案越大。"
+    },
     "generation": {
       "description": "微調語言模型產生譯文的方式。",
       "enableReasoning": "啟用推理",
@@ -425,6 +455,7 @@
     },
     "tabs": {
       "appearance": "外觀",
+      "export": "匯出",
       "pipeline": "流程",
       "providers": "提供者",
       "shortcuts": "快捷鍵",

--- a/packages/koharu/tests/components/editor-components.test.tsx
+++ b/packages/koharu/tests/components/editor-components.test.tsx
@@ -134,6 +134,7 @@ const preferences: Preferences = {
       },
     ],
   },
+  export: { jpeg_quality: 90, webp_quality: 85 },
   typesetting: {
     font_families: ['Noto Sans'],
   },
@@ -883,6 +884,7 @@ describe('greenfield editor', () => {
         nextPreferences.pipeline,
         preferences.providers,
         preferences.typesetting,
+        preferences.export,
       ),
     )
     expect(
@@ -906,11 +908,12 @@ describe('greenfield editor', () => {
     const user = userEvent.setup()
     const save = vi
       .spyOn(commands, 'savePreferences')
-      .mockImplementation(async (pipeline, providers, typesetting) => ({
+      .mockImplementation(async (pipeline, providers, typesetting, exportConfig) => ({
         ...preferences,
         pipeline,
         providers,
         typesetting,
+        export: exportConfig,
       }))
     render(
       <ThemeProvider attribute='class'>
@@ -1004,6 +1007,7 @@ describe('greenfield editor', () => {
         nextPreferences.pipeline,
         currentPreferences.providers,
         currentPreferences.typesetting,
+        currentPreferences.export,
       ),
     )
     expect(useKoharuStore.getState().preferences?.pipeline.translation).toEqual(
@@ -1059,6 +1063,7 @@ describe('greenfield editor', () => {
         nextPreferences.pipeline,
         preferences.providers,
         preferences.typesetting,
+        preferences.export,
       ),
     )
     expect(useKoharuStore.getState().preferences?.pipeline.translation).toEqual(
@@ -1123,6 +1128,7 @@ describe('greenfield editor', () => {
         }),
         preferences.providers,
         preferences.typesetting,
+        preferences.export,
       ),
     )
     fireEvent.click(screen.getByRole('button', { name: 'Providers' }))
@@ -1151,6 +1157,7 @@ describe('greenfield editor', () => {
         }),
         preferences.providers,
         preferences.typesetting,
+        preferences.export,
       ),
     )
     const vision = screen.getByRole('switch', { name: 'Vision' })
@@ -1167,6 +1174,7 @@ describe('greenfield editor', () => {
         }),
         preferences.providers,
         preferences.typesetting,
+        preferences.export,
       ),
     )
     expect(screen.getByLabelText('Translation model')).toHaveTextContent('Gemma 4 E2B Instruct')
@@ -1249,6 +1257,7 @@ describe('greenfield editor', () => {
         }),
         configured.providers,
         configured.typesetting,
+        configured.export,
       ),
     )
   })
@@ -1356,6 +1365,7 @@ describe('greenfield editor', () => {
         }),
         preferences.providers,
         preferences.typesetting,
+        preferences.export,
       ),
     )
   })
@@ -1484,11 +1494,12 @@ describe('greenfield editor', () => {
     ])
     const save = vi
       .spyOn(commands, 'savePreferences')
-      .mockImplementation(async (pipeline, providers, typesetting) => ({
+      .mockImplementation(async (pipeline, providers, typesetting, exportConfig) => ({
         ...preferences,
         pipeline,
         providers,
         typesetting,
+        export: exportConfig,
       }))
     render(
       <ThemeProvider attribute='class'>
@@ -1502,15 +1513,21 @@ describe('greenfield editor', () => {
     await user.click(await screen.findByRole('option', { name: 'Arial, System' }))
 
     await waitFor(() =>
-      expect(save).toHaveBeenLastCalledWith(preferences.pipeline, preferences.providers, {
-        font_families: ['Noto Sans', 'Arial'],
-      }),
+      expect(save).toHaveBeenLastCalledWith(
+        preferences.pipeline,
+        preferences.providers,
+        { font_families: ['Noto Sans', 'Arial'] },
+        preferences.export,
+      ),
     )
     await user.click(screen.getByRole('button', { name: 'Remove Noto Sans' }))
     await waitFor(() =>
-      expect(save).toHaveBeenLastCalledWith(preferences.pipeline, preferences.providers, {
-        font_families: ['Arial'],
-      }),
+      expect(save).toHaveBeenLastCalledWith(
+        preferences.pipeline,
+        preferences.providers,
+        { font_families: ['Arial'] },
+        preferences.export,
+      ),
     )
   })
 
@@ -1541,6 +1558,7 @@ describe('greenfield editor', () => {
     useKoharuStore.setState({
       jobs: {
         job: {
+          kind: 'processing',
           state: 'running',
           id: 'job',
           completed: 1,
@@ -1557,6 +1575,54 @@ describe('greenfield editor', () => {
     expect(screen.getByText('25%')).toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: 'Stop' }))
     await waitFor(() => expect(stop).toHaveBeenCalledWith('job'))
+  })
+
+  it('describes an export job as exporting and keeps it stoppable', async () => {
+    installProject()
+    useKoharuStore.setState({
+      jobs: {
+        export: {
+          kind: 'export',
+          state: 'running',
+          id: 'export',
+          completed: 3,
+          total: 12,
+          page: null,
+          stage: null,
+          model: null,
+          error: null,
+        },
+      },
+    })
+    const stop = vi.spyOn(commands, 'stopJob').mockResolvedValue(null)
+    render(<ActivityCenter />)
+    expect(screen.getByText('Exporting')).toBeInTheDocument()
+    expect(screen.queryByText('Processing')).not.toBeInTheDocument()
+    expect(screen.getByText('3 / 12')).toBeInTheDocument()
+    expect(screen.getByText('25%')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Stop' }))
+    await waitFor(() => expect(stop).toHaveBeenCalledWith('export'))
+  })
+
+  it('reports a failed export with the export wording', () => {
+    installProject()
+    useKoharuStore.setState({
+      jobs: {
+        export: {
+          kind: 'export',
+          state: 'failed',
+          id: 'export',
+          completed: 0,
+          total: 4,
+          page: null,
+          stage: null,
+          model: null,
+          error: null,
+        },
+      },
+    })
+    render(<ActivityCenter />)
+    expect(screen.getByText('Export failed.')).toBeInTheDocument()
   })
 
   it('combines concurrent downloads into one progress bar', () => {

--- a/packages/koharu/tests/lib/runtime.test.ts
+++ b/packages/koharu/tests/lib/runtime.test.ts
@@ -46,6 +46,7 @@ const preferences: Preferences = {
   providers: {
     entries: [],
   },
+  export: { jpeg_quality: 90, webp_quality: 85 },
   typesetting: {
     font_families: ['CCWildWords', 'Adobe 黑体 Std'],
   },
@@ -118,6 +119,7 @@ describe('Tauri runtime', () => {
     act(() => {
       jobChannel.onmessage({
         id: 'job',
+        kind: 'processing',
         state: 'running',
         completed: 0,
         total: 4,
@@ -183,6 +185,7 @@ describe('Tauri runtime', () => {
     const [, jobChannel] = binding.mock.calls[0]
     jobChannel.onmessage({
       id: 'job',
+      kind: 'processing',
       state: 'running',
       completed: 1,
       total: 2,


### PR DESCRIPTION
Superseded by #1016, opened to agree the approach first. Leaving this closed.

Koharu can import CBZ but not export it, so shipping a finished chapter means exporting loose PNGs and zipping them by hand. This adds CBZ alongside PNG and PSD, under a new `File -> Export` submenu.

Revives #471, which @mayocream asked to hold for the data model redesign and which was then closed unmerged after going stale. This is a fresh implementation against the current `koharu-scene` model, keeping #471's `P001` member naming.

## What changed

- Choosing CBZ asks which format the pages use: PNG, JPEG or WebP. All three are already import formats, so an archive re-opens as a project.
- New Export section in settings holds quality for the lossy formats (JPEG 90, WebP 85).
- Export runs as a job, so the activity panel shows progress and can stop it. Previously the invoke promise stayed pending for the whole run with no feedback.

## Behaviour differences

- The three export entries move one level deeper, under `Export`.
- CBZ always exports every page in project order, ignoring the rail selection, because a single-page archive is rarely useful; the label says so. PNG and PSD still follow the selection.
- Archive members are `P001.png`, widening past three digits when a project needs it. Loose PNG and PSD files keep `0001_page-label.png`.
- A stopped or failed CBZ export deletes its partial archive.
- The destination dialog now opens after the "no pages to export" check.

## Notes

- JPEG is composed onto white first: its encoder rejects RGBA outright, and dropping alpha would darken transparent areas.
- Members are stored uncompressed; every supported page format is already compressed.
- **AVIF dropped.** This build encodes it via `ravif` but cannot decode it — `image` reads AVIF only through `avif-native` and `dav1d` — so archives would export but not re-import.
- **CB7 dropped**, unlike #471: Koharu cannot import `.cb7`, which is the same asymmetry. Happy to add both if you want parity.
- `save_preferences` takes `export_config`, not `export`: specta emits argument names verbatim and `export` is reserved in TypeScript, which produced a `protocol.ts` that would not parse.

## Verified

CI is green. Locally: `cargo fmt --check`, `cargo check`, `cargo clippy -- -D warnings` (plus `-p koharu-app --all-targets`, since `default-members` skips that crate), `cargo test --workspace --tests` 385 passed, UI lint and test 90 passed, `bun run ui:build`, and `protocol.ts` regenerates with no diff.

New tests cover each encoding producing its own container and decoding back, the JPEG matte, quality clamping, member naming and ordering, and stored compression.

Screenshots are in the comment below.

---

AI-assisted. Reviewed and tested by a human before submission.