### PR TITLE
configurable package store path

### DIFF
--- a/crates/koharu-app/src/app.rs
+++ b/crates/koharu-app/src/app.rs
@@ -113,15 +113,6 @@ pub fn run(context: tauri::Context<CefRuntime>) -> Result<()> {
         .plugin(tauri_plugin_updater::Builder::new().build())
         .invoke_handler(crate::commands::bindings().invoke_handler())
         .setup(move |application| {
-            #[cfg(target_os = "windows")]
-            koharu_runtime::Store::configure(
-                application
-                    .path()
-                    .resource_dir()
-                    .context("failed to locate Koharu's installation directory")?
-                    .join("store"),
-            )?;
-
             application.manage(CurrentProject {
                 project: Mutex::new(None),
             });

--- a/crates/koharu-renderer/src/error.rs
+++ b/crates/koharu-renderer/src/error.rs
@@ -35,7 +35,7 @@ pub enum Error {
         source: anyhow::Error,
     },
 
-    #[error("renderer backend failed")]
+    #[error("renderer backend failed: {0:#}")]
     Backend(#[source] anyhow::Error),
 }
 

--- a/crates/koharu-runtime/src/store.rs
+++ b/crates/koharu-runtime/src/store.rs
@@ -7,53 +7,50 @@ use std::{
 
 use anyhow::{Context, Result, ensure};
 use fs4::FileExt;
+use serde::{Deserialize, Serialize};
 
 static ROOT: OnceLock<PathBuf> = OnceLock::new();
+
+#[derive(Default, Deserialize, Serialize)]
+struct StoreConfig {
+    packages_path: Option<PathBuf>,
+}
 
 /// Koharu's process-wide immutable package store.
 pub struct Store;
 
 impl Store {
-    /// Selects the store before the first artifact or runtime is resolved.
-    pub fn configure(root: impl Into<PathBuf>) -> Result<()> {
-        let requested = root.into();
-        ensure!(
-            requested.is_absolute(),
-            "runtime store must be absolute: {}",
-            requested.display()
-        );
-
-        if let Some(active) = ROOT.get() {
-            ensure!(
-                active == &requested,
-                "runtime store is already {}",
-                active.display()
-            );
-            return Ok(());
-        }
-
-        if let Err(requested) = ROOT.set(requested) {
-            let active = ROOT
-                .get()
-                .context("runtime store was configured concurrently without a value")?;
-            ensure!(
-                active == &requested,
-                "runtime store is already {}",
-                active.display()
-            );
-        }
-        Ok(())
-    }
-
     /// Returns the configured root, or the operating system cache by default.
     #[must_use]
     pub fn root() -> &'static Path {
-        ROOT.get_or_init(|| {
-            dirs::cache_dir()
-                .unwrap_or_else(std::env::temp_dir)
-                .join("koharu")
-                .join("packages")
-        })
+        ROOT.get_or_init(Self::resolve_root)
+    }
+
+    fn resolve_root() -> PathBuf {
+        match Self::configured_packages_path() {
+            Some(path) if path.is_absolute() => path,
+            Some(path) => {
+                tracing::warn!(
+                    "ignoring non-absolute runtime packages_path: {}",
+                    path.display()
+                );
+                Self::default_root()
+            }
+            None => Self::default_root(),
+        }
+    }
+
+    fn configured_packages_path() -> Option<PathBuf> {
+        let section = koharu_config::load::<StoreConfig>("runtime").ok()?;
+        let value = section.read().ok()?;
+        value.packages_path.clone()
+    }
+
+    fn default_root() -> PathBuf {
+        dirs::cache_dir()
+            .unwrap_or_else(std::env::temp_dir)
+            .join("koharu")
+            .join("packages")
     }
 
     pub(crate) async fn directory<Valid, Install, Pending>(

--- a/crates/koharu-runtime/src/store.rs
+++ b/crates/koharu-runtime/src/store.rs
@@ -49,7 +49,7 @@ impl Store {
     fn default_root() -> PathBuf {
         dirs::cache_dir()
             .unwrap_or_else(std::env::temp_dir)
-            .join("koharu")
+            .join("Koharu")
             .join("packages")
     }
 


### PR DESCRIPTION
## Summary

Adds support for configuring the packages path via config.toml:

```toml
[runtime]
packages_path = "C:/EXAMPLE"
```

If packages_path is absolute, it is used as is. Otherwise the default location is used: %LOCALAPPDATA%\koharu\packages on windows (tested), and the same paths as before on linux and mac (not tested).

error.rs now surfaces the underlying cause instead of hiding it, so backend load failures show the real reason (e.g. a bad config.toml) instead of a bare "renderer backend failed".

Solves #1076, #942, and #1005.

Open questions
- Should this be exposed as a UI-visible setting, or is the current behavior plus documentation good enough?
- nsis uninstaller: currently removes the packages only if the "delete app data" checkbox is checked (it defaults to unchecked). Maybe it should be checked by default on uninstall, but stay unchecked during updates.
- msi uninstaller: currently leaves the packages behind. Maybe it should delete %LOCALAPPDATA%\koharu.
- Could we make the uninstallers read config.toml to determine the packages path instead of assuming the default?

## Test plan

Ran the program and verified where files were downloaded in all cases.