### PR TITLE
feat(navigator): delete selected pages in a batch

### DIFF
--- a/packages/koharu/components/editor/PageRail.tsx
+++ b/packages/koharu/components/editor/PageRail.tsx
@@ -37,6 +37,17 @@ import {
   type PageSummary,
   type ProjectInfo,
 } from '@koharu/bridge/protocol'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogMedia,
+  AlertDialogTitle,
+} from '@koharu/ui/components/alert-dialog'
 import { Button } from '@koharu/ui/components/button'
 import {
   Dialog,
@@ -82,7 +93,13 @@ export function PageRail() {
   const [query, setQuery] = useState('')
   const [renaming, setRenaming] = useState<PageSummary | null>(null)
   const [renameValue, setRenameValue] = useState('')
+  const [pagesToDelete, setPagesToDelete] = useState<string[] | null>(null)
+  const [deleting, setDeleting] = useState(false)
   const normalized = query.trim().toLocaleLowerCase()
+  const selectedItems = useMemo(
+    () => pages.filter((page) => selected.includes(page.id)),
+    [pages, selected],
+  )
   const visiblePages = useMemo(
     () =>
       pages
@@ -205,6 +222,23 @@ export function PageRail() {
       })
       .catch(() => undefined)
 
+  const deleteSelectedPages = async () => {
+    const targets = pagesToDelete
+    if (!targets?.length || deleting) return
+    setDeleting(true)
+    selectionRequest.current += 1
+    try {
+      await call(commands.deletePages, targets)
+      setPagesToDelete(null)
+      const deleted = new Set(targets)
+      selectPages(selected.filter((page) => !deleted.has(page)))
+      if (active && deleted.has(active)) selectLayers([])
+      await refresh(projectKey, pagesKey, pageKey)
+    } finally {
+      setDeleting(false)
+    }
+  }
+
   const openRename = (page: PageSummary) => {
     setRenaming(page)
     setRenameValue(page.label)
@@ -263,6 +297,24 @@ export function PageRail() {
                 onChange={(event) => setQuery(event.currentTarget.value)}
               />
             </label>
+          </div>
+        )}
+
+        {selectedItems.length > 1 && (
+          <div className='flex h-8 shrink-0 items-center justify-between gap-2 border-b border-border/70 bg-destructive/[0.04] px-2'>
+            <span className='truncate text-[10px] text-muted-foreground'>
+              {t('navigator.selectedCount', { count: selectedItems.length })}
+            </span>
+            <Button
+              type='button'
+              variant='destructive'
+              size='xs'
+              aria-label={t('navigator.deleteSelected')}
+              onClick={() => setPagesToDelete(selectedItems.map((page) => page.id))}
+            >
+              <Trash2 />
+              {t('navigator.deleteSelected')}
+            </Button>
           </div>
         )}
 
@@ -382,6 +434,38 @@ export function PageRail() {
           </form>
         </DialogContent>
       </Dialog>
+
+      <AlertDialog
+        open={pagesToDelete !== null}
+        onOpenChange={(open) => {
+          if (!open && !deleting) setPagesToDelete(null)
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogMedia className='bg-destructive/10 text-destructive'>
+              <Trash2 className='size-5' />
+            </AlertDialogMedia>
+            <AlertDialogTitle>{t('navigator.batchDeleteConfirmTitle')}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {t('navigator.batchDeleteConfirmDescription', {
+                count: pagesToDelete?.length ?? 0,
+              })}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={deleting}>{t('common.cancel')}</AlertDialogCancel>
+            <AlertDialogAction
+              variant='destructive'
+              disabled={deleting}
+              aria-busy={deleting}
+              onClick={() => void deleteSelectedPages().catch(() => undefined)}
+            >
+              {deleting ? t('navigator.deleting') : t('navigator.delete')}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </>
   )
 }

--- a/packages/koharu/public/locales/en-US/translation.json
+++ b/packages/koharu/public/locales/en-US/translation.json
@@ -279,7 +279,12 @@
   },
   "navigator": {
     "actionsFor": "Actions for {{page}}",
+    "batchDeleteConfirmDescription": "Delete {{count}} selected pages from this project?",
+    "batchDeleteConfirmTitle": "Delete selected pages?",
     "delete": "Delete",
+    "deleteSelected": "Delete selected",
+    "deleting": "Deleting…",
+    "selectedCount": "{{count}} selected",
     "emptyDescription": "Import image files or a folder to add pages.",
     "emptyTitle": "No pages yet",
     "filter": "Filter pages",

--- a/packages/koharu/public/locales/es-ES/translation.json
+++ b/packages/koharu/public/locales/es-ES/translation.json
@@ -279,7 +279,12 @@
   },
   "navigator": {
     "actionsFor": "Acciones para {{page}}",
+    "batchDeleteConfirmDescription": "¿Eliminar {{count}} páginas seleccionadas de este proyecto?",
+    "batchDeleteConfirmTitle": "¿Eliminar las páginas seleccionadas?",
     "delete": "Eliminar",
+    "deleteSelected": "Eliminar seleccionadas",
+    "deleting": "Eliminando…",
+    "selectedCount": "{{count}} seleccionadas",
     "emptyDescription": "Importa archivos de imagen o una carpeta para añadir páginas.",
     "emptyTitle": "Aún no hay páginas",
     "filter": "Filtrar páginas",

--- a/packages/koharu/public/locales/ja-JP/translation.json
+++ b/packages/koharu/public/locales/ja-JP/translation.json
@@ -279,7 +279,12 @@
   },
   "navigator": {
     "actionsFor": "{{page}}の操作",
+    "batchDeleteConfirmDescription": "選択した{{count}}ページをこのプロジェクトから削除しますか？",
+    "batchDeleteConfirmTitle": "選択したページを削除しますか？",
     "delete": "削除",
+    "deleteSelected": "選択項目を削除",
+    "deleting": "削除中…",
+    "selectedCount": "{{count}}件選択中",
     "emptyDescription": "画像ファイルまたはフォルダーを読み込んでページを追加します。",
     "emptyTitle": "ページがまだありません",
     "filter": "ページを絞り込む",

--- a/packages/koharu/public/locales/ko-KR/translation.json
+++ b/packages/koharu/public/locales/ko-KR/translation.json
@@ -279,7 +279,12 @@
   },
   "navigator": {
     "actionsFor": "{{page}} 작업",
+    "batchDeleteConfirmDescription": "선택한 {{count}}개의 페이지를 이 프로젝트에서 삭제하시겠습니까?",
+    "batchDeleteConfirmTitle": "선택한 페이지를 삭제하시겠습니까?",
     "delete": "삭제",
+    "deleteSelected": "선택 항목 삭제",
+    "deleting": "삭제 중…",
+    "selectedCount": "{{count}}개 선택됨",
     "emptyDescription": "이미지 파일이나 폴더를 가져와 페이지를 추가하세요.",
     "emptyTitle": "아직 페이지가 없습니다",
     "filter": "페이지 필터링",

--- a/packages/koharu/public/locales/pt-BR/translation.json
+++ b/packages/koharu/public/locales/pt-BR/translation.json
@@ -279,7 +279,12 @@
   },
   "navigator": {
     "actionsFor": "Ações para {{page}}",
+    "batchDeleteConfirmDescription": "Excluir as {{count}} páginas selecionadas deste projeto?",
+    "batchDeleteConfirmTitle": "Excluir as páginas selecionadas?",
     "delete": "Excluir",
+    "deleteSelected": "Excluir selecionadas",
+    "deleting": "Excluindo…",
+    "selectedCount": "{{count}} selecionadas",
     "emptyDescription": "Importe arquivos de imagem ou uma pasta para adicionar páginas.",
     "emptyTitle": "Ainda não há páginas",
     "filter": "Filtrar páginas",

--- a/packages/koharu/public/locales/ru-RU/translation.json
+++ b/packages/koharu/public/locales/ru-RU/translation.json
@@ -279,7 +279,12 @@
   },
   "navigator": {
     "actionsFor": "Действия для {{page}}",
+    "batchDeleteConfirmDescription": "Удалить выбранные страницы ({{count}}) из этого проекта?",
+    "batchDeleteConfirmTitle": "Удалить выбранные страницы?",
     "delete": "Удалить",
+    "deleteSelected": "Удалить выбранные",
+    "deleting": "Удаление…",
+    "selectedCount": "Выбрано: {{count}}",
     "emptyDescription": "Импортируйте изображения или папку, чтобы добавить страницы.",
     "emptyTitle": "Страниц пока нет",
     "filter": "Фильтровать страницы",

--- a/packages/koharu/public/locales/tr-TR/translation.json
+++ b/packages/koharu/public/locales/tr-TR/translation.json
@@ -279,7 +279,12 @@
   },
   "navigator": {
     "actionsFor": "{{page}} için eylemler",
+    "batchDeleteConfirmDescription": "Seçilen {{count}} sayfa bu projeden silinsin mi?",
+    "batchDeleteConfirmTitle": "Seçilen sayfalar silinsin mi?",
     "delete": "Sil",
+    "deleteSelected": "Seçilenleri sil",
+    "deleting": "Siliniyor…",
+    "selectedCount": "{{count}} seçildi",
     "emptyDescription": "Sayfa eklemek için görüntü dosyalarını veya bir klasörü içe aktarın.",
     "emptyTitle": "Henüz sayfa yok",
     "filter": "Sayfaları filtrele",

--- a/packages/koharu/public/locales/zh-CN/translation.json
+++ b/packages/koharu/public/locales/zh-CN/translation.json
@@ -279,7 +279,12 @@
   },
   "navigator": {
     "actionsFor": "{{page}} 的操作",
+    "batchDeleteConfirmDescription": "从此项目中删除所选的 {{count}} 个页面吗？",
+    "batchDeleteConfirmTitle": "删除所选页面？",
     "delete": "删除",
+    "deleteSelected": "删除所选项",
+    "deleting": "正在删除…",
+    "selectedCount": "已选择 {{count}} 项",
     "emptyDescription": "导入图像文件或文件夹以添加页面。",
     "emptyTitle": "还没有页面",
     "filter": "筛选页面",

--- a/packages/koharu/public/locales/zh-TW/translation.json
+++ b/packages/koharu/public/locales/zh-TW/translation.json
@@ -279,7 +279,12 @@
   },
   "navigator": {
     "actionsFor": "{{page}} 的操作",
+    "batchDeleteConfirmDescription": "從此專案中刪除所選的 {{count}} 個頁面嗎？",
+    "batchDeleteConfirmTitle": "刪除所選頁面？",
     "delete": "刪除",
+    "deleteSelected": "刪除所選項目",
+    "deleting": "正在刪除…",
+    "selectedCount": "已選擇 {{count}} 項",
     "emptyDescription": "匯入影像檔案或資料夾以新增頁面。",
     "emptyTitle": "尚無頁面",
     "filter": "篩選頁面",

--- a/packages/koharu/tests/components/editor-components.test.tsx
+++ b/packages/koharu/tests/components/editor-components.test.tsx
@@ -330,6 +330,46 @@ describe('greenfield editor', () => {
     expect(screen.queryByText('01')).not.toBeInTheDocument()
   })
 
+  it('confirms before deleting the selected pages as one batch', async () => {
+    const user = userEvent.setup()
+    installProject()
+    queryClient.setQueryData(pagesKey, [
+      ...(queryClient.getQueryData<PageSummary[]>(pagesKey) ?? []),
+      {
+        id: 'page-2',
+        label: 'Page 2',
+        size: { width: 1000, height: 1500 },
+        source_asset: null,
+        layer_count: 0,
+      },
+    ])
+    useKoharuStore.setState({ selectedPages: ['page', 'page-2'] })
+    const deletePages = vi.spyOn(commands, 'deletePages').mockResolvedValue(null)
+    vi.spyOn(commands, 'getProject').mockResolvedValue({
+      name: 'Book',
+      revision: 2,
+      active_page: null,
+      can_undo: true,
+      can_redo: false,
+    })
+    vi.spyOn(commands, 'getPages').mockResolvedValue([])
+    vi.spyOn(commands, 'getPage').mockResolvedValue(null)
+    render(<PageRail />)
+
+    expect(screen.getByText('2 selected')).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: 'Delete selected' }))
+
+    expect(screen.getByRole('heading', { name: 'Delete selected pages?' })).toBeInTheDocument()
+    expect(screen.getByText('Delete 2 selected pages from this project?')).toBeInTheDocument()
+    expect(deletePages).not.toHaveBeenCalled()
+
+    await user.click(screen.getByRole('button', { name: 'Delete' }))
+
+    await waitFor(() => expect(deletePages).toHaveBeenCalledWith(['page', 'page-2']))
+    await waitFor(() => expect(useKoharuStore.getState().selectedPages).toEqual([]))
+    expect(useKoharuStore.getState().selectedLayers).toEqual([])
+  })
+
   it('keeps rapid page switches on the latest native selection', async () => {
     installProject()
     const pages = [


### PR DESCRIPTION
## Summary

Addresses the selection count and batch-deletion parts of #1017.

The page rail already supports Shift-click range selection and Ctrl/Cmd-click individual selection. 
The existing `delete_pages` command also accepts multiple page IDs. 
What was missing was a UI action connecting the current selection to that command.

When more than one page is selected, this change shows the selection count and a destructive action. 
Deletion requires confirmation and the dialog states how many pages will be removed.

The current implementation uses a trash icon with the text `Delete selected`. 
#1017 also discusses an icon-only button with a hover tooltip. 
Either presentation works with the underlying behavior, so this remains open for review.

No backend or protocol changes were required.


## Related issue

Addresses part of #1017.

This pull request covers the selection count and batch-deletion action.

## Verification

- Verified deletion using Shift-click range selection.
- Verified deletion using Ctrl-click individual selection.
- Verified that the confirmation count matched the selected pages.
- Added a component test covering confirmation, the batched `delete_pages` call, and selection cleanup.

I reviewed the complete diff and personally tested the compiled application on Windows. 

## AI assistance

OpenAI Codex assisted with the implementation, component test, and locale text.