### PR TITLE
refactor(runtime): move compatibility checks into hardware

### DIFF
--- a/crates/koharu-runtime/src/device.rs
+++ b/crates/koharu-runtime/src/device.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
+use crate::hardware::GfxTarget;
+
 /// Compute backend used by a machine-learning device.
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq, Hash, Serialize, strum::Display)]
 pub enum Backend {
@@ -40,7 +42,7 @@ pub struct Device {
     #[serde(skip)]
     pub(crate) compute_capability: u32,
     #[serde(skip)]
-    pub(crate) target: Option<String>,
+    pub(crate) target: Option<GfxTarget>,
 }
 
 impl Device {
@@ -106,7 +108,7 @@ impl Device {
 
     #[must_use]
     pub fn target(&self) -> Option<&str> {
-        self.target.as_deref()
+        self.target.as_ref().map(|target| target.as_ref())
     }
 }
 

--- a/crates/koharu-runtime/src/download.rs
+++ b/crates/koharu-runtime/src/download.rs
@@ -39,6 +39,7 @@ static CLIENT: OnceLock<DownloadClient> = OnceLock::new();
 struct Activity {
     id: u64,
     name: String,
+    finished: bool,
 }
 
 #[derive(Clone, Copy)]
@@ -60,7 +61,11 @@ impl Activity {
             id,
             name: name.clone(),
         });
-        Self { id, name }
+        Self {
+            id,
+            name,
+            finished: false,
+        }
     }
 
     fn progress(&self, completed: u64, total: u64) {
@@ -72,21 +77,34 @@ impl Activity {
         });
     }
 
-    async fn finish(self, destination: &Path, result: Result<()>) -> Result<()> {
-        match result {
-            Ok(()) => {
-                let _ = EVENTS.send(Event::Finished { id: self.id });
-                Ok(())
-            }
-            Err(error) => {
-                let _ = tokio::fs::remove_file(destination).await;
-                let _ = EVENTS.send(Event::Failed {
-                    id: self.id,
-                    name: self.name,
-                    error: error.to_string(),
-                });
-                Err(error)
-            }
+    async fn finish(mut self, destination: &Path, result: Result<()>) -> Result<()> {
+        if result.is_err() {
+            let _ = tokio::fs::remove_file(destination).await;
+        }
+        let event = match &result {
+            Ok(()) => Event::Finished { id: self.id },
+            Err(error) => Event::Failed {
+                id: self.id,
+                name: self.name.clone(),
+                error: error.to_string(),
+            },
+        };
+        self.finished = true;
+        let _ = EVENTS.send(event);
+        result
+    }
+}
+
+impl Drop for Activity {
+    fn drop(&mut self) {
+        // The store owns staged file cleanup; this guard owns terminal events
+        // when a failed sibling or caller cancels the download future.
+        if !self.finished {
+            let _ = EVENTS.send(Event::Failed {
+                id: self.id,
+                name: self.name.clone(),
+                error: "download cancelled".to_owned(),
+            });
         }
     }
 }
@@ -171,7 +189,9 @@ where
     let read_timeout = Duration::from_secs(network::config()?.read_timeout.max(1));
     let activity = Activity::start(name.to_owned());
     let result = async {
-        let (total, stream) = source.await?;
+        let (total, stream) = tokio::time::timeout(read_timeout, source)
+            .await
+            .context("download metadata request timed out")??;
         write_stream(
             &activity,
             destination,

--- a/crates/koharu-runtime/src/hardware/hip/linux.rs
+++ b/crates/koharu-runtime/src/hardware/hip/linux.rs
@@ -5,8 +5,10 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use super::targets::KNOWN_TARGETS;
-use crate::{Backend, Device};
+use strum::{EnumProperty, IntoEnumIterator};
+
+use super::GfxTarget;
+use crate::{Backend, Device, DeviceType};
 
 const KFD_TOPOLOGY: &str = "/sys/class/kfd/kfd/topology/nodes";
 
@@ -18,8 +20,6 @@ pub(super) enum ProbeError {
         #[source]
         source: io::Error,
     },
-    #[error("unknown gfx_target_version: {0}")]
-    UnknownTarget(i64),
 }
 
 pub(super) fn probe() -> Result<Vec<Device>, ProbeError> {
@@ -80,21 +80,25 @@ pub(super) fn probe() -> Result<Vec<Device>, ProbeError> {
             continue;
         }
 
-        let target = KNOWN_TARGETS
-            .iter()
-            .find(|target| target.version == version)
-            .ok_or(ProbeError::UnknownTarget(version))?;
+        let Some(target) = GfxTarget::iter().find(|target| *target as i64 == version) else {
+            tracing::warn!(version, path = %path.display(), "skipping unknown AMD architecture");
+            continue;
+        };
         let index = devices.len();
         devices.push(Device {
             index,
             name: format!("ROCm{index}"),
-            description: target.name.to_owned(),
+            description: target.to_string(),
             backend: Backend::Rocm,
-            device_type: target.device_type,
+            device_type: if target.get_str("integrated").is_some() {
+                DeviceType::IntegratedGpu
+            } else {
+                DeviceType::Gpu
+            },
             memory_total: 0,
             memory_free: 0,
             compute_capability: 0,
-            target: Some(target.name.to_owned()),
+            target: Some(target),
         });
     }
     Ok(devices)

--- a/crates/koharu-runtime/src/hardware/hip/mod.rs
+++ b/crates/koharu-runtime/src/hardware/hip/mod.rs
@@ -1,5 +1,6 @@
-#[cfg(any(target_os = "linux", target_os = "windows"))]
 mod targets;
+
+pub(crate) use targets::GfxTarget;
 
 #[cfg(target_os = "linux")]
 mod linux;

--- a/crates/koharu-runtime/src/hardware/hip/targets.rs
+++ b/crates/koharu-runtime/src/hardware/hip/targets.rs
@@ -3,181 +3,107 @@
 //! Architecture names and KFD versions follow `rocm-systems` commit
 //! `a022846cf553c2b135410a5168f97705f1b9c6ac`. Device types follow TheRock's
 //! iGPU families, including legacy APUs retained by `rocm-bootstrap`.
+//! Platform properties identify targets packaged by Koharu's ROCm runtime.
 
-use crate::DeviceType;
-use DeviceType::{Gpu, IntegratedGpu};
+use strum::{AsRefStr, EnumIter, EnumProperty, EnumString};
 
-pub(super) struct GfxTarget {
-    pub(super) name: &'static str,
-    #[allow(dead_code)] // Read by the Linux KFD probe; the table is shared with Windows.
-    pub(super) version: i64,
-    pub(super) device_type: DeviceType,
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    PartialEq,
+    AsRefStr,
+    EnumIter,
+    EnumProperty,
+    EnumString,
+    strum::Display,
+)]
+#[repr(i64)]
+pub(crate) enum GfxTarget {
+    #[strum(serialize = "gfx900")]
+    Gfx900 = 90_000,
+    #[strum(serialize = "gfx902", props(integrated = "true"))]
+    Gfx902 = 90_002,
+    #[strum(serialize = "gfx904")]
+    Gfx904 = 90_004,
+    #[strum(serialize = "gfx906")]
+    Gfx906 = 90_006,
+    #[strum(serialize = "gfx908", props(linux = "true"))]
+    Gfx908 = 90_008,
+    #[strum(serialize = "gfx909", props(integrated = "true"))]
+    Gfx909 = 90_009,
+    #[strum(serialize = "gfx90a", props(linux = "true"))]
+    Gfx90a = 90_010,
+    #[strum(serialize = "gfx90c", props(integrated = "true"))]
+    Gfx90c = 90_012,
+    #[strum(serialize = "gfx942", props(linux = "true"))]
+    Gfx942 = 90_402,
+    #[strum(serialize = "gfx950", props(linux = "true"))]
+    Gfx950 = 90_500,
+    #[strum(serialize = "gfx1010", props(windows = "true", linux = "true"))]
+    Gfx1010 = 100_100,
+    #[strum(serialize = "gfx1011", props(windows = "true", linux = "true"))]
+    Gfx1011 = 100_101,
+    #[strum(serialize = "gfx1012", props(windows = "true", linux = "true"))]
+    Gfx1012 = 100_102,
+    #[strum(serialize = "gfx1013", props(integrated = "true"))]
+    Gfx1013 = 100_103,
+    #[strum(serialize = "gfx1030", props(windows = "true", linux = "true"))]
+    Gfx1030 = 100_300,
+    #[strum(serialize = "gfx1031", props(windows = "true", linux = "true"))]
+    Gfx1031 = 100_301,
+    #[strum(serialize = "gfx1032", props(windows = "true", linux = "true"))]
+    Gfx1032 = 100_302,
+    #[strum(
+        serialize = "gfx1033",
+        props(integrated = "true", windows = "true", linux = "true")
+    )]
+    Gfx1033 = 100_303,
+    #[strum(serialize = "gfx1034", props(windows = "true", linux = "true"))]
+    Gfx1034 = 100_304,
+    #[strum(
+        serialize = "gfx1035",
+        props(integrated = "true", windows = "true", linux = "true")
+    )]
+    Gfx1035 = 100_305,
+    #[strum(
+        serialize = "gfx1036",
+        props(integrated = "true", windows = "true", linux = "true")
+    )]
+    Gfx1036 = 100_306,
+    #[strum(serialize = "gfx1100", props(windows = "true", linux = "true"))]
+    Gfx1100 = 110_000,
+    #[strum(serialize = "gfx1101", props(windows = "true", linux = "true"))]
+    Gfx1101 = 110_001,
+    #[strum(serialize = "gfx1102", props(windows = "true", linux = "true"))]
+    Gfx1102 = 110_002,
+    #[strum(serialize = "gfx1103", props(integrated = "true", windows = "true"))]
+    Gfx1103 = 110_003,
+    #[strum(
+        serialize = "gfx1150",
+        props(integrated = "true", windows = "true", linux = "true")
+    )]
+    Gfx1150 = 110_500,
+    #[strum(
+        serialize = "gfx1151",
+        props(integrated = "true", windows = "true", linux = "true")
+    )]
+    Gfx1151 = 110_501,
+    #[strum(
+        serialize = "gfx1152",
+        props(integrated = "true", windows = "true", linux = "true")
+    )]
+    Gfx1152 = 110_502,
+    #[strum(serialize = "gfx1153", props(integrated = "true", windows = "true"))]
+    Gfx1153 = 110_503,
+    #[strum(serialize = "gfx1200", props(windows = "true", linux = "true"))]
+    Gfx1200 = 120_000,
+    #[strum(serialize = "gfx1201", props(windows = "true", linux = "true"))]
+    Gfx1201 = 120_001,
+    #[strum(serialize = "gfx1250")]
+    Gfx1250 = 120_500,
+    #[strum(serialize = "gfx1251")]
+    Gfx1251 = 120_501,
 }
