### PR TITLE
fix: unlock font-size field for global editing without selection

### DIFF
--- a/packages/koharu/components/editor/Inspector.tsx
+++ b/packages/koharu/components/editor/Inspector.tsx
@@ -135,8 +135,8 @@ function TypeInspector() {
   const selectedIds = useKoharuStore((state) => state.selectedLayers)
   const availableFonts = useFonts().data
   const expandedSelection = page ? expandLayerSelection(page.layers, selectedIds) : []
-  const selected =
-    page?.layers.filter(isTextLayer).filter((layer) => expandedSelection.includes(layer.id)) ?? []
+  const textLayers = page?.layers.filter(isTextLayer) ?? []
+  const selected = textLayers.filter((layer) => expandedSelection.includes(layer.id))
   const current = selected[0]
   const [draft, setDraft] = useState<{
     layer: EntityId
@@ -147,8 +147,9 @@ function TypeInspector() {
   useEffect(() => setDraft(null), [current?.id])
 
   const apply = (update: (value: Typography) => Typography) => {
-    if (!selected.length) return
-    const updates = selected.map((layer) => ({
+    const targets = selected.length ? selected : textLayers
+    if (!targets.length) return
+    const updates = targets.map((layer) => ({
       layer: layer.id,
       typography: update(layer.typography ?? defaultTypography),
     }))
@@ -167,7 +168,7 @@ function TypeInspector() {
     current && draft?.layer === current.id
       ? draft.typography
       : (current?.typography ?? defaultTypography)
-  const disabled = !current
+  const disabled = textLayers.length === 0
   const families = useMemo(() => {
     const available = availableFonts ?? []
     return available.some(

--- a/packages/koharu/tests/components/editor-components.test.tsx
+++ b/packages/koharu/tests/components/editor-components.test.tsx
@@ -551,6 +551,28 @@ describe('greenfield editor', () => {
     )
   })
 
+  it('applies font size to all text layers when none is selected', async () => {
+    const user = userEvent.setup()
+    installProject()
+    useKoharuStore.setState({ selectedLayers: [] })
+    const setTypography = vi.spyOn(commands, 'setTypography').mockResolvedValue(null)
+    render(<Inspector />)
+
+    expect(screen.getByTestId('type-size')).not.toBeDisabled()
+    await user.type(screen.getByTestId('type-size'), '20')
+    await user.tab()
+    await waitFor(() =>
+      expect(setTypography).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            layer: 'element',
+            typography: expect.objectContaining({ size: 20, auto_fit: false }),
+          }),
+        ]),
+      ),
+    )
+  })
+
   it('defaults vertical text alignment to top and maps end to bottom', async () => {
     const user = userEvent.setup()
     installProject()


### PR DESCRIPTION
The font-size field was disabled when no text layer was selected, blocking the global workflow: typing a value with nothing selected should apply to every text layer on the page, and clearing it should reset all layers to auto.

**What changed:** Extracted all text layers into `textLayers` and changed the disabled guard from `!current` to `textLayers.length === 0`, so the field stays enabled whenever the page has text layers. In `apply`, fall back to `textLayers` when nothing is selected instead of returning early. Per-layer edits when a layer is selected are unchanged. `FontSizeField` already has its own draft buffer, so no separate global input state is needed.

**User-visible behavior differences:** With no text layer selected, the font-size field is now editable (previously greyed out). Typing a number applies it to every text layer on the page; clearing the field resets all layers to auto. Selecting a single text layer still applies changes only to that layer, unchanged.

**How I verified:** `bun run format` and `bun run test` (38/38 editor component tests passed, including a new test covering the no-selection case).

Fixes: #649

This patch was made with AI assistance (Devin/Claude). The code was reviewed and tested before submission.