### PR TITLE
chore(app): default the processing scope to the selection

### DIFF
--- a/packages/docs/en/guides/processing.mdx
+++ b/packages/docs/en/guides/processing.mdx
@@ -4,7 +4,7 @@ description: 'Run detection, OCR, translation, and inpainting at the scope your 
 icon: 'play'
 ---
 
-The processing selector above the canvas controls the page scope and stages. Start with the smallest scope that covers the work. The selector starts on the selected-pages scope, which follows the page-rail selection.
+The processing selector above the canvas controls the page scope and stages. Start with the smallest scope that covers the work.
 
 ## Choose a scope
 

--- a/packages/docs/en/guides/processing.mdx
+++ b/packages/docs/en/guides/processing.mdx
@@ -4,7 +4,7 @@ description: 'Run detection, OCR, translation, and inpainting at the scope your 
 icon: 'play'
 ---
 
-The processing selector above the canvas controls the page scope and stages. Start with the smallest scope that covers the work.
+The processing selector above the canvas controls the page scope and stages. Start with the smallest scope that covers the work. The selector starts on the selected-pages scope, which follows the page-rail selection.
 
 ## Choose a scope
 

--- a/packages/koharu/lib/store.ts
+++ b/packages/koharu/lib/store.ts
@@ -101,7 +101,7 @@ export const useKoharuStore = create<KoharuStore>()((set) => ({
   tool: 'select',
   brush: { diameter: 48, color: '#FFFFFF' },
   inspector: 'copy',
-  processingScope: 'page',
+  processingScope: 'selected-pages',
   processingStages: [...pipelineStages],
   settingsOpen: false,
   shortcuts: defaultShortcuts,

--- a/packages/koharu/tests/components/editor-components.test.tsx
+++ b/packages/koharu/tests/components/editor-components.test.tsx
@@ -789,7 +789,7 @@ describe('greenfield editor', () => {
     render(<CanvasCommandBar />)
 
     fireEvent.click(screen.getByRole('button', { name: 'Processing settings' }))
-    fireEvent.click(screen.getByRole('button', { name: /Scope Page/ }))
+    fireEvent.click(screen.getByRole('button', { name: /Scope Selection/ }))
     fireEvent.click(screen.getByRole('button', { name: /Entire project/ }))
     fireEvent.click(screen.getByRole('button', { name: /Stages 4 stages/ }))
     fireEvent.click(screen.getByRole('button', { name: /Translation/ }))
@@ -817,7 +817,7 @@ describe('greenfield editor', () => {
     )
   })
 
-  it('runs the current page and exposes the runtime shortcuts', async () => {
+  it('runs the selected pages by default and exposes the runtime shortcuts', async () => {
     installProject()
     const run = vi.spyOn(commands, 'process').mockResolvedValue('job')
     render(<CanvasCommandBar />)
@@ -837,7 +837,7 @@ describe('greenfield editor', () => {
     fireEvent.click(selector)
     await waitFor(() => expect(commands.getTranslationModels).toHaveBeenCalled())
     expect(screen.getByRole('button', { name: /Model Gemma 4 E2B Instruct/ })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /Scope Page/ })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Scope Selection/ })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /Stages 4 stages/ })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /Output English/ })).toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: 'Settings' }))
@@ -919,7 +919,7 @@ describe('greenfield editor', () => {
     )
 
     await user.click(screen.getByRole('button', { name: 'Processing settings' }))
-    await user.click(screen.getByRole('button', { name: /Scope Page/ }))
+    await user.click(screen.getByRole('button', { name: /Scope Selection/ }))
     await user.click(screen.getByRole('button', { name: /Entire project/ }))
     await user.click(screen.getByRole('button', { name: /Stages 4 stages/ }))
     await user.click(screen.getByRole('button', { name: /Translation/ }))

--- a/packages/koharu/tests/setup.ts
+++ b/packages/koharu/tests/setup.ts
@@ -88,7 +88,7 @@ beforeEach(() => {
     tool: 'select',
     brush: { diameter: 48, color: '#FFFFFF' },
     inspector: 'copy',
-    processingScope: 'page',
+    processingScope: 'selected-pages',
     processingStages: ['detection', 'ocr', 'translation', 'inpainting'],
     settingsOpen: false,
     shortcuts: defaultShortcuts,


### PR DESCRIPTION
## Summary

The runtime selector above the canvas now starts on the selected-pages scope instead of the current page. The page rail always auto-selects the active page, so the default run still processes exactly the current page, while an explicit page-rail selection is now honored by default instead of being silently ignored in favor of the active page.

Scope removal (the stronger option in the issue) is intentionally left out; this is the conservative change and keeps the current-page escape hatch.

Closes #1086

## Test plan

- Updated the store test mock and the runtime-selector tests to the new default (`/Scope Selection/`), and renamed the default-run test to `runs the selected pages by default`; the default run still sends `{ scope: 'pages', value: ['page'] }`. The processing guide notes the new default.
- `bun run --filter @koharu/app test` — 89/89 passed on latest main.
- `bun run --filter '@koharu/*' lint` — clean in all packages.

AI assistance: Claude Code implemented and verified this change; the human author reviewed the complete diff.