-
-pub(super) const KNOWN_TARGETS: &[GfxTarget] = &[
-    GfxTarget {
-        name: "gfx900",
-        version: 90_000,
-        device_type: Gpu,
-    },
-    GfxTarget {
-        name: "gfx902",
-        version: 90_002,
-        device_type: IntegratedGpu,
-    },
-    GfxTarget {
-        name: "gfx904",
-        version: 90_004,
-        device_type: Gpu,
-    },
-    GfxTarget {
-        name: "gfx906",
-        version: 90_006,
-        device_type: Gpu,
-    },
-    GfxTarget {
-        name: "gfx908",
-        version: 90_008,
-        device_type: Gpu,
-    },
-    GfxTarget {
-        name: "gfx909",
-        version: 90_009,
-        device_type: IntegratedGpu,
-    },
-    GfxTarget {
-        name: "gfx90a",
-        version: 90_010,
-        device_type: Gpu,
-    },
-    GfxTarget {
-        name: "gfx90c",
-        version: 90_012,
-        device_type: IntegratedGpu,
-    },
-    GfxTarget {
-        name: "gfx942",
-        version: 90_402,
-        device_type: Gpu,
-    },
-    GfxTarget {
-        name: "gfx950",
-        version: 90_500,
-        device_type: Gpu,
-    },
-    GfxTarget {
-        name: "gfx1010",
-        version: 100_100,
-        device_type: Gpu,
-    },
-    GfxTarget {
-        name: "gfx1011",
-        version: 100_101,
-        device_type: Gpu,
-    },
-    GfxTarget {
-        name: "gfx1012",
-        version: 100_102,
-        device_type: Gpu,
-    },
-    GfxTarget {
-        name: "gfx1013",
-        version: 100_103,
-        device_type: IntegratedGpu,
-    },
-    GfxTarget {
-        name: "gfx1030",
-        version: 100_300,
-        device_type: Gpu,
-    },
-    GfxTarget {
-        name: "gfx1031",
-        version: 100_301,
-        device_type: Gpu,
-    },
-    GfxTarget {
-        name: "gfx1032",
-        version: 100_302,
-        device_type: Gpu,
-    },
-    GfxTarget {
-        name: "gfx1033",
-        version: 100_303,
-        device_type: IntegratedGpu,
-    },
-    GfxTarget {
-        name: "gfx1034",
-        version: 100_304,
-        device_type: Gpu,
-    },
-    GfxTarget {
-        name: "gfx1035",
-        version: 100_305,
-        device_type: IntegratedGpu,
-    },
-    GfxTarget {
-        name: "gfx1036",
-        version: 100_306,
-        device_type: IntegratedGpu,
-    },
-    GfxTarget {
-        name: "gfx1100",
-        version: 110_000,
-        device_type: Gpu,
-    },
-    GfxTarget {
-        name: "gfx1101",
-        version: 110_001,
-        device_type: Gpu,
-    },
-    GfxTarget {
-        name: "gfx1102",
-        version: 110_002,
-        device_type: Gpu,
-    },
-    GfxTarget {
-        name: "gfx1103",
-        version: 110_003,
-        device_type: IntegratedGpu,
-    },
-    GfxTarget {
-        name: "gfx1150",
-        version: 110_500,
-        device_type: IntegratedGpu,
-    },
-    GfxTarget {
-        name: "gfx1151",
-        version: 110_501,
-        device_type: IntegratedGpu,
-    },
-    GfxTarget {
-        name: "gfx1152",
-        version: 110_502,
-        device_type: IntegratedGpu,
-    },
-    GfxTarget {
-        name: "gfx1153",
-        version: 110_503,
-        device_type: IntegratedGpu,
-    },
-    GfxTarget {
-        name: "gfx1200",
-        version: 120_000,
-        device_type: Gpu,
-    },
-    GfxTarget {
-        name: "gfx1201",
-        version: 120_001,
-        device_type: Gpu,
-    },
-    GfxTarget {
-        name: "gfx1250",
-        version: 120_500,
-        device_type: Gpu,
-    },
-    GfxTarget {
-        name: "gfx1251",
-        version: 120_501,
-        device_type: Gpu,
-    },
-];

