### PR TITLE
feat(ui): show how many pages a multi-selection covers

### DIFF
--- a/packages/koharu/components/app/TitleBar.tsx
+++ b/packages/koharu/components/app/TitleBar.tsx
@@ -57,6 +57,10 @@ export function TitleBar() {
 
   const closeProject = () => void call(commands.closeProject).catch(() => undefined)
 
+  // Exactly what the export commands below will receive, so the count in the
+  // menu cannot disagree with what is written.
+  const exportCount = exportSelection(selectedPages, page?.id).length
+
   return (
     <>
       <header
@@ -109,6 +113,11 @@ export function TitleBar() {
                 }
               >
                 {t('menu.exportPng')}
+                {exportCount > 1 && (
+                  <MenubarShortcut>
+                    {t('menu.exportSelection', { count: exportCount })}
+                  </MenubarShortcut>
+                )}
               </MenubarItem>
               <MenubarItem
                 disabled={!project || pages.length === 0}
@@ -117,6 +126,11 @@ export function TitleBar() {
                 }
               >
                 {t('menu.exportPsd')}
+                {exportCount > 1 && (
+                  <MenubarShortcut>
+                    {t('menu.exportSelection', { count: exportCount })}
+                  </MenubarShortcut>
+                )}
               </MenubarItem>
               <MenubarSeparator />
               <MenubarItem disabled={!project} onClick={closeProject}>

--- a/packages/koharu/components/editor/PageRail.tsx
+++ b/packages/koharu/components/editor/PageRail.tsx
@@ -231,13 +231,22 @@ export function PageRail() {
   return (
     <>
       <aside className='flex h-full min-h-0 flex-col bg-[var(--surface-sidebar)]'>
-        <header className='flex h-10 shrink-0 items-center px-2.5'>
+        <header className='flex h-10 shrink-0 items-center justify-between gap-2 px-2.5'>
           <div className='flex min-w-0 items-center gap-2'>
             <h2 className='text-[11px] font-semibold'>{t('navigator.pages')}</h2>
             <span className='rounded-full bg-primary/[0.07] px-1.5 py-0.5 text-[9px] text-muted-foreground tabular-nums'>
               {pages.length}
             </span>
           </div>
+          {selected.length > 1 && (
+            <span
+              role='status'
+              aria-live='polite'
+              className='shrink-0 text-[9px] text-muted-foreground tabular-nums'
+            >
+              {t('navigator.selected', { count: selected.length })}
+            </span>
+          )}
         </header>
 
         {importing && (

--- a/packages/koharu/public/locales/en-US/translation.json
+++ b/packages/koharu/public/locales/en-US/translation.json
@@ -247,6 +247,7 @@
     "edit": "Edit",
     "exportPng": "Export PNG…",
     "exportPsd": "Export PSD…",
+    "exportSelection": "{{count}} pages",
     "file": "File",
     "fit": "Fit Window",
     "github": "GitHub",
@@ -297,7 +298,8 @@
     "pages": "Pages",
     "rename": "Rename",
     "renameDescription": "Choose a new name for this page.",
-    "renameTitle": "Rename page"
+    "renameTitle": "Rename page",
+    "selected": "{{count}} selected"
   },
   "outputPicker": {
     "instructions": "Translation instructions",

--- a/packages/koharu/public/locales/es-ES/translation.json
+++ b/packages/koharu/public/locales/es-ES/translation.json
@@ -247,6 +247,7 @@
     "edit": "Editar",
     "exportPng": "Exportar PNG…",
     "exportPsd": "Exportar PSD…",
+    "exportSelection": "{{count}} páginas",
     "file": "Archivo",
     "fit": "Ajustar a la ventana",
     "github": "GitHub",
@@ -297,7 +298,8 @@
     "pages": "Páginas",
     "rename": "Cambiar nombre",
     "renameDescription": "Elige un nombre nuevo para esta página.",
-    "renameTitle": "Cambiar nombre de página"
+    "renameTitle": "Cambiar nombre de página",
+    "selected": "{{count}} seleccionadas"
   },
   "outputPicker": {
     "instructions": "Instrucciones de traducción",

--- a/packages/koharu/public/locales/ja-JP/translation.json
+++ b/packages/koharu/public/locales/ja-JP/translation.json
@@ -247,6 +247,7 @@
     "edit": "編集",
     "exportPng": "PNGを書き出す…",
     "exportPsd": "PSDを書き出す…",
+    "exportSelection": "{{count}}ページ",
     "file": "ファイル",
     "fit": "ウィンドウに合わせる",
     "github": "GitHub",
@@ -297,7 +298,8 @@
     "pages": "ページ",
     "rename": "名前を変更",
     "renameDescription": "このページの新しい名前を入力します。",
-    "renameTitle": "ページ名を変更"
+    "renameTitle": "ページ名を変更",
+    "selected": "{{count}}件選択中"
   },
   "outputPicker": {
     "instructions": "翻訳指示",

--- a/packages/koharu/public/locales/ko-KR/translation.json
+++ b/packages/koharu/public/locales/ko-KR/translation.json
@@ -247,6 +247,7 @@
     "edit": "편집",
     "exportPng": "PNG 내보내기…",
     "exportPsd": "PSD 내보내기…",
+    "exportSelection": "{{count}}페이지",
     "file": "파일",
     "fit": "창에 맞춤",
     "github": "GitHub",
@@ -297,7 +298,8 @@
     "pages": "페이지",
     "rename": "이름 바꾸기",
     "renameDescription": "이 페이지의 새 이름을 정하세요.",
-    "renameTitle": "페이지 이름 바꾸기"
+    "renameTitle": "페이지 이름 바꾸기",
+    "selected": "{{count}}개 선택됨"
   },
   "outputPicker": {
     "instructions": "번역 지침",

--- a/packages/koharu/public/locales/pt-BR/translation.json
+++ b/packages/koharu/public/locales/pt-BR/translation.json
@@ -247,6 +247,7 @@
     "edit": "Editar",
     "exportPng": "Exportar PNG…",
     "exportPsd": "Exportar PSD…",
+    "exportSelection": "{{count}} páginas",
     "file": "Arquivo",
     "fit": "Ajustar à janela",
     "github": "GitHub",
@@ -297,7 +298,8 @@
     "pages": "Páginas",
     "rename": "Renomear",
     "renameDescription": "Escolha um novo nome para esta página.",
-    "renameTitle": "Renomear página"
+    "renameTitle": "Renomear página",
+    "selected": "{{count}} selecionadas"
   },
   "outputPicker": {
     "instructions": "Instruções de tradução",

--- a/packages/koharu/public/locales/ru-RU/translation.json
+++ b/packages/koharu/public/locales/ru-RU/translation.json
@@ -247,6 +247,7 @@
     "edit": "Правка",
     "exportPng": "Экспорт PNG…",
     "exportPsd": "Экспорт PSD…",
+    "exportSelection": "{{count}} стр.",
     "file": "Файл",
     "fit": "Вписать в окно",
     "github": "GitHub",
@@ -297,7 +298,8 @@
     "pages": "Страницы",
     "rename": "Переименовать",
     "renameDescription": "Выберите новое имя для страницы.",
-    "renameTitle": "Переименовать страницу"
+    "renameTitle": "Переименовать страницу",
+    "selected": "Выбрано: {{count}}"
   },
   "outputPicker": {
     "instructions": "Инструкции по переводу",

--- a/packages/koharu/public/locales/tr-TR/translation.json
+++ b/packages/koharu/public/locales/tr-TR/translation.json
@@ -247,6 +247,7 @@
     "edit": "Düzenle",
     "exportPng": "PNG Dışa Aktar…",
     "exportPsd": "PSD Dışa Aktar…",
+    "exportSelection": "{{count}} sayfa",
     "file": "Dosya",
     "fit": "Pencereye Sığdır",
     "github": "GitHub",
@@ -297,7 +298,8 @@
     "pages": "Sayfalar",
     "rename": "Yeniden adlandır",
     "renameDescription": "Bu sayfa için yeni bir ad seçin.",
-    "renameTitle": "Sayfayı yeniden adlandır"
+    "renameTitle": "Sayfayı yeniden adlandır",
+    "selected": "{{count}} seçili"
   },
   "outputPicker": {
     "instructions": "Çeviri talimatları",

--- a/packages/koharu/public/locales/zh-CN/translation.json
+++ b/packages/koharu/public/locales/zh-CN/translation.json
@@ -247,6 +247,7 @@
     "edit": "编辑",
     "exportPng": "导出 PNG…",
     "exportPsd": "导出 PSD…",
+    "exportSelection": "{{count}} 页",
     "file": "文件",
     "fit": "适应窗口",
     "github": "GitHub",
@@ -297,7 +298,8 @@
     "pages": "页面",
     "rename": "重命名",
     "renameDescription": "为此页面选择一个新名称。",
-    "renameTitle": "重命名页面"
+    "renameTitle": "重命名页面",
+    "selected": "已选择 {{count}}"
   },
   "outputPicker": {
     "instructions": "翻译说明",

--- a/packages/koharu/public/locales/zh-TW/translation.json
+++ b/packages/koharu/public/locales/zh-TW/translation.json
@@ -247,6 +247,7 @@
     "edit": "編輯",
     "exportPng": "匯出 PNG…",
     "exportPsd": "匯出 PSD…",
+    "exportSelection": "{{count}} 頁",
     "file": "檔案",
     "fit": "適應視窗",
     "github": "GitHub",
@@ -297,7 +298,8 @@
     "pages": "頁面",
     "rename": "重新命名",
     "renameDescription": "為此頁面選擇新名稱。",
-    "renameTitle": "重新命名頁面"
+    "renameTitle": "重新命名頁面",
+    "selected": "已選擇 {{count}}"
   },
   "outputPicker": {
     "instructions": "翻譯指示",

--- a/packages/koharu/tests/components/editor-components.test.tsx
+++ b/packages/koharu/tests/components/editor-components.test.tsx
@@ -1559,6 +1559,39 @@ describe('greenfield editor', () => {
     await waitFor(() => expect(stop).toHaveBeenCalledWith('job'))
   })
 
+  it('shows how many pages are selected above the filter', async () => {
+    installProject()
+    act(() => {
+      useKoharuStore.setState({ selectedPages: ['page-1'] })
+    })
+    render(<PageRail />)
+
+    // A single selection is not worth announcing.
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+
+    // The rail subscribes to the store, so no re-render is needed.
+    act(() => {
+      useKoharuStore.setState({ selectedPages: ['page-1', 'page-2', 'page-3'] })
+    })
+
+    expect(await screen.findByRole('status')).toHaveTextContent('3 selected')
+  })
+
+  it('tells the export items how many pages they will write', async () => {
+    installProject()
+    const user = userEvent.setup()
+    act(() => {
+      useKoharuStore.setState({ selectedPages: ['page-1', 'page-2'] })
+    })
+    render(<TitleBar />)
+
+    await user.click(screen.getByRole('menuitem', { name: 'File' }))
+    const png = await screen.findByRole('menuitem', { name: /Export PNG/ })
+    const psd = await screen.findByRole('menuitem', { name: /Export PSD/ })
+    expect(png).toHaveTextContent('2 pages')
+    expect(psd).toHaveTextContent('2 pages')
+  })
+
   it('combines concurrent downloads into one progress bar', () => {
     useKoharuStore.setState({
       downloads: {


### PR DESCRIPTION
Superseded by #1017, opened to agree the approach first. Leaving this closed.

Selecting several pages gave no running total, and the PNG and PSD export entries did not say how many pages they would write, so a selection made in the rail was invisible at the moment of exporting.

- The page rail header shows `N selected` above the filter once more than one page is selected.
- The PNG and PSD export items show the same count.

The menu count is derived from the value the export commands actually receive, so it cannot disagree with what is written. A single selection is left unannotated: that is the ordinary case, and it behaves the same as exporting the active page.

Frontend only — two components, nine locale files, one test file. No Rust, no regenerated bindings.

## Verified

`bun run --filter @koharu/app lint` and `test` (90 passed), `tsc --noEmit`, `oxfmt --check`, `cargo check`.

New tests cover the rail showing nothing at one selection and `3 selected` at three, and both export items reporting `2 pages`.

## Note

This touches the same export menu items and `menu` locale section as #1009, so whichever merges second needs a small conflict fix.

---

AI-assisted. Reviewed and tested by a human before submission.