### PR TITLE
chore(editor): change default brush color to pure white

### DIFF
--- a/packages/koharu/lib/store.ts
+++ b/packages/koharu/lib/store.ts
@@ -99,7 +99,7 @@ export const useKoharuStore = create<KoharuStore>()((set) => ({
   selectedLayers: [],
   selectedPages: [],
   tool: 'select',
-  brush: { diameter: 48, color: '#111111' },
+  brush: { diameter: 48, color: '#FFFFFF' },
   inspector: 'copy',
   processingScope: 'page',
   processingStages: [...pipelineStages],

--- a/packages/koharu/tests/lib/store.test.ts
+++ b/packages/koharu/tests/lib/store.test.ts
@@ -21,4 +21,8 @@ describe('editor state', () => {
     useKoharuStore.getState().dismissDownload(9)
     expect(useKoharuStore.getState().downloads[9]).toBeUndefined()
   })
+
+  it('defaults paint brush color to pure white (#FFFFFF)', () => {
+    expect(useKoharuStore.getState().brush.color).toBe('#FFFFFF')
+  })
 })

--- a/packages/koharu/tests/setup.ts
+++ b/packages/koharu/tests/setup.ts
@@ -86,7 +86,7 @@ beforeEach(() => {
     selectedLayers: [],
     selectedPages: [],
     tool: 'select',
-    brush: { diameter: 48, color: '#111111' },
+    brush: { diameter: 48, color: '#FFFFFF' },
     inspector: 'copy',
     processingScope: 'page',
     processingStages: ['detection', 'ocr', 'translation', 'inpainting'],


### PR DESCRIPTION
Closes #980

### 🔍 Summary of Changes

- Updated `brush.color` initial state from `#111111` to `#FFFFFF` in `packages/koharu/lib/store.ts`.
- Updated test setup initial store state in `packages/koharu/tests/setup.ts`.
- Added unit test in `packages/koharu/tests/lib/store.test.ts` to verify default brush color is pure white (`#FFFFFF`).