--- a/crates/koharu-runtime/src/hardware/hip/windows.rs
+++ b/crates/koharu-runtime/src/hardware/hip/windows.rs
@@ -2,8 +2,10 @@
 
 use std::ffi::c_void;
 
-use super::targets::KNOWN_TARGETS;
-use crate::{Backend, Device};
+use strum::EnumProperty;
+
+use super::GfxTarget;
+use crate::{Backend, Device, DeviceType};
 
 type ClInt = i32;
 type ClUint = u32;
@@ -75,20 +77,24 @@ pub(super) fn probe() -> Vec<Device> {
             let Some(name) = opencl.device_name(device) else {
                 continue;
             };
-            let Some(target) = KNOWN_TARGETS.iter().find(|target| target.name == name) else {
+            let Ok(target) = name.parse::<GfxTarget>() else {
                 continue;
             };
             let index = result.len();
             result.push(Device {
                 index,
                 name: format!("ROCm{index}"),
-                description: target.name.to_owned(),
+                description: target.to_string(),
                 backend: Backend::Rocm,
-                device_type: target.device_type,
+                device_type: if target.get_str("integrated").is_some() {
+                    DeviceType::IntegratedGpu
+                } else {
+                    DeviceType::Gpu
+                },
                 memory_total: 0,
                 memory_free: 0,
                 compute_capability: 0,
-                target: Some(target.name.to_owned()),
+                target: Some(target),
             });
         }
     }

--- a/crates/koharu-runtime/src/hardware/mod.rs
+++ b/crates/koharu-runtime/src/hardware/mod.rs
@@ -4,7 +4,11 @@ mod vulkan;
 
 use std::{cmp::Reverse, sync::OnceLock};
 
+use strum::EnumProperty;
+
 use crate::{Backend, Device, DeviceType};
+
+pub(crate) use hip::GfxTarget;
 
 /// Accelerator capabilities and their process-wide selection priority.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
