### PR TITLE
Fix long project names pushing the delete button off screen

### DIFF
--- a/packages/koharu/components/start/StartView.tsx
+++ b/packages/koharu/components/start/StartView.tsx
@@ -208,7 +208,7 @@ export function StartView() {
                       {projects.map((project) => (
                         <li
                           key={project.name}
-                          className='group flex items-center rounded-lg hover:bg-foreground/[0.045]'
+                          className='group flex min-w-0 items-center rounded-lg hover:bg-foreground/[0.045]'
                         >
                           <button
                             type='button'


### PR DESCRIPTION
<!--
Thank you for contributing to Koharu. Please discuss substantial changes in an
issue before starting implementation. See the contribution guide:
https://koharu.rs/development/contributing/

If AI substantially helped design or implement this change, briefly mention how
in your summary. Routine code completion, grammar fixes, and translation do not
require disclosure.
-->

## Summary

Long project names pushed the delete button off screen. Fixed by keeping the name from expanding past its container.

before:
<img width="658" height="148" alt="image" src="https://github.com/user-attachments/assets/70578b4b-444a-4ec7-a649-95f87e6fc14d" />

after:
<img width="545" height="83" alt="image" src="https://github.com/user-attachments/assets/de2b1d7a-091e-46ab-9aea-452aef87a9db" />

the dots look like that because of the font (noto-sans-cjk), we can cutoff the text instead of you want:
<img width="545" height="101" alt="image" src="https://github.com/user-attachments/assets/961c3449-e1ca-4a93-8342-193037587310" />


## Test plan

I looked at it 👍