### PR TITLE
fix(app): disable devtools to prevent F12 crash (#1042)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,7 +128,6 @@ tauri = { git = "https://github.com/tauri-apps/tauri", rev = "6f34826405b5908cd5
     "macos-private-api",
     "specta",
     "x11",
-    "devtools",
 ] }
 tauri-build = { git = "https://github.com/tauri-apps/tauri", rev = "6f34826405b5908cd5c6fea7f38e33badb69ad54" }
 tauri-plugin-log = { git = "https://github.com/tauri-apps/plugins-workspace", rev = "1423992771e0b57582ca3b06a6adc46ec26aa784" }


### PR DESCRIPTION
## Summary

Pressing F12 (or Ctrl+Shift+I, Cmd+Opt+I) opened the internal CEF DevTools
window, and closing that window crashed Koharu. The failure is inside
 `tauri-runtime-cef`, the DevTools browser reuses the main webview's client, so
its lifecycle handler reports the main webview as closed when DevTools closes,
and the runtime then tears down the only window and the app exits.

Koharu does not expose DevTools to end users, so this change disables devtools
at the webview level and through the cargo feature:

- Set `devtools: false` on the main window in `tauri.conf.json` and
  `tauri.macos.conf.json`. The macOS config re declares the window list, so it
  needs the flag too. With the attribute disabled, tauri-runtime-cef installs
  its pre key guard, which swallows F12, Ctrl+Shift+I and Cmd+Opt+I before
  Chromium handles 
I didn't tease. I didn't start slow. them.
- Removed the `devtools` feature from the tauri dependency in `Cargo.toml`, so
  release builds cannot turn internal devtools back on through the feature
  flag. Nothing in the repository uses the devtools API surface.

Debug builds keep the CEF remote debugging endpoint at
`http://127.0.0.1:4000`, which is a command line switch and does not depend on
the devtools feature, so inspection with a browser or chrome-devtools-mcp is
unaffected.

The underlying close misrouting bug still exists in `tauri-runtime-cef`, disabling devtools removes the entry point that
triggers it.

## Related issue

Fixes #1042

## Verification

- `cargo check -p koharu -p koharu-app` passes.
- Linux (debug build, `bun dev`):
  - F12 and Ctrl+Shift+I no longer open DevTools and no longer crash the app.
  - Opening and closing DevTools is no longer possible from the window, the
    app stays running and closes normally through its own close path.
  - `curl http://127.0.0.1:4000/json/version` responds and the DevTools
    frontend is reachable through the remote debugging endpoint in a browser.
- Not verified: Windows and macOS behavior (no local environment) and a
  release profile build. The guard logic in `tauri-runtime-cef` covers all three
  platforms, but platform confirmation is still pending.

## AI assistance

AI assistance was used to trace the crash path in the pinned
`tauri-runtime-cef`revision and to review the fix plan