### PR TITLE
feat(navigator): say how many pages a selection covers

### DIFF
--- a/packages/koharu/components/editor/PageRail.tsx
+++ b/packages/koharu/components/editor/PageRail.tsx
@@ -238,6 +238,17 @@ export function PageRail() {
               {pages.length}
             </span>
           </div>
+          {/* One selected page behaves exactly like acting on the active
+              page, so saying so would be noise. */}
+          {selected.length > 1 && (
+            <span
+              role='status'
+              aria-live='polite'
+              className='ml-auto text-[9px] text-muted-foreground tabular-nums'
+            >
+              {t('navigator.selected', { count: selected.length })}
+            </span>
+          )}
         </header>
 
         {importing && (

--- a/packages/koharu/public/locales/en-US/translation.json
+++ b/packages/koharu/public/locales/en-US/translation.json
@@ -298,7 +298,8 @@
     "pages": "Pages",
     "rename": "Rename",
     "renameDescription": "Choose a new name for this page.",
-    "renameTitle": "Rename page"
+    "renameTitle": "Rename page",
+    "selected": "{{count}} selected"
   },
   "outputPicker": {
     "instructions": "Translation instructions",

--- a/packages/koharu/public/locales/es-ES/translation.json
+++ b/packages/koharu/public/locales/es-ES/translation.json
@@ -298,7 +298,8 @@
     "pages": "Páginas",
     "rename": "Cambiar nombre",
     "renameDescription": "Elige un nombre nuevo para esta página.",
-    "renameTitle": "Cambiar nombre de página"
+    "renameTitle": "Cambiar nombre de página",
+    "selected": "{{count}} seleccionadas"
   },
   "outputPicker": {
     "instructions": "Instrucciones de traducción",

--- a/packages/koharu/public/locales/ja-JP/translation.json
+++ b/packages/koharu/public/locales/ja-JP/translation.json
@@ -298,7 +298,8 @@
     "pages": "ページ",
     "rename": "名前を変更",
     "renameDescription": "このページの新しい名前を入力します。",
-    "renameTitle": "ページ名を変更"
+    "renameTitle": "ページ名を変更",
+    "selected": "{{count}}件選択中"
   },
   "outputPicker": {
     "instructions": "翻訳指示",

--- a/packages/koharu/public/locales/ko-KR/translation.json
+++ b/packages/koharu/public/locales/ko-KR/translation.json
@@ -298,7 +298,8 @@
     "pages": "페이지",
     "rename": "이름 바꾸기",
     "renameDescription": "이 페이지의 새 이름을 정하세요.",
-    "renameTitle": "페이지 이름 바꾸기"
+    "renameTitle": "페이지 이름 바꾸기",
+    "selected": "{{count}}개 선택됨"
   },
   "outputPicker": {
     "instructions": "번역 지침",

--- a/packages/koharu/public/locales/pt-BR/translation.json
+++ b/packages/koharu/public/locales/pt-BR/translation.json
@@ -298,7 +298,8 @@
     "pages": "Páginas",
     "rename": "Renomear",
     "renameDescription": "Escolha um novo nome para esta página.",
-    "renameTitle": "Renomear página"
+    "renameTitle": "Renomear página",
+    "selected": "{{count}} selecionadas"
   },
   "outputPicker": {
     "instructions": "Instruções de tradução",

--- a/packages/koharu/public/locales/ru-RU/translation.json
+++ b/packages/koharu/public/locales/ru-RU/translation.json
@@ -298,7 +298,8 @@
     "pages": "Страницы",
     "rename": "Переименовать",
     "renameDescription": "Выберите новое имя для страницы.",
-    "renameTitle": "Переименовать страницу"
+    "renameTitle": "Переименовать страницу",
+    "selected": "Выбрано: {{count}}"
   },
   "outputPicker": {
     "instructions": "Инструкции по переводу",

--- a/packages/koharu/public/locales/tr-TR/translation.json
+++ b/packages/koharu/public/locales/tr-TR/translation.json
@@ -298,7 +298,8 @@
     "pages": "Sayfalar",
     "rename": "Yeniden adlandır",
     "renameDescription": "Bu sayfa için yeni bir ad seçin.",
-    "renameTitle": "Sayfayı yeniden adlandır"
+    "renameTitle": "Sayfayı yeniden adlandır",
+    "selected": "{{count}} seçili"
   },
   "outputPicker": {
     "instructions": "Çeviri talimatları",

--- a/packages/koharu/public/locales/zh-CN/translation.json
+++ b/packages/koharu/public/locales/zh-CN/translation.json
@@ -298,7 +298,8 @@
     "pages": "页面",
     "rename": "重命名",
     "renameDescription": "为此页面选择一个新名称。",
-    "renameTitle": "重命名页面"
+    "renameTitle": "重命名页面",
+    "selected": "已选择 {{count}}"
   },
   "outputPicker": {
     "instructions": "翻译说明",

--- a/packages/koharu/public/locales/zh-TW/translation.json
+++ b/packages/koharu/public/locales/zh-TW/translation.json
@@ -298,7 +298,8 @@
     "pages": "頁面",
     "rename": "重新命名",
     "renameDescription": "為此頁面選擇新名稱。",
-    "renameTitle": "重新命名頁面"
+    "renameTitle": "重新命名頁面",
+    "selected": "已選擇 {{count}}"
   },
   "outputPicker": {
     "instructions": "翻譯指示",

--- a/packages/koharu/tests/components/editor-components.test.tsx
+++ b/packages/koharu/tests/components/editor-components.test.tsx
@@ -354,6 +354,26 @@ describe('greenfield editor', () => {
     expect(nativeGetVersion).toHaveBeenCalledTimes(1)
   })
 
+  it('shows how many pages are selected above the filter', async () => {
+    installProject()
+    act(() => {
+      useKoharuStore.setState({ selectedPages: ['page-1'] })
+    })
+    render(<PageRail />)
+
+    // One page behaves like acting on the active page, so it is not worth
+    // announcing.
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+
+    act(() => {
+      useKoharuStore.setState({ selectedPages: ['page-1', 'page-2', 'page-3'] })
+    })
+
+    // A status region, so the count reaches assistive technology when it
+    // changes rather than only being visible.
+    expect(await screen.findByRole('status')).toHaveTextContent('3 selected')
+  })
+
   it('loads page thumbnails into the filmstrip', async () => {
     installProject()
     const thumbnail = vi.spyOn(commands, 'getThumbnail').mockResolvedValue([1])


### PR DESCRIPTION
## Summary

Selecting several pages in the rail gave no running total. The selection showed only as highlighted rows, so on a long rail there was no way to tell how many pages it held without counting them.

The same number was missing where it matters most. `Export PNG` and `Export PSD` act on the selection, falling back to the active page, but said nothing about how many pages they would write, so a selection made in the rail became invisible at the moment of exporting.

The rail header now states the count above the filter.

- The rail states it in a `role="status"` region, so it reaches assistive technology when it changes rather than only being visible.
- One selected page stays unannotated. It is the ordinary case and behaves exactly like acting on the active page, so a `1 page` badge would only add noise.

Frontend only: one component, nine locale files, one test file. No backend, no protocol change, no new commands.

## Related issue

Closes #1017.

That issue proposes the count **and** process/delete buttons in the rail. This is the count alone, which is the half agreed in the issue thread — the buttons are deliberately not here, so the design question about action buttons living in the rail stays open and can be answered separately.

## Verification

`bun run --filter @koharu/app test` (97 passed), `tsc --noEmit`, and `bun run --filter @koharu/app lint` are clean.

One test added: the rail announcing `3 selected` through a status region while staying silent at one selection.

Not verified: this was unit tested rather than exercised in the built application, so the visual placement of the count in a narrow rail has not been seen on screen.

## AI assistance

AI assisted in implementing this change and drafting this description. Reviewed and tested by a human before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

