### PR TITLE
fix(app): support ctrl and shift multi-select in the layer panel

### DIFF
--- a/packages/koharu/components/editor/Inspector.tsx
+++ b/packages/koharu/components/editor/Inspector.tsx
@@ -21,7 +21,7 @@ import {
   Trash2,
   Type,
 } from 'lucide-react'
-import { useEffect, useId, useMemo, useRef, useState } from 'react'
+import { type MouseEvent, useEffect, useId, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { ColorWell } from '@/components/controls/ColorWell'
@@ -499,6 +499,7 @@ function LayersInspector() {
     selected.length === 1 ? (selected[0] ?? null) : null,
   )
   const [movingLayer, setMovingLayer] = useState<EntityId | null>(null)
+  const anchor = useRef<EntityId | null>(null)
 
   useEffect(() => {
     setExpandedLayer(selected.length === 1 ? (selected[0] ?? null) : null)
@@ -547,13 +548,39 @@ function LayersInspector() {
       })
       .catch(() => undefined)
 
-  const selectLayer = (layer: EntityId) => {
-    if (selected.length === 1 && selected[0] === layer) {
-      setExpandedLayer((current) => (current === layer ? null : layer))
+  // Modifier semantics mirror the page rail: ctrl/meta toggles, shift selects a display range.
+  const selectLayer = (layer: EntityId, additive: boolean, range: boolean) => {
+    if (!additive && !range) {
+      anchor.current = layer
+      if (selected.length === 1 && selected[0] === layer) {
+        setExpandedLayer((current) => (current === layer ? null : layer))
+        return
+      }
+      selectLayers([layer])
+      setExpandedLayer(layer)
       return
     }
-    selectLayers([layer])
-    setExpandedLayer(layer)
+    const order = layers.map((row) => row.layer.id)
+    const anchorIndex = anchor.current ? order.indexOf(anchor.current) : -1
+    if (range && anchorIndex >= 0) {
+      const targetIndex = order.indexOf(layer)
+      const span = layers
+        .slice(Math.min(anchorIndex, targetIndex), Math.max(anchorIndex, targetIndex) + 1)
+        .filter((row) => !isLockedLayer(row.layer))
+        .map((row) => row.layer.id)
+      selectLayers(additive ? [...selected, ...span] : span)
+      return
+    }
+    anchor.current = layer
+    if (!additive) {
+      selectLayers([layer])
+      return
+    }
+    selectLayers(
+      selected.includes(layer)
+        ? selected.filter((selectedLayer) => selectedLayer !== layer)
+        : [...selected, layer],
+    )
   }
 
   return (
@@ -590,7 +617,9 @@ function LayersInspector() {
                 selected={selected.includes(layer.id)}
                 expanded={!locked && expandedLayer === layer.id}
                 locked={locked}
-                onSelect={() => selectLayer(layer.id)}
+                onSelect={(event) =>
+                  selectLayer(layer.id, event.ctrlKey || event.metaKey, event.shiftKey)
+                }
                 onToggle={() =>
                   void call(commands.setVisibility, [layer.id], !layer.visibility.visible, null)
                     .then(() => refresh(projectKey, pageKey))
@@ -632,7 +661,7 @@ function LayerRow({
   selected: boolean
   expanded: boolean
   locked: boolean
-  onSelect: () => void
+  onSelect: (event: MouseEvent<HTMLButtonElement>) => void
   onToggle: () => void
   onMove: (delta: number) => void
   canMoveUp: boolean

--- a/packages/koharu/tests/components/editor-components.test.tsx
+++ b/packages/koharu/tests/components/editor-components.test.tsx
@@ -755,6 +755,112 @@ describe('greenfield editor', () => {
     expect(screen.queryByText('Onomatopoeia')).not.toBeInTheDocument()
   })
 
+  function installLayerSelectionFixture() {
+    installProject()
+    queryClient.setQueryData(pageKey, (page: { layers: Layer[] }) => ({
+      ...page,
+      layers: [
+        ...page.layers,
+        {
+          ...textLayer,
+          id: 'second',
+          content: {
+            ...textLayer.content,
+            id: 'second-content',
+            translation: { text: 'Second', language: null },
+          },
+        },
+        {
+          type: 'artwork',
+          id: 'artwork',
+          parent: 'page',
+          geometry: {
+            points: [
+              { x: 0, y: 0 },
+              { x: 10, y: 0 },
+              { x: 10, y: 10 },
+              { x: 0, y: 10 },
+            ],
+          },
+          visibility: { visible: true, opacity: 1 },
+          image: 'source',
+        },
+        {
+          ...textLayer,
+          id: 'third',
+          content: {
+            ...textLayer.content,
+            id: 'third-content',
+            translation: { text: 'Third', language: null },
+          },
+        },
+      ],
+    }))
+  }
+
+  it('toggles layers in the selection with ctrl-click', () => {
+    installLayerSelectionFixture()
+    render(<Inspector />)
+
+    expect(useKoharuStore.getState().selectedLayers).toEqual(['element'])
+    fireEvent.click(screen.getByRole('button', { name: 'Edit Second' }), { ctrlKey: true })
+    expect(useKoharuStore.getState().selectedLayers).toEqual(['element', 'second'])
+    fireEvent.click(screen.getByRole('button', { name: 'Edit Hello' }), { ctrlKey: true })
+    expect(useKoharuStore.getState().selectedLayers).toEqual(['second'])
+    fireEvent.click(screen.getByRole('button', { name: 'Edit Second' }), { ctrlKey: true })
+    expect(useKoharuStore.getState().selectedLayers).toEqual([])
+  })
+
+  it('toggles layers in the selection with meta-click', () => {
+    installLayerSelectionFixture()
+    render(<Inspector />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit Second' }), { metaKey: true })
+    expect(useKoharuStore.getState().selectedLayers).toEqual(['element', 'second'])
+    fireEvent.click(screen.getByRole('button', { name: 'Edit Second' }), { metaKey: true })
+    expect(useKoharuStore.getState().selectedLayers).toEqual(['element'])
+  })
+
+  it('selects a display range with shift-click, skipping locked layers', () => {
+    installLayerSelectionFixture()
+    render(<Inspector />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit Third' }))
+    expect(useKoharuStore.getState().selectedLayers).toEqual(['third'])
+    fireEvent.click(screen.getByRole('button', { name: 'Edit Hello' }), { shiftKey: true })
+    expect(useKoharuStore.getState().selectedLayers).toEqual(['third', 'second', 'element'])
+  })
+
+  it('unions a shift range with the existing selection when ctrl is held', () => {
+    installLayerSelectionFixture()
+    render(<Inspector />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit Second' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Edit Third' }), {
+      ctrlKey: true,
+      shiftKey: true,
+    })
+    expect(useKoharuStore.getState().selectedLayers).toEqual(['second', 'third'])
+  })
+
+  it('falls back to single selection when shift-clicking without an anchor', () => {
+    installLayerSelectionFixture()
+    render(<Inspector />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit Third' }), { shiftKey: true })
+    expect(useKoharuStore.getState().selectedLayers).toEqual(['third'])
+  })
+
+  it('collapses a multi-selection back to a single layer on plain click', () => {
+    installLayerSelectionFixture()
+    render(<Inspector />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit Second' }), { ctrlKey: true })
+    expect(useKoharuStore.getState().selectedLayers).toEqual(['element', 'second'])
+    fireEvent.click(screen.getByRole('button', { name: 'Edit Hello' }))
+    expect(useKoharuStore.getState().selectedLayers).toEqual(['element'])
+  })
+
   it('resets a custom text frame to its automatic region', async () => {
     installProject()
     queryClient.setQueryData(pageKey, (page: { layers: Layer[] }) => ({

--- a/packages/koharu/tests/components/editor-components.test.tsx
+++ b/packages/koharu/tests/components/editor-components.test.tsx
@@ -88,6 +88,42 @@ const textLayer: Layer = {
   automatic_region: null,
 }
 
+const secondLayer: Layer = {
+  ...textLayer,
+  id: 'second',
+  content: {
+    ...textLayer.content,
+    id: 'second-content',
+    translation: { text: 'Second', language: null },
+  },
+}
+
+const thirdLayer: Layer = {
+  ...textLayer,
+  id: 'third',
+  content: {
+    ...textLayer.content,
+    id: 'third-content',
+    translation: { text: 'Third', language: null },
+  },
+}
+
+const artworkLayer: Layer = {
+  type: 'artwork',
+  id: 'artwork',
+  parent: 'page',
+  geometry: {
+    points: [
+      { x: 0, y: 0 },
+      { x: 10, y: 0 },
+      { x: 10, y: 10 },
+      { x: 0, y: 10 },
+    ],
+  },
+  visibility: { visible: true, opacity: 1 },
+  image: 'source',
+}
+
 const preferences: Preferences = {
   pipeline: {
     detection: { model: 'koharu-layout-rfdetr-seg-2xl' },
@@ -759,42 +795,7 @@ describe('greenfield editor', () => {
     installProject()
     queryClient.setQueryData(pageKey, (page: { layers: Layer[] }) => ({
       ...page,
-      layers: [
-        ...page.layers,
-        {
-          ...textLayer,
-          id: 'second',
-          content: {
-            ...textLayer.content,
-            id: 'second-content',
-            translation: { text: 'Second', language: null },
-          },
-        },
-        {
-          type: 'artwork',
-          id: 'artwork',
-          parent: 'page',
-          geometry: {
-            points: [
-              { x: 0, y: 0 },
-              { x: 10, y: 0 },
-              { x: 10, y: 10 },
-              { x: 0, y: 10 },
-            ],
-          },
-          visibility: { visible: true, opacity: 1 },
-          image: 'source',
-        },
-        {
-          ...textLayer,
-          id: 'third',
-          content: {
-            ...textLayer.content,
-            id: 'third-content',
-            translation: { text: 'Third', language: null },
-          },
-        },
-      ],
+      layers: [...page.layers, secondLayer, artworkLayer, thirdLayer],
     }))
   }
 


### PR DESCRIPTION
## Summary

Layer rows discarded mouse modifiers, so every click replaced the selection. The panel now passes `ctrlKey`/`metaKey`/`shiftKey` into the selection handler, mirroring the page rail semantics:

- Ctrl/Cmd-click toggles a layer in the selection (down to an empty selection, as on the canvas).
- Shift-click selects the display range from the last clicked (anchor) layer, skipping locked artwork rows that cannot be clicked directly.
- Shift+Ctrl/Cmd unions the range with the existing selection.
- Plain click keeps the current behavior: single select, and clicking the only selected row toggles its expansion.

The anchor is stored by layer id, so a stale anchor after a page switch falls back to single selection. Multi-selection already renders on the canvas overlay and works with Delete, Select All, and Process Selected Layers.

Closes #1085

## Test plan

- Added six component tests: ctrl-click toggle (including deselect-to-empty), meta-click toggle, shift range skipping the locked artwork row, shift+ctrl union ordering, shift-click without an anchor, and plain-click collapse back to single selection.
- `bun run --filter @koharu/app test` — 95/95 passed on latest main.
- `bun run --filter '@koharu/*' lint` — clean; `oxfmt --check` on the touched files — clean.

AI assistance: Claude Code implemented and verified this change; the human author reviewed the complete diff.