### PR TITLE
fix(ci): remove AppImage bundle target (#1035)

### DIFF
--- a/crates/koharu/tauri.linux.conf.json
+++ b/crates/koharu/tauri.linux.conf.json
@@ -2,6 +2,6 @@
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/468796f87cd332fdcefc3f0f7c2058e9905197db/crates/tauri-schema-generator/schemas/config.schema.json",
   "identifier": "Koharu",
   "bundle": {
-    "targets": ["deb", "rpm", "appimage"]
+    "targets": ["deb", "rpm"]
   }
 }


### PR DESCRIPTION
## Summary

Remove the AppImage target from the Linux release configuration, leaving the native `.deb` and `.rpm` packages.

The AppImage bundles system libraries that can conflict with newer host libraries and graphics/runtime stacks, causing startup failures on Fedora 44. Native packages use the host system libraries and avoid these collisions.

## Related issue

Closes #1035

## Verification

* Confirmed `crates/koharu/tauri.linux.conf.json` now targets only `deb` and `rpm`.
* No runtime code was changed.
* Full release packaging was not run locally.