@@ -54,11 +58,41 @@ impl Hardware {
                 // ROCm, integrated CUDA, integrated ROCm, then Vulkan.
                 let category = match (&device.backend, device.is_integrated()) {
                     (Backend::Metal, _) => 0,
-                    (Backend::Cuda, false) if device.compute_capability >= 75 => 0,
-                    (Backend::Rocm, false) => 1,
-                    (Backend::Cuda, true) if device.compute_capability >= 75 => 2,
-                    (Backend::Rocm, true) => 3,
-                    (Backend::Vulkan, _) => 4,
+                    (Backend::Cuda, integrated)
+                        if cfg!(any(
+                            all(target_os = "windows", target_arch = "x86_64"),
+                            all(target_os = "linux", target_arch = "x86_64"),
+                            all(target_os = "linux", target_arch = "aarch64")
+                        )) && device.compute_capability >= 75 =>
+                    {
+                        if integrated {
+                            2
+                        } else {
+                            0
+                        }
+                    }
+                    (Backend::Rocm, integrated)
+                        if cfg!(all(
+                            target_arch = "x86_64",
+                            any(target_os = "windows", target_os = "linux")
+                        )) && device.target.is_some_and(|target| {
+                            target.get_str(std::env::consts::OS).is_some()
+                        }) =>
+                    {
+                        if integrated {
+                            3
+                        } else {
+                            1
+                        }
+                    }
+                    (Backend::Vulkan, _)
+                        if cfg!(all(
+                            target_arch = "x86_64",
+                            any(target_os = "windows", target_os = "linux")
+                        )) =>
+                    {
+                        4
+                    }
                     _ => return None,
                 };
                 Some((position, category))
@@ -110,7 +144,11 @@ impl Hardware {
 
     #[must_use]
     pub fn supports_cuda(&self) -> bool {
-        matches!(self.device(), Some(device) if device.backend == Backend::Cuda)
+        cfg!(any(
+            all(target_os = "windows", target_arch = "x86_64"),
+            all(target_os = "linux", target_arch = "x86_64"),
+            all(target_os = "linux", target_arch = "aarch64")
+        )) && matches!(self.device(), Some(device) if device.backend == Backend::Cuda && device.compute_capability >= 75)
     }
 
     #[must_use]
@@ -122,23 +160,74 @@ impl Hardware {
 
     #[must_use]
     pub fn supports_rocm(&self) -> bool {
-        matches!(self.device(), Some(device) if device.backend == Backend::Rocm)
+        cfg!(all(
+            target_arch = "x86_64",
+            any(target_os = "windows", target_os = "linux")
+        )) && self
+            .rocm_target()
+            .is_some_and(|target| target.get_str(std::env::consts::OS).is_some())
     }
 
-    #[must_use]
-    pub fn rocm_target(&self) -> Option<&str> {
+    pub(crate) fn rocm_target(&self) -> Option<GfxTarget> {
         self.device()
             .filter(|device| device.backend == Backend::Rocm)
-            .and_then(Device::target)
+            .and_then(|device| device.target)
     }
 
     #[must_use]
     pub fn supports_vulkan(&self) -> bool {
-        matches!(self.device(), Some(device) if device.backend == Backend::Vulkan)
+        cfg!(all(
+            target_arch = "x86_64",
+            any(target_os = "windows", target_os = "linux")
+        )) && matches!(self.device(), Some(device) if device.backend == Backend::Vulkan)
     }
 
     #[must_use]
     pub fn supports_metal(&self) -> bool {
-        matches!(self.device(), Some(device) if device.backend == Backend::Metal)
+        cfg!(all(target_os = "macos", target_arch = "aarch64"))
+            && matches!(self.device(), Some(device) if device.backend == Backend::Metal)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_supported_targets() {
+        let supported = |target: &str| {
+            let Ok(target) = target.parse::<GfxTarget>() else {
+                return false;
+            };
+            Hardware {
+                devices: vec![Device {
+                    target: Some(target),
+                    ..Device::rocm(0)
+                }],
+                candidates: vec![0],
+                selected: Some(0),
+            }
+            .supports_rocm()
+        };
+        let x64_rocm = cfg!(all(
+            target_arch = "x86_64",
+            any(target_os = "windows", target_os = "linux")
+        ));
+        assert_eq!(supported("gfx1010"), x64_rocm);
+        assert_eq!(supported("gfx1036"), x64_rocm);
+        assert_eq!(supported("gfx1201"), x64_rocm);
+        assert_eq!(
+            supported("gfx908"),
+            cfg!(all(target_os = "linux", target_arch = "x86_64"))
+        );
+        assert_eq!(
+            supported("gfx1103"),
+            cfg!(all(target_os = "windows", target_arch = "x86_64"))
+        );
+        assert_eq!(
+            supported("gfx1153"),
+            cfg!(all(target_os = "windows", target_arch = "x86_64"))
+        );
+        assert!(!supported("gfx1251"));
     }
 }

--- a/crates/koharu-runtime/src/runtime/graph.rs
+++ b/crates/koharu-runtime/src/runtime/graph.rs
@@ -34,13 +34,13 @@ impl Component {
         }
     }
 
-    async fn activate(self) -> Result<()> {
+    async fn activate(self, device: &mut Device) -> Result<()> {
         match self {
-            Self::Cuda(package) => activate(package).await,
-            Self::Rocm(package) => activate(package).await,
-            Self::Torch(package) => activate(package).await,
-            Self::Llama(package) => activate(package).await,
-            Self::Diffusion(package) => activate(package).await,
+            Self::Cuda(package) => activate(package, device).await,
+            Self::Rocm(package) => activate(package, device).await,
+            Self::Torch(package) => activate(package, device).await,
+            Self::Llama(package) => activate(package, device).await,
+            Self::Diffusion(package) => activate(package, device).await,
         }
     }
 
@@ -55,9 +55,9 @@ impl Component {
     }
 }
 
-async fn activate<P: RuntimePackage>(package: P) -> Result<()> {
+async fn activate<P: RuntimePackage>(package: P, device: &mut Device) -> Result<()> {
     package
-        .activate()
+        .activate(device)
         .await
         .with_context(|| format!("failed to activate {}", package.label()))
 }
@@ -94,6 +94,7 @@ impl From<Diffusion> for Component {
 
 #[derive(Debug, Default)]
 pub(crate) struct Plan {
+    pub(super) uses_accelerator: bool,
     graph: DiGraph<Component, ()>,
     nodes: HashMap<Component, NodeIndex>,
     expanded: HashSet<Component>,
@@ -105,9 +106,12 @@ impl Plan {
         P: DiscoverablePackage,
         Component: From<P>,
     {
-        P::discover(hardware)
-            .map(|package| self.insert(package.into(), hardware))
-            .transpose()
+        let Some(package) = P::discover(hardware) else {
+            return Ok(None);
+        };
+        let node = self.insert(package.into(), hardware)?;
+        self.uses_accelerator |= package.uses_accelerator();
+        Ok(Some(node))
     }
 
     fn insert(&mut self, component: Component, hardware: &Hardware) -> Result<NodeIndex> {
@@ -143,12 +147,7 @@ impl Plan {
             )
         })?;
         for node in order {
-            let component = self.graph[node];
-            component.activate().await?;
-            if let Component::Rocm(rocm) = component {
-                device.index = rocm.probe().await?;
-                device.name = format!("ROCm{}", device.index);
-            }
+            self.graph[node].activate(&mut device).await?;
         }
         Ok(device)
     }

--- a/crates/koharu-runtime/src/runtime/loader.rs
+++ b/crates/koharu-runtime/src/runtime/loader.rs
@@ -1,13 +1,14 @@
-use std::{mem::forget, path::Path};
+use std::path::Path;
 
 use anyhow::Result;
 
-pub(super) fn load(path: impl AsRef<Path>, global: bool) -> Result<()> {
+pub(super) fn load(path: impl AsRef<Path>, global: bool) -> Result<&'static libloading::Library> {
     let path = path.as_ref();
     let path = dunce::canonicalize(path)?;
     let library = unsafe { open(&path, global) }?;
-    forget(library);
-    Ok(())
+    // Native backends retain symbols for the process lifetime. Return the same
+    // retained handle to packages that need to inspect their loaded runtime.
+    Ok(Box::leak(Box::new(library)))
 }
 
 #[cfg(windows)]

--- a/crates/koharu-runtime/src/runtime/mod.rs
+++ b/crates/koharu-runtime/src/runtime/mod.rs
@@ -29,7 +29,7 @@ pub(crate) trait RuntimePackage: Package + std::fmt::Debug + Eq + Hash {
         Ok(Vec::new())
     }
 
-    async fn activate(self) -> Result<()>;
+    async fn activate(self, device: &mut Device) -> Result<()>;
 
     fn label(self) -> String {
         format!("{} {self}", Self::NAME)
@@ -38,6 +38,10 @@ pub(crate) trait RuntimePackage: Package + std::fmt::Debug + Eq + Hash {
 
 pub(crate) trait DiscoverablePackage: RuntimePackage {
     fn discover(hardware: &Hardware) -> Option<Self>;
+
+    fn uses_accelerator(self) -> bool {
+        true
+    }
 }
 
 /// A process-wide runtime capability requested by a consumer.
@@ -57,10 +61,19 @@ pub struct Runtime {
 
 impl Runtime {
     pub fn discover(features: impl IntoIterator<Item = Feature>) -> Result<Self> {
-        let features = features.into_iter().collect::<Vec<_>>();
+        let mut requested = Vec::new();
+        for feature in features {
+            if !requested.contains(&feature) {
+                requested.push(feature);
+            }
+        }
         let hardware = Hardware::discover();
         for candidate in hardware.candidates() {
-            if let Some(plan) = Self::plan(&features, &candidate)? {
+            if let Some(plan) = Self::plan(&requested, &candidate)? {
+                // Keep looking when every requested package falls back to CPU.
+                if candidate.device().is_some() && !plan.uses_accelerator {
+                    continue;
+                }
                 return Ok(Self {
                     plan,
                     hardware: candidate,

--- a/crates/koharu-runtime/src/runtime/packages/cuda.rs
+++ b/crates/koharu-runtime/src/runtime/packages/cuda.rs
@@ -5,7 +5,7 @@ use strum::EnumProperty;
 use walkdir::WalkDir;
 
 use crate::{
-    Store, download,
+    Device, Store, download,
     runtime::{Package, RuntimePackage, loader, sealed},
     source::{Platform, extract, wheel},
 };
@@ -152,12 +152,16 @@ impl sealed::Sealed for Cuda {}
 impl Package for Cuda {
     async fn install(self) -> Result<PathBuf> {
         let project = self.project()?;
-        let target = Store::root().join("cuda").join(project.replace('/', "--"));
+        let platform = Platform::host()?;
+        let target = Store::root()
+            .join("cuda")
+            .join(project.replace('/', "--"))
+            .join(platform.to_string());
         Store::directory(
             target,
             move |path| self.library_paths(path).is_ok(),
             move |stage| async move {
-                let url = wheel(project, Platform::host()?).await?;
+                let url = wheel(project, platform).await?;
                 let archive = tempfile::Builder::new().suffix(".whl").tempfile()?;
                 download::fetch(&url, archive.path()).await?;
                 extract(
@@ -174,7 +178,7 @@ impl Package for Cuda {
 impl RuntimePackage for Cuda {
     const NAME: &'static str = "CUDA";
 
-    async fn activate(self) -> Result<()> {
+    async fn activate(self, _device: &mut Device) -> Result<()> {
         let directory = self.install().await?;
         for library in self.library_paths(&directory)? {
             loader::load(library, false)?;

--- a/crates/koharu-runtime/src/runtime/packages/diffusion.rs
+++ b/crates/koharu-runtime/src/runtime/packages/diffusion.rs
@@ -1,10 +1,10 @@
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use strum::EnumProperty;
 
 use crate::{
-    Hardware, Store, download,
+    Device, Hardware, Store, download,
     runtime::{
         DiscoverablePackage, Package, RuntimePackage,
         graph::Component,
@@ -89,25 +89,21 @@ impl Diffusion {
         self.get_str("library")
             .expect("diffusion package has a library")
     }
-
-    fn complete(self, path: &Path) -> bool {
-        path.join(self.library()).is_file()
-    }
 }
 
 impl sealed::Sealed for Diffusion {}
 
 impl Package for Diffusion {
     async fn install(self) -> Result<PathBuf> {
-        let target = Store::root()
+        let asset = self.asset();
+        let path = Store::root()
             .join("diffusion")
             .join(RELEASE)
-            .join(self.to_string());
+            .join(asset.trim_end_matches(".tar.gz"));
         Store::directory(
-            target,
-            move |path| self.complete(path),
+            path,
+            move |path| path.join(self.library()).is_file(),
             move |stage| async move {
-                let asset = self.asset();
                 let url = format!(
                     "https://github.com/koharu-rs/diffusion/releases/download/{RELEASE}/{asset}"
                 );
@@ -126,32 +122,28 @@ impl Package for Diffusion {
 
 impl DiscoverablePackage for Diffusion {
     fn discover(hardware: &Hardware) -> Option<Self> {
-        if cfg!(all(target_os = "windows", target_arch = "x86_64")) {
-            if hardware.supports_cuda() {
-                return Some(Self::WindowsCuda);
-            }
-            if Rocm::discover(hardware).is_ok() {
-                return Some(Self::WindowsHip);
-            }
-            if hardware.supports_vulkan() {
-                return Some(Self::WindowsVulkan);
-            }
-            None
-        } else if cfg!(all(target_os = "linux", target_arch = "x86_64")) {
-            if hardware.supports_cuda() {
-                return Some(Self::LinuxCuda);
-            }
-            if Rocm::discover(hardware).is_ok() {
-                return Some(Self::LinuxHip);
-            }
-            hardware.supports_vulkan().then_some(Self::LinuxVulkan)
-        } else if cfg!(all(target_os = "linux", target_arch = "aarch64")) {
-            hardware.supports_cuda().then_some(Self::LinuxCuda)
-        } else if hardware.supports_metal() {
-            Some(Self::MacosMetal)
-        } else {
-            None
+        if hardware.supports_cuda() {
+            return Some(if cfg!(target_os = "windows") {
+                Self::WindowsCuda
+            } else {
+                Self::LinuxCuda
+            });
         }
+        if hardware.supports_rocm() {
+            return Some(if cfg!(target_os = "windows") {
+                Self::WindowsHip
+            } else {
+                Self::LinuxHip
+            });
+        }
+        if hardware.supports_vulkan() {
+            return Some(if cfg!(target_os = "windows") {
+                Self::WindowsVulkan
+            } else {
+                Self::LinuxVulkan
+            });
+        }
+        hardware.supports_metal().then_some(Self::MacosMetal)
     }
 }
 
@@ -164,15 +156,18 @@ impl RuntimePackage for Diffusion {
                 Component::Cuda(Cuda::Runtime13),
                 Component::Cuda(Cuda::Blas13),
             ]),
-            Self::WindowsHip | Self::LinuxHip => {
-                Ok(vec![Component::Rocm(Rocm::discover(hardware)?)])
-            }
+            Self::WindowsHip | Self::LinuxHip => Ok(vec![Component::Rocm(Rocm(
+                hardware
+                    .rocm_target()
+                    .context("no ROCm device was discovered")?,
+            ))]),
             Self::WindowsVulkan | Self::LinuxVulkan | Self::MacosMetal => Ok(Vec::new()),
         }
     }
 
-    async fn activate(self) -> Result<()> {
+    async fn activate(self, _device: &mut Device) -> Result<()> {
         let root = self.install().await?;
-        loader::load(root.join(self.library()), false)
+        loader::load(root.join(self.library()), false)?;
+        Ok(())
     }
 }

--- a/crates/koharu-runtime/src/runtime/packages/llama.rs
+++ b/crates/koharu-runtime/src/runtime/packages/llama.rs
@@ -1,10 +1,10 @@
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 use strum::EnumProperty;
 
 use crate::{
-    Hardware, Store, download,
+    Device, Hardware, Store, download,
     runtime::{
         DiscoverablePackage, Package, RuntimePackage,
         graph::Component,
@@ -89,25 +89,21 @@ impl Llama {
             .expect("llama package has libraries")
             .split(',')
     }
-
-    fn complete(self, path: &Path) -> bool {
-        self.libraries().all(|name| path.join(name).is_file())
-    }
 }
 
 impl sealed::Sealed for Llama {}
 
 impl Package for Llama {
     async fn install(self) -> Result<PathBuf> {
-        let target = Store::root()
+        let asset = self.asset();
+        let path = Store::root()
             .join("llama")
             .join(RELEASE)
-            .join(self.to_string());
+            .join(asset.trim_end_matches(".tar.gz"));
         Store::directory(
-            target,
-            move |path| self.complete(path),
+            path,
+            move |path| self.libraries().all(|name| path.join(name).is_file()),
             move |stage| async move {
-                let asset = self.asset();
                 let url = format!(
                     "https://github.com/koharu-rs/llama/releases/download/{RELEASE}/{asset}"
                 );
@@ -126,32 +122,28 @@ impl Package for Llama {
 
 impl DiscoverablePackage for Llama {
     fn discover(hardware: &Hardware) -> Option<Self> {
-        if cfg!(all(target_os = "windows", target_arch = "x86_64")) {
-            if hardware.supports_cuda() {
-                return Some(Self::WindowsCuda);
-            }
-            if Rocm::discover(hardware).is_ok() {
-                return Some(Self::WindowsHip);
-            }
-            if hardware.supports_vulkan() {
-                return Some(Self::WindowsVulkan);
-            }
-            None
-        } else if cfg!(all(target_os = "linux", target_arch = "x86_64")) {
-            if hardware.supports_cuda() {
-                return Some(Self::LinuxCuda);
-            }
-            if Rocm::discover(hardware).is_ok() {
-                return Some(Self::LinuxHip);
-            }
-            hardware.supports_vulkan().then_some(Self::LinuxVulkan)
-        } else if cfg!(all(target_os = "linux", target_arch = "aarch64")) {
-            hardware.supports_cuda().then_some(Self::LinuxCuda)
-        } else if hardware.supports_metal() {
-            Some(Self::MacosMetal)
-        } else {
-            None
+        if hardware.supports_cuda() {
+            return Some(if cfg!(target_os = "windows") {
+                Self::WindowsCuda
+            } else {
+                Self::LinuxCuda
+            });
         }
+        if hardware.supports_rocm() {
+            return Some(if cfg!(target_os = "windows") {
+                Self::WindowsHip
+            } else {
+                Self::LinuxHip
+            });
+        }
+        if hardware.supports_vulkan() {
+            return Some(if cfg!(target_os = "windows") {
+                Self::WindowsVulkan
+            } else {
+                Self::LinuxVulkan
+            });
+        }
+        hardware.supports_metal().then_some(Self::MacosMetal)
     }
 }
 
@@ -164,14 +156,16 @@ impl RuntimePackage for Llama {
                 Component::Cuda(Cuda::Runtime13),
                 Component::Cuda(Cuda::Blas13),
             ]),
-            Self::WindowsHip | Self::LinuxHip => {
-                Ok(vec![Component::Rocm(Rocm::discover(hardware)?)])
-            }
+            Self::WindowsHip | Self::LinuxHip => Ok(vec![Component::Rocm(Rocm(
+                hardware
+                    .rocm_target()
+                    .context("no ROCm device was discovered")?,
+            ))]),
             Self::WindowsVulkan | Self::LinuxVulkan | Self::MacosMetal => Ok(Vec::new()),
         }
     }
 
-    async fn activate(self) -> Result<()> {
+    async fn activate(self, _device: &mut Device) -> Result<()> {
         let root = self.install().await?;
         for library in self.libraries() {
             loader::load(root.join(library), false)

--- a/crates/koharu-runtime/src/runtime/packages/rocm.rs
+++ b/crates/koharu-runtime/src/runtime/packages/rocm.rs
@@ -1,16 +1,20 @@
-use std::{
-    ffi::c_void,
-    path::{Path, PathBuf},
-};
+use std::path::{Path, PathBuf};
+
+#[cfg(any(target_os = "windows", target_os = "linux"))]
+use std::ffi::c_void;
 
 use anyhow::{Context, Result};
 use strum::IntoEnumIterator;
 
 use crate::{
-    Hardware, Store, download,
-    runtime::{Package, RuntimePackage, loader, sealed},
+    Device, Store, download,
+    hardware::GfxTarget,
+    runtime::{Package, RuntimePackage, sealed},
     source::extract,
 };
+
+#[cfg(any(target_os = "windows", target_os = "linux"))]
+use crate::runtime::loader;
 
 pub(crate) const VERSION: &str = "10.0.0";
 pub(crate) const INDEX: &str = "https://stable.repo.amd.com/rocm/core/whl-next";
@@ -129,110 +133,23 @@ enum Library {
     Unsupported,
 }
 
-pub(crate) fn wheel_platform() -> Result<&'static str> {
-    if cfg!(all(target_os = "windows", target_arch = "x86_64")) {
-        Ok("win_amd64")
-    } else if cfg!(all(target_os = "linux", target_arch = "x86_64")) {
-        Ok("linux_x86_64")
-    } else {
-        anyhow::bail!("ROCm packages support only Windows and Linux x86_64")
-    }
-}
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(crate) struct Rocm(pub(crate) GfxTarget);
 
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, strum::Display, strum::EnumString)]
-pub(crate) enum Rocm {
-    #[cfg(target_os = "linux")]
-    #[strum(serialize = "gfx908")]
-    Gfx908,
-    #[cfg(target_os = "linux")]
-    #[strum(serialize = "gfx90a")]
-    Gfx90a,
-    #[cfg(target_os = "linux")]
-    #[strum(serialize = "gfx942")]
-    Gfx942,
-    #[cfg(target_os = "linux")]
-    #[strum(serialize = "gfx950")]
-    Gfx950,
-    #[strum(serialize = "gfx1010")]
-    Gfx1010,
-    #[strum(serialize = "gfx1011")]
-    Gfx1011,
-    #[strum(serialize = "gfx1012")]
-    Gfx1012,
-    #[strum(serialize = "gfx1030")]
-    Gfx1030,
-    #[strum(serialize = "gfx1031")]
-    Gfx1031,
-    #[strum(serialize = "gfx1032")]
-    Gfx1032,
-    #[strum(serialize = "gfx1033")]
-    Gfx1033,
-    #[strum(serialize = "gfx1034")]
-    Gfx1034,
-    #[strum(serialize = "gfx1035")]
-    Gfx1035,
-    #[strum(serialize = "gfx1036")]
-    Gfx1036,
-    #[strum(serialize = "gfx1100")]
-    Gfx1100,
-    #[strum(serialize = "gfx1101")]
-    Gfx1101,
-    #[strum(serialize = "gfx1102")]
-    Gfx1102,
-    #[cfg(target_os = "windows")]
-    #[strum(serialize = "gfx1103")]
-    Gfx1103,
-    #[strum(serialize = "gfx1150")]
-    Gfx1150,
-    #[strum(serialize = "gfx1151")]
-    Gfx1151,
-    #[strum(serialize = "gfx1152")]
-    Gfx1152,
-    #[cfg(target_os = "windows")]
-    #[strum(serialize = "gfx1153")]
-    Gfx1153,
-    #[strum(serialize = "gfx1200")]
-    Gfx1200,
-    #[strum(serialize = "gfx1201")]
-    Gfx1201,
+impl std::fmt::Display for Rocm {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(formatter)
+    }
 }
 
 impl Rocm {
-    pub(crate) fn discover(hardware: &Hardware) -> Result<Self> {
-        hardware
-            .rocm_target()
-            .context("no ROCm device was discovered")?
-            .parse()
-            .context("ROCm device is unsupported")
-    }
-
-    pub(crate) async fn probe(self) -> Result<usize> {
+    #[cfg(any(target_os = "windows", target_os = "linux"))]
+    fn probe(self, library: &libloading::Library) -> Result<usize> {
         type GetDeviceCount = unsafe extern "C" fn(*mut i32) -> i32;
         type GetDeviceProperties = unsafe extern "C" fn(*mut c_void, i32) -> i32;
 
         #[repr(C, align(64))]
         struct Properties([u8; 64 * 1024]);
-
-        let root = self.install().await?;
-        let path = if cfg!(target_os = "windows") {
-            root.join("_rocm_sdk_core/bin/amdhip64_7.dll")
-        } else if cfg!(target_os = "linux") {
-            root.join("_rocm_sdk_core/lib/libamdhip64.so.7")
-        } else {
-            anyhow::bail!("ROCm packages support only Windows and Linux")
-        };
-
-        #[cfg(target_os = "windows")]
-        let library: libloading::Library = unsafe {
-            libloading::os::windows::Library::load_with_flags(
-                &path,
-                libloading::os::windows::LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR
-                    | libloading::os::windows::LOAD_LIBRARY_SEARCH_SYSTEM32,
-            )?
-            .into()
-        };
-        #[cfg(not(target_os = "windows"))]
-        let library = unsafe { libloading::Library::new(&path)? };
 
         let get_device_count = unsafe { *library.get::<GetDeviceCount>(b"hipGetDeviceCount\0")? };
         let get_device_properties =
@@ -285,18 +202,18 @@ impl Rocm {
         #[cfg(target_os = "linux")]
         let device_library = {
             let root = path.join("_rocm_sdk_libraries/lib/rocblas/library");
-            match self {
-                Self::Gfx90a => {
+            match self.0 {
+                GfxTarget::Gfx90a => {
                     let root = root.join("gfx90a");
                     root.join("Kernels.so-000-gfx90a-xnack+.hsaco").is_file()
                         && root.join("Kernels.so-000-gfx90a-xnack-.hsaco").is_file()
                 }
-                Self::Gfx908
-                | Self::Gfx942
-                | Self::Gfx950
-                | Self::Gfx1150
-                | Self::Gfx1151
-                | Self::Gfx1152 => root
+                GfxTarget::Gfx908
+                | GfxTarget::Gfx942
+                | GfxTarget::Gfx950
+                | GfxTarget::Gfx1150
+                | GfxTarget::Gfx1151
+                | GfxTarget::Gfx1152 => root
                     .join(self.to_string())
                     .join(format!("Kernels.so-000-{self}.hsaco"))
                     .is_file(),
@@ -313,10 +230,17 @@ impl sealed::Sealed for Rocm {}
 
 impl Package for Rocm {
     async fn install(self) -> Result<PathBuf> {
-        let platform = wheel_platform()?;
+        let (platform, target) = if cfg!(all(target_os = "windows", target_arch = "x86_64")) {
+            ("win_amd64", "x86_64-pc-windows-msvc")
+        } else if cfg!(all(target_os = "linux", target_arch = "x86_64")) {
+            ("linux_x86_64", "x86_64-unknown-linux-gnu")
+        } else {
+            anyhow::bail!("ROCm packages support only Windows and Linux x86_64")
+        };
         let path = Store::root()
             .join("rocm")
             .join(VERSION)
+            .join(target)
             .join(self.to_string());
         Store::directory(
             path,
@@ -356,39 +280,25 @@ impl Package for Rocm {
 impl RuntimePackage for Rocm {
     const NAME: &'static str = "ROCm";
 
-    async fn activate(self) -> Result<()> {
-        let root = self.install().await?;
-        if !cfg!(any(target_os = "windows", target_os = "linux")) {
+    async fn activate(self, device: &mut Device) -> Result<()> {
+        #[cfg(any(target_os = "windows", target_os = "linux"))]
+        {
+            let root = self.install().await?;
+            let mut hip = None;
+            for library in Library::iter() {
+                let loaded = loader::load(root.join(library.to_string()), true)?;
+                if matches!(library, Library::Hip) {
+                    hip = Some(loaded);
+                }
+            }
+            device.index = self.probe(hip.context("ROCm manifest has no HIP library")?)?;
+            device.name = format!("ROCm{}", device.index);
+            Ok(())
+        }
+        #[cfg(not(any(target_os = "windows", target_os = "linux")))]
+        {
+            let _ = device;
             anyhow::bail!("ROCm packages support only Windows and Linux")
         }
-        for library in Library::iter() {
-            loader::load(root.join(library.to_string()), true)?;
-        }
-        Ok(())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn parses_supported_targets() {
-        assert_eq!("gfx1010".parse(), Ok(Rocm::Gfx1010));
-        assert_eq!("gfx1036".parse(), Ok(Rocm::Gfx1036));
-        assert_eq!("gfx1201".parse(), Ok(Rocm::Gfx1201));
-        #[cfg(target_os = "linux")]
-        assert_eq!("gfx908".parse(), Ok(Rocm::Gfx908));
-        #[cfg(not(target_os = "linux"))]
-        assert!("gfx908".parse::<Rocm>().is_err());
-        #[cfg(target_os = "windows")]
-        assert_eq!("gfx1103".parse(), Ok(Rocm::Gfx1103));
-        #[cfg(not(target_os = "windows"))]
-        assert!("gfx1103".parse::<Rocm>().is_err());
-        #[cfg(target_os = "windows")]
-        assert_eq!("gfx1153".parse(), Ok(Rocm::Gfx1153));
-        #[cfg(not(target_os = "windows"))]
-        assert!("gfx1153".parse::<Rocm>().is_err());
-        assert!("gfx1251".parse::<Rocm>().is_err());
     }
 }

--- a/crates/koharu-runtime/src/runtime/packages/torch.rs
+++ b/crates/koharu-runtime/src/runtime/packages/torch.rs
@@ -1,10 +1,10 @@
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 use strum::EnumProperty;
 
 use crate::{
-    Hardware, Store, download,
+    Device, Hardware, Store, download,
     runtime::{
         DiscoverablePackage, Package, RuntimePackage,
         graph::Component,
@@ -64,11 +64,6 @@ impl Torch {
             .split(','))
     }
 
-    fn complete(self, root: &Path) -> bool {
-        self.library_names()
-            .is_ok_and(|names| names.into_iter().all(|name| root.join(name).is_file()))
-    }
-
     fn asset(self) -> Result<String> {
         let target = if cfg!(all(target_os = "windows", target_arch = "x86_64")) {
             "x86_64-pc-windows-msvc"
@@ -89,15 +84,15 @@ impl sealed::Sealed for Torch {}
 
 impl Package for Torch {
     async fn install(self) -> Result<PathBuf> {
+        let asset = self.asset()?;
+        let libraries = self.library_names()?.collect::<Vec<_>>();
         let path = Store::root()
             .join("torch")
             .join(RELEASE)
-            .join(self.to_string());
-        let asset = self.asset()?;
-
+            .join(asset.trim_end_matches(".tar.gz"));
         Store::directory(
             path,
-            move |path| self.complete(path),
+            |path| libraries.iter().all(|name| path.join(name).is_file()),
             move |stage| async move {
                 let url = format!(
                     "https://github.com/koharu-rs/torch/releases/download/{RELEASE}/{asset}"
@@ -116,24 +111,25 @@ impl Package for Torch {
 }
 
 impl DiscoverablePackage for Torch {
+    fn uses_accelerator(self) -> bool {
+        self != Self::Cpu || cfg!(all(target_os = "macos", target_arch = "aarch64"))
+    }
+
     fn discover(hardware: &Hardware) -> Option<Self> {
         if hardware.supports_metal() {
             return Some(Self::Cpu);
         }
-        if cfg!(all(target_os = "linux", target_arch = "aarch64")) {
-            return hardware.supports_cuda().then_some(Self::Cuda);
+        if hardware.supports_cuda() {
+            return Some(Self::Cuda);
+        }
+        if hardware.supports_rocm() {
+            return Some(Self::Rocm);
         }
         if !cfg!(any(
             all(target_os = "windows", target_arch = "x86_64"),
             all(target_os = "linux", target_arch = "x86_64")
         )) {
             return None;
-        }
-        if hardware.supports_cuda() {
-            return Some(Self::Cuda);
-        }
-        if hardware.supports_rocm() && Rocm::discover(hardware).is_ok() {
-            return Some(Self::Rocm);
         }
         tracing::warn!("no supported Torch accelerator was discovered; using CPU");
         Some(Self::Cpu)
@@ -146,7 +142,11 @@ impl RuntimePackage for Torch {
     fn dependencies(self, hardware: &Hardware) -> Result<Vec<Component>> {
         match self {
             Self::Cpu => Ok(Vec::new()),
-            Self::Rocm => Ok(vec![Component::Rocm(Rocm::discover(hardware)?)]),
+            Self::Rocm => Ok(vec![Component::Rocm(Rocm(
+                hardware
+                    .rocm_target()
+                    .context("no ROCm device was discovered")?,
+            ))]),
             Self::Cuda => {
                 let packages = [
                     Cuda::Runtime13,
@@ -164,7 +164,7 @@ impl RuntimePackage for Torch {
         }
     }
 
-    async fn activate(self) -> Result<()> {
+    async fn activate(self, _device: &mut Device) -> Result<()> {
         let directory = self.install().await?;
         for library in self.library_names()? {
             loader::load(directory.join(library), false)?;

--- a/crates/koharu-runtime/src/source/pypi.rs
+++ b/crates/koharu-runtime/src/source/pypi.rs
@@ -1,12 +1,17 @@
+use std::time::Duration;
+
 use anyhow::{Context, Result};
 use serde::Deserialize;
 
 use crate::network;
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, strum::Display)]
 pub(crate) enum Platform {
+    #[strum(serialize = "x86_64-pc-windows-msvc")]
     WindowsX64,
+    #[strum(serialize = "x86_64-unknown-linux-gnu")]
     LinuxX64,
+    #[strum(serialize = "aarch64-unknown-linux-gnu")]
     LinuxArm64,
 }
 
@@ -48,6 +53,7 @@ pub(crate) async fn wheel(project: &str, platform: Platform) -> Result<String> {
     let client = network::http()?;
     let metadata: Metadata = client
         .get(&url)
+        .timeout(Duration::from_secs(network::config()?.read_timeout.max(1)))
         .send()
         .await
         .with_context(|| format!("failed to query {project}"))?


### PR DESCRIPTION
## Summary

Move CUDA platform/compute-capability and HIP compatibility checks into `Hardware`, using one hardware-owned `GfxTarget` definition for discovery and ROCm packaging. Each runtime package owns its installation logic and selects accelerators through `hardware.supports_cuda()` and `hardware.supports_rocm()`.

- Retain supported AMD GPUs when an unknown KFD architecture is encountered.
- Resolve Torch-only CPU plans correctly and deduplicate requested features before building the dependency graph.
- Bound metadata requests and emit terminal download events when sibling failures cancel downloads.
- Qualify native package cache paths by platform/architecture and probe ROCm through its already-loaded HIP handle.

The cache paths change, so native packages will download once into the new layout.

## Related issue

Related to #1052. The original bundled-HIP `hipErrorNoDevice` report still requires verification on the affected machine.

## Verification

- `cargo test -p koharu-runtime parses_supported_targets` passed on Windows and WSL Ubuntu/Linux.
- Compared all 33 architecture names, KFD versions, GPU classifications, and platform support flags with the previous definitions; all matched.
- Standalone reproductions passed for CUDA CC 61/74 rejection and 75/80 acceptance, unknown KFD nodes, unsupported HIP fallback, Torch-only CPU selection, duplicate features, package cache identities, stalled metadata requests, and download cancellation/completion events.
- `cargo fmt -p koharu-runtime -- --check` and `git diff --check` passed.

No physical GPU inference or end-to-end tests were run. The existing target test moved with its owning code; no additional unit tests were added.

## AI assistance

Codex assisted with investigation, implementation, and focused verification under maintainer direction. This draft is for maintainer